### PR TITLE
feat(ffi): measure SSZ-bytes marshalling cost (M6)

### DIFF
--- a/ConsensusLean4/Ffi.lean
+++ b/ConsensusLean4/Ffi.lean
@@ -312,3 +312,27 @@ def csfBenchComputeLmdGhostHeadBuildOnly
   let blocks := buildForkChoiceBlocks b
   let atts := buildForkChoiceAttestations b a
   consumeBlocksVec blocks ^^^ consumeAttsVec atts
+
+/-! ## M6 — FFI marshalling cost.
+
+The §1/§2 benches cross only primitive `UInt64`, so they measure Lean-side
+compute with the (near-zero) boundary cost cancelled out. This pair measures
+the cost the *real* SSZ-bytes boundary (issue #4) would add: a `ByteArray`
+(`lean_sarray_object`) is built on the Rust side via the `csf_make_bytearray`
+C shim (alloc + memcpy O(size)), handed to the export as an owned argument,
+and dec_ref'd by Lean's runtime on return.
+
+No SSZ codec and no `hash_tree_root`/SHA are involved — `ByteArray` is a flat
+buffer, so (de)serialization is pure byte layout. `_touch` reads every byte
+(XOR-fold), a lower bound on what a real decoder pays to scan its input;
+`_noop` only consumes the argument, isolating alloc + memcpy + dec_ref. -/
+
+/-- Touch every byte (decode-scan lower bound). Consumes `data` (dec_ref). -/
+@[export csf_bench_marshal_touch]
+def csfBenchMarshalTouch (data : ByteArray) : UInt8 :=
+  data.foldl (fun acc x => acc ^^^ x) 0
+
+/-- Consume `data` without reading it. Paired-delta twin: the gap from
+`_touch` is the Lean-side byte-scan, leaving alloc + memcpy + dec_ref. -/
+@[export csf_bench_marshal_noop]
+def csfBenchMarshalNoop (_data : ByteArray) : UInt8 := 0

--- a/ConsensusLean4/Ffi.lean
+++ b/ConsensusLean4/Ffi.lean
@@ -336,3 +336,150 @@ def csfBenchMarshalTouch (data : ByteArray) : UInt8 :=
 `_touch` is the Lean-side byte-scan, leaving alloc + memcpy + dec_ref. -/
 @[export csf_bench_marshal_noop]
 def csfBenchMarshalNoop (_data : ByteArray) : UInt8 := 0
+
+/-! ## M7 — end-to-end: marshal → decode → pure STF.
+
+This wires the full SSZ-bytes path (issue #4) the M6 marshal bench left
+disconnected: a `ByteArray` is decoded into the typed `State` / `Block` and
+fed to the pure `stateTransitionFast`. The byte layout is a simple flat,
+length-prefixed binary codec (NOT canonical SSZ) defined to round-trip with
+the Rust serializer in `bench-ffi-ssz.rs`; it covers every field of `State`
+and `Block`. No `hash_tree_root`/SHA is involved — decoding is pure layout.
+
+Layout: U64 = 8 bytes LE; H256 = 32 bytes; pubkey = 52 bytes; Bool = 1 byte;
+`Vec α` = U64 count then `count` elements. Out-of-range reads return 0
+(`ByteArray.get!` default), so the Rust side must supply every byte read. -/
+
+@[inline] private def u8OfUInt8 (x : UInt8) : Std.U8 :=
+  Std.U8.ofNat x.toNat (by
+    have hlt : x.toNat < UInt8.size := x.toNat_lt
+    have hsize : UInt8.size = 256 := by decide
+    rw [Std.UScalar.cMax_eq_pow_cNumBits]
+    show x.toNat ≤ 2 ^ Std.UScalarTy.U8.cNumBits - 1
+    have hbits : Std.UScalarTy.U8.cNumBits = 8 := rfl
+    rw [hbits]; omega)
+
+@[inline] private def readU64LE (d : ByteArray) (o : Nat) : UInt64 :=
+  let b : Nat → UInt64 := fun i => (d.get! (o + i)).toUInt64
+  b 0 ||| (b 1 <<< 8) ||| (b 2 <<< 16) ||| (b 3 <<< 24)
+    ||| (b 4 <<< 32) ||| (b 5 <<< 40) ||| (b 6 <<< 48) ||| (b 7 <<< 56)
+
+@[inline] private def rdU64 (d : ByteArray) (o : Nat) : Std.U64 × Nat :=
+  (u64OfUInt64 (readU64LE d o), o + 8)
+
+@[inline] private def rdCount (d : ByteArray) (o : Nat) : Nat × Nat :=
+  ((readU64LE d o).toNat, o + 8)
+
+private def readH256 (d : ByteArray) (o : Nat) : types.H256 :=
+  Array.make 32#usize ((List.range 32).map (fun i => u8OfUInt8 (d.get! (o + i))))
+
+private def readPubkey (d : ByteArray) (o : Nat) : Array Std.U8 52#usize :=
+  Array.make 52#usize ((List.range 52).map (fun i => u8OfUInt8 (d.get! (o + i))))
+
+@[inline] private def rdH256 (d : ByteArray) (o : Nat) : types.H256 × Nat :=
+  (readH256 d o, o + 32)
+
+private def rdCheckpoint (d : ByteArray) (o : Nat) : types.Checkpoint × Nat :=
+  ({ root := readH256 d o, slot := u64OfUInt64 (readU64LE d (o + 32)) }, o + 40)
+
+private def rdHeader (d : ByteArray) (o : Nat) : types.BlockHeader × Nat :=
+  ({ slot := u64OfUInt64 (readU64LE d o)
+     proposer_index := u64OfUInt64 (readU64LE d (o + 8))
+     parent_root := readH256 d (o + 16)
+     state_root := readH256 d (o + 48)
+     body_root := readH256 d (o + 80) }, o + 112)
+
+private def rdVecH256 (d : ByteArray) (o : Nat) :
+    alloc.vec.Vec types.H256 × Nat :=
+  let (cnt, o) := rdCount d o
+  let xs := (List.range cnt).map (fun i => readH256 d (o + i * 32))
+  (buildVecFromList xs (alloc.vec.Vec.new types.H256), o + cnt * 32)
+
+private def rdVecBool (d : ByteArray) (o : Nat) :
+    alloc.vec.Vec Bool × Nat :=
+  let (cnt, o) := rdCount d o
+  let xs := (List.range cnt).map (fun i => d.get! (o + i) != 0)
+  (buildVecFromList xs (alloc.vec.Vec.new Bool), o + cnt)
+
+private def rdValidator (d : ByteArray) (o : Nat) : types.Validator × Nat :=
+  ({ pubkey := readPubkey d o, index := u64OfUInt64 (readU64LE d (o + 52)) }, o + 60)
+
+private def rdVecValidator (d : ByteArray) (o : Nat) :
+    alloc.vec.Vec types.Validator × Nat :=
+  let (cnt, o) := rdCount d o
+  let xs := (List.range cnt).map (fun i => (rdValidator d (o + i * 60)).1)
+  (buildVecFromList xs (alloc.vec.Vec.new types.Validator), o + cnt * 60)
+
+private def rdAttData (d : ByteArray) (o : Nat) : types.AttestationData × Nat :=
+  ({ slot := u64OfUInt64 (readU64LE d o)
+     head := (rdCheckpoint d (o + 8)).1
+     target := (rdCheckpoint d (o + 48)).1
+     source := (rdCheckpoint d (o + 88)).1 }, o + 128)
+
+private def rdAggAtt (d : ByteArray) (o : Nat) :
+    types.AggregatedAttestation × Nat :=
+  let (bits, o) := rdVecBool d o
+  let (data, o) := rdAttData d o
+  ({ aggregation_bits := bits, data := data }, o)
+
+private def rdAggAttList (d : ByteArray) :
+    Nat → Nat → List types.AggregatedAttestation →
+    List types.AggregatedAttestation × Nat
+  | 0,     o, acc => (acc.reverse, o)
+  | k + 1, o, acc => let (a, o') := rdAggAtt d o; rdAggAttList d k o' (a :: acc)
+
+private def rdVecAggAtt (d : ByteArray) (o : Nat) :
+    alloc.vec.Vec types.AggregatedAttestation × Nat :=
+  let (cnt, o) := rdCount d o
+  let (xs, oEnd) := rdAggAttList d cnt o []
+  (buildVecFromList xs (alloc.vec.Vec.new types.AggregatedAttestation), oEnd)
+
+private def decodeState (d : ByteArray) (o : Nat) : types.State × Nat :=
+  let (genesisTime, o) := rdU64 d o
+  let (slot, o) := rdU64 d o
+  let (hdr, o) := rdHeader d o
+  let (lj, o) := rdCheckpoint d o
+  let (lf, o) := rdCheckpoint d o
+  let (hbh, o) := rdVecH256 d o
+  let (js, o) := rdVecBool d o
+  let (vals, o) := rdVecValidator d o
+  let (jr, o) := rdVecH256 d o
+  let (jv, o) := rdVecBool d o
+  ({ config := { genesis_time := genesisTime }
+     slot := slot
+     latest_block_header := hdr
+     latest_justified := lj
+     latest_finalized := lf
+     historical_block_hashes := hbh
+     justified_slots := js
+     validators := vals
+     justifications_roots := jr
+     justifications_validators := jv }, o)
+
+private def decodeBlock (d : ByteArray) (o : Nat) : types.Block × Nat :=
+  let (slot, o) := rdU64 d o
+  let (proposer, o) := rdU64 d o
+  let (parentRoot, o) := rdH256 d o
+  let (stateRoot, o) := rdH256 d o
+  let (atts, o) := rdVecAggAtt d o
+  ({ slot := slot
+     proposer_index := proposer
+     parent_root := parentRoot
+     state_root := stateRoot
+     body := { attestations := atts } }, o)
+
+/-- End-to-end: decode `State ++ Block` from `data`, then run the pure fast
+state transition. `data` is consumed (dec_ref). -/
+@[export csf_bench_state_transition_ssz_run]
+def csfBenchStateTransitionSszRun (data : ByteArray) : UInt8 :=
+  let (state, o) := decodeState data 0
+  let (block, _) := decodeBlock data o
+  packStatePipeline (ConsensusLean4.FastPath.stateTransitionFast state block)
+
+/-- Twin: decode only, skip the pipeline. Paired-delta isolates decode cost
+(`_ssz_run` − `_ssz_decode` = pure STF; `_ssz_decode` − marshal = decode). -/
+@[export csf_bench_state_transition_ssz_decode]
+def csfBenchStateTransitionSszDecode (data : ByteArray) : UInt8 :=
+  let (state, o) := decodeState data 0
+  let (block, _) := decodeBlock data o
+  consumeState state ^^^ consumeBlock block

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -212,7 +212,9 @@ target/release/bench-ffi-overhead
 | プリミティブ `UInt64` (§4b) | ~1.9 ns | サイズ非依存 (定数) |
 | `ByteArray` マーシャル (本節) | 25 ns 〜 14 ms | **O(payload size)** |
 
-「FFI は速い」は **プリミティブ境界に限った話**。データを渡す実運用では、コストは渡すバイト数に線形で、mainnet 規模では STF と肩を並べる。
+「FFI は速い」は **プリミティブ境界に限った話**。データを渡すとコストは渡すバイト数に線形になる。
+
+> **spec スケールでの補正 (§4d 参照)**: 上表の N=10K 以上 (≥586 KB) は `VALIDATOR_REGISTRY_LIMIT = 4096` を超える非物理サイズ。このモデルの payload 上限は V=4096 ⇒ **≤ 240 KB** で、そこでの marshal は **≤ 6.8 µs** = 誤差。「14 ms@57 MB」は到達不能な規模の一般特性であり、実運用 marshal は無視できる。本節の大サイズ行は境界の size-scaling 特性の参考値として残す。
 
 ### 限界
 
@@ -237,48 +239,54 @@ target/release/bench-ffi-marshal
 - **正当性ゲート**: `csf_bench_state_transition_ssz_run` が全 N で sentinel **0 (Ok)** を返すことを assert。誤ったコーデックなら sentinel が変わるかクラッシュするため、これがパイプライン全体の正当性検証になっている。
 - **分解**: marshal = `_marshal_noop`、decode = `_ssz_decode` − marshal、STF = `_ssz_run` − `_ssz_decode`。
 
-### 計測結果
+### V の上限 = 4096 (重要)
 
-| N | payload | marshal | decode | STF | total (e2e) |
+V (validator 数) は **`VALIDATOR_REGISTRY_LIMIT = 2^12 = 4096`** で上限が決まる。これは leanSpec 正準値 (`lean_spec/types/participation.py:11`: `Uint64(2**12)`) であり、`consensus-lean4` の `types.VALIDATOR_REGISTRY_LIMIT` (`Funs/Types.lean`) も同値。`checkpoint_sync` は `validator_count > VALIDATOR_REGISTRY_LIMIT` の state を拒否する。
+
+実運用 V はさらに小さく、**leanSpec のベースラインは 4** (テストは 4/8)。よって計測軸は **devnet baseline (4) → spec 上限 (4096)** とする。
+
+> **訂正**: 本節の旧版は N=100〜1,000,000 で測っていたが、**10,000 以上は spec 上限 4096 を超える非物理値** (mainnet beacon chain の規模を誤って持ち込んだもの)。以下は spec 準拠の軸での再測値。
+
+### 計測結果 (spec-realistic V = 4 … 4096、3 回中央値)
+
+| V | payload | marshal | decode | STF | total (e2e) |
 |---:|---:|---:|---:|---:|---:|
-| 100 | 6.2 KB | 113 ns | 111 µs | 47.6 µs | 159 µs |
-| 1,000 | 58.9 KB | 1.60 µs | 1.06 ms | 83.4 µs | 1.14 ms |
-| 10,000 | 586.3 KB | 20.0 µs | 12.23 ms | 347 µs | 12.60 ms |
-| 100,000 | 5.7 MB | 220 µs | 139.46 ms | 5.05 ms | **144.73 ms** |
+| 4 (devnet baseline) | 0.6 KB | 34 ns | 9.4 µs | 42 µs | **51 µs** |
+| 8 | 0.8 KB | 35 ns | 13 µs | 42 µs | **56 µs** |
+| 64 | 4.1 KB | 86 ns | 71 µs | 48 µs | **119 µs** |
+| 512 | 30.3 KB | 0.8 µs | 555 µs | 60 µs | **615 µs** |
+| 4096 (spec max) | 240.3 KB | 6.8 µs | 4.6 ms | 0.4 ms | **~5.0 ms** |
 
-(N=1M は `--include-1m` で opt-in。decode が ~1.4 µs/validator で線形のため ~1.4 s/call ＋ 数 GB RSS と推定。常用せず。)
+(governor 非固定のため total は 3.3〜5.1 ms の run 間ばらつきあり。decode が支配。)
 
-### 判定 — §4b/§4c の予測を **訂正**
+### 判定
 
-§4c では「実運用 FFI コストの新規項は **marshal**(alloc+memcpy)で、mainnet で STF と肩を並べる」と予測した。**実測はこれを覆した**:
+1. **実運用域では FFI 全経路が無視できる**。devnet baseline (V=4) で e2e **51 µs**、spec 上限 (V=4096) でも **~5 ms**。1 スロット ~数秒の世界で、状態遷移の marshal+decode+STF は誤差。
+2. **小 V では STF が支配、大 V で decode が逆転**。V=4 では STF 42 µs > decode 9 µs (STF の固定コスト)。V≥512 で decode が上回り、V=4096 で decode 4.6 ms / STF 0.4 ms。交差点は V≈64〜512。
+3. **decode コストは List materialize 由来だが上限内では問題化しない**。~1.1 µs/validator (Aeneas の `pubkey : Array Std.U8 52` = 52 ノード list × V)。V=4096 でも 4.6 ms に留まり、spec 上限を超えない限り catastrophic にならない。
+4. **marshal は常に誤差** (≤ 6.8 µs)。payload は V≤4096 で ≤ 240 KB が上限。§4c の「14 ms@57 MB」は V≈1M 相当で **このモデルでは到達不能**。
 
-1. **支配項は marshal ではなく decode**。N=100K で marshal 220 µs に対し **decode 139 ms** —— marshal の **約 630 倍**、STF (5 ms) の **約 28 倍**。memcpy は速い (~26 GB/s、§4c と一致) が、バイト列を **Aeneas の List-backed 型へ materialize する**コストが桁違いに大きい。
-2. **decode は N に線形 (~1.4 µs/validator)** だが定数が巨大。原因は Aeneas 表現: `pubkey : Array Std.U8 52` が **52 要素の連結リスト**で、それが N 個 + `validators : Vec` 自体も List。実データを入れると 1 validator あたり 52 ノードの list 構築が走る。
-3. **STF も §1 より重い** (100K で 5.05 ms vs §1 1.80 ms、~2.8×)。§1 は全 validator が `Array.repeat` の**同一共有オブジェクト**だったが、decode 版は各 validator が**別個のオブジェクト**。実データでは共有が効かず、STF の走査が distinct なキャッシュライン/参照カウントに当たるため。**§1 の 22 ms@1M は共有による楽観値**だった、という重要な含意。
-4. **marshal の相対的軽さが確定**: §4c 単独では「14 ms@1M は無視できない」と見えたが、decode と並べると marshal は誤差。**ボトルネックは一貫して Aeneas の List-backed 表現**で、これは fork-choice の O(B²)(§2)と同一の根本原因。
-
-### この経路の全体像
+### この経路の全体像 (spec 上限 V=4096)
 
 ```
 [Rust bytes] ──①marshal──▶ [ByteArray] ──②decode──▶ [typed State/Block] ──③STF──▶ sentinel
-  serialize       220µs@100K(誤差)      139ms@100K(支配項)        5ms@100K
+  serialize       6.8µs(誤差)        4.6ms(支配項)            0.4ms
 ```
 
-「FFI を実データで使う」コストの正体は **越境でも memcpy でもなく、検証用 Aeneas 型への materialize**。改善は (a) decode 先を Array-backed の高速表現にする、(b) `validators` を flat buffer のまま保持し遅延デコードする、等。issue #4 の本質的課題はマーシャルではなく **decode 表現** にあることが定量的に判明した。
+実運用スケールでは「FFI を実データで使う」コストは全部足しても ~5 ms (最悪)。**真のスケール懸念は validator 軸ではなく blocks 軸** —— fork-choice (§2) の O(B²) で、B は `HISTORICAL_ROOTS_LIMIT = 2^18 = 262144` まで伸びうる。decode/marshal の最適化より `compute_lmd_ghost_head_fast` が優先。
 
 ### 限界
 
 - フラットコーデックで正準 SSZ wire 非互換 (offset/union 等は未対応)。実 devnet テストベクタとの互換は別途。
 - 片道のみ (結果 `State` のエンコード+復路は未計測)。
-- decode 先が List-backed なのは Aeneas 既定。Array-backed への変更で decode/STF とも大きく変わる見込み (future work)。
+- decode 先が List-backed なのは Aeneas 既定。Array-backed への変更で decode はさらに減るが、上限内 (≤5 ms) で既に十分小さい。
 
 ### 再現
 
 ```bash
 cd consensus-lean4 && lake build ConsensusLean4:static
 cd rust-ffi && cargo build --release --bin bench-ffi-ssz
-target/release/bench-ffi-ssz            # N=100..100K
-target/release/bench-ffi-ssz --include-1m
+target/release/bench-ffi-ssz            # V = 4, 8, 64, 512, 4096 (spec range)
 ```
 
 ## 5. Future work

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -289,6 +289,47 @@ cd rust-ffi && cargo build --release --bin bench-ffi-ssz
 target/release/bench-ffi-ssz            # V = 4, 8, 64, 512, 4096 (spec range)
 ```
 
+## 4e. STF 忠実度 — leanSpec `spec.py` 対応と realistic 化の差分
+
+計測対象の `stateTransitionFast` が leanSpec 正準 STF (`src/lean_spec/forks/lstar/spec.py` の `state_transition`, L614) のどこを実装しているかを明記する。**本ベンチの数値は "完全な STF" ではなく以下の被覆範囲に対する値**である点に注意 (= 実 STF コストの下限)。
+
+leanSpec `state_transition` (L614-647) は 4 ステップ:
+
+```python
+def state_transition(state, block, valid_signatures=True):
+    if not valid_signatures: raise              # 1. 署名は前提条件 (検証は外部)
+    advanced  = process_slots(state, block.slot) # 2.
+    new_state = process_block(advanced, block)   # 3. = header + attestations
+    assert block.state_root == hash_tree_root(new_state)  # 4.
+    return new_state
+```
+
+| leanSpec `spec.py` | consensus-lean4 | 状態 |
+|---|---|---|
+| 2. `process_slots` (L135) | `state_transition.process_slots` | ✅ 実装 |
+| 3. `process_block` (L332) | `processBlockFast` | ✅ 実装 |
+| ├ `process_block_header` (L195) | `state_transition.process_block_header` | ✅(内部 HTR は stub) |
+| └ `process_attestations` (L385) | `processAttestationsFast` + `try_finalize` | ✅ 実装 |
+| 4. `hash_tree_root` 照合 (L644) | `hash_tree_root_state`→`eq`→`StateRootMismatch` | ⚠️ 枠のみ。HTR は `ok H256.ZERO` stub |
+| 1. `valid_signatures` 前提 (L634) | — | ❌ 引数なし(常に valid 扱い) |
+| `verify_signatures` (L864, 別メソッド) | — | ❌ 完全欠如 |
+
+→ **`state_transition` 本体の step 2・3 は完全、step 4 は構造のみ実装済み。** 欠けているのは関数外の署名検証と、step 4 の実ハッシュ。
+
+### realistic STF への差分(実装先つき)
+
+| # | 欠けている処理 | 実装先 | 備考 |
+|---|---|---|---|
+| ① | `verify_signatures` (L864): 提案者 + 集約署名 (XMSS) | **Rust/FFI**(leanSig/leanMultisig, Plonky3) + 段取りは Lean | leanSpec では STF の外。最大コスト |
+| ② | 実 `hash_tree_root` (step 4 / header 内) | merkleize 構造=**Lean**、**Poseidon1** 置換=Rust/FFI or Lean | leanSpec は **Poseidon1/KoalaBear**(SHA-256 ではない) |
+| ③ | 非空 attestation/justification 入力 | データ(leanSpec テストベクタ) | 現 fixture は空で 3SF 本体が未駆動 |
+| ④ | 正準 SSZ codec | **Lean**(decode) | 現状はフラット自前コーデック |
+| ⑤ | マルチスロット/エポック境界 | **Lean**(既存ロジック) | 入力次第で駆動 |
+
+**信頼境界の原則**: 検証対象ロジック (STF / SSZ decode / merkleize 構造 / 署名検証の段取り) は Lean、重い暗号プリミティブ (Poseidon1 置換, XMSS/集約 ZK 検証) は Rust/FFI。`compute_block_weights` (L1370) は STF ではなく fork-choice(§2 `compute_lmd_ghost_head`)で別系統。
+
+**ベンチ解釈への含意**: §1/§4 の数値は「署名検証なし・HTR=ZERO・attestation 空」での値。realistic STF では ① 署名検証(支配項)+ ② Poseidon HTR が加わり、桁が上がる。現数値は **FFI/decode/STF ロジックの下限**として読むこと。
+
 ## 5. Future work
 
 `docs/ffi-feasibility.md` に既出の項目を実数値で裏付け:

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -8,6 +8,7 @@ tags:
   - state-transition
   - fork-choice
   - boundary-cost
+  - marshalling
 ---
 
 # Rust ↔ Lean 4 FFI ベンチマーク 実測結果
@@ -165,6 +166,65 @@ target/release/bench-fork-choice --single-cell=100,128
 cd consensus-lean4 && lake build ConsensusLean4:static
 cd rust-ffi && cargo build --release --bin bench-ffi-overhead
 target/release/bench-ffi-overhead
+```
+
+## 4c. FFI マーシャリングコスト 追測 (2026-06-04)
+
+§4b で「プリミティブ越境は ~0、ただしこれは床値。実運用の FFI コストは `lean_object*` のマーシャル/dec_ref で、それは未測定」と結論した。その未測定分を `bench-ffi-marshal` (`rust-ffi/src/bin/bench-ffi-marshal.rs`) で直接計測した。
+
+本来の SSZ-bytes 境界 (issue #4) で新規に立つコスト ——「Rust 側で `ByteArray` を構築 (alloc + memcpy O(size)) → owned 引数として越境 → Lean ランタイムが dec_ref」—— を、ペイロードサイズの関数として測る。`ByteArray` はフラットバッファなので **SSZ コーデックも `hash_tree_root`/SHA も不要** (serde はバイト並びのみ)。
+
+- `csf_make_bytearray` (C shim, `rust-ffi/csf_marshal_shim.c`): `lean_alloc_sarray` + `memcpy`。`lean_alloc_sarray`/`lean_sarray_cptr` は lean.h で `static inline` のため Rust から直接リンクできず、lean.h に対してコンパイルした C shim 経由で呼ぶ (build.rs が `cc` でビルド)。
+- Lean export 2 種 (`ConsensusLean4/Ffi.lean` M6): `csf_bench_marshal_touch` = 全バイトを XOR-fold (decode スキャンの下限)、`csf_bench_marshal_noop` = 引数を消費するだけ (alloc + memcpy + dec_ref)。差 = Lean 側スキャン。
+- サイズ軸は §1 の N に対応: Validator = pubkey(52)+index(8) = 60 B とし、ペイロード S = N·60。**正準 SSZ ではなく代表サイズのフラットバッファ。** 計測手法は §1/§4b と同様 (target 200ms/trial, 11 試行中央値, `black_box`)。
+
+### 計測結果
+
+| N | payload S | marshal (noop) | full (marshal+scan) | scan Δ | marshal GB/s | marshal ns/byte |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 60 B | 25.3 ns | 32.3 ns | 7.0 ns | 2.4 | 0.422 |
+| 100 | 5.9 KB | 114 ns | 235 ns | 121 ns | 52.4 | 0.019 |
+| 1,000 | 58.6 KB | 1.32 µs | 2.84 µs | 1.52 µs | 45.5 | 0.022 |
+| 10,000 | 585.9 KB | 20.5 µs | 32.1 µs | 11.6 µs | 29.3 | 0.034 |
+| 100,000 | 5.7 MB | 223 µs | 351 µs | 128 µs | 26.9 | 0.037 |
+| 1,000,000 | 57.2 MB | **14.39 ms** | 16.64 ms | 2.25 ms | 4.2 | 0.240 |
+
+### 判定 (vs §1 の STF 計算コスト)
+
+| N | marshal (片道) | §1 STF pipeline | marshal / STF |
+|---:|---:|---:|---:|
+| 100 | 114 ns | 41.3 µs | 0.3% |
+| 100,000 | 223 µs | 1.80 ms | 12% |
+| 1,000,000 | **14.39 ms** | 22.02 ms | **65%** |
+
+→ **§4b の予測どおり、オーバーヘッドはサイズに比例して変化する。**
+
+1. **小サイズ (devnet 相当, validator 数百 = KB 級)**: 100〜1,300 ns。§4b のプリミティブ越境と同様、**実質ノイズ**。SSZ 化しても体感不変。
+2. **大サイズ (mainnet 相当, validator 1M = ~57 MB)**: 片道 **14.4 ms** で、STF 計算本体 (22 ms) の **約 65%**。往復 (入力デコード + 結果エンコード) なら ~29 ms で STF を上回る。**この規模ではマーシャルが支配項の一つになる**。
+3. **スループットの劣化**: 小サイズで ~52 GB/s (L2/L3 内に収まる) → 57 MB で 4.2 GB/s。これは純粋な memcpy 帯域ではなく、**呼び出しごとに 57 MB を新規 alloc → first-touch ページフォルト → memcpy → dec_ref/free** するためで、per-call マーシャルの現実的なコスト構造を反映している。
+4. **Lean 側スキャン (scan Δ) は安価**: ~0.03–0.04 ns/byte (~25–30 GB/s)。decode の「全バイト走査」部分は memcpy と同オーダーで、マーシャルの支配項は alloc+copy 側。
+
+### §4b との関係 (FFI コストの全体像)
+
+| 入力形態 | 越境あたりのコスト | スケール |
+|---|---|---|
+| プリミティブ `UInt64` (§4b) | ~1.9 ns | サイズ非依存 (定数) |
+| `ByteArray` マーシャル (本節) | 25 ns 〜 14 ms | **O(payload size)** |
+
+「FFI は速い」は **プリミティブ境界に限った話**。データを渡す実運用では、コストは渡すバイト数に線形で、mainnet 規模では STF と肩を並べる。
+
+### 限界
+
+- **正準 SSZ ではない**: フラットな代表バッファで、可変長フィールドの offset や型付きデコードは含まない。型付き `State` への decode を入れると scan Δ 側が増えるが、マーシャル (alloc+memcpy) の支配性は変わらない見込み (issue #4 で要確認)。
+- **片道のみ**: 結果 `State` のエンコード + 復路は未計測。実運用は往復なので概ね 2 倍が目安。
+- **zero-copy の余地**: Lean が呼び出し中に読むだけなら borrowed pointer 受けで memcpy を回避できる可能性 (§4b 限界参照)。本計測は owned-copy 前提の上限値。
+
+### 再現
+
+```bash
+cd consensus-lean4 && lake build ConsensusLean4:static
+cd rust-ffi && cargo build --release --bin bench-ffi-marshal
+target/release/bench-ffi-marshal
 ```
 
 ## 5. Future work

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -9,6 +9,7 @@ tags:
   - fork-choice
   - boundary-cost
   - marshalling
+  - decode
 ---
 
 # Rust ↔ Lean 4 FFI ベンチマーク 実測結果
@@ -225,6 +226,59 @@ target/release/bench-ffi-overhead
 cd consensus-lean4 && lake build ConsensusLean4:static
 cd rust-ffi && cargo build --release --bin bench-ffi-marshal
 target/release/bench-ffi-marshal
+```
+
+## 4d. End-to-end SSZ-bytes パイプライン 追測 (2026-06-04)
+
+§4b/§4c は「①marshal」だけを測り、「②decode → ③純粋関数」が未接続だった。本節でその全経路を繋いだ ——`ByteArray` を**型付き `State`/`Block` にデコードし、純粋 `stateTransitionFast` に渡す**。`bench-ffi-ssz` (`rust-ffi/src/bin/bench-ffi-ssz.rs`) + `ConsensusLean4/Ffi.lean` M7。
+
+- **コーデック**: フラットな length-prefixed バイナリ (正準 SSZ ではない) を Lean decode (`decodeState`/`decodeBlock`) と Rust serializer (`serialize_fixture`) で round-trip。`State`/`Block` の全フィールドを網羅。**`hash_tree_root`/SHA は不使用** (decode は純粋なバイト配置)。
+- **fixture は §1 と byte-for-byte 一致**: `buildBenchState(n)`/`buildBenchBlock(n)` と同一内容を直列化。よって decode 後の入力は §1 のスカラー生成版と等価で、STF コストを直接比較できる。
+- **正当性ゲート**: `csf_bench_state_transition_ssz_run` が全 N で sentinel **0 (Ok)** を返すことを assert。誤ったコーデックなら sentinel が変わるかクラッシュするため、これがパイプライン全体の正当性検証になっている。
+- **分解**: marshal = `_marshal_noop`、decode = `_ssz_decode` − marshal、STF = `_ssz_run` − `_ssz_decode`。
+
+### 計測結果
+
+| N | payload | marshal | decode | STF | total (e2e) |
+|---:|---:|---:|---:|---:|---:|
+| 100 | 6.2 KB | 113 ns | 111 µs | 47.6 µs | 159 µs |
+| 1,000 | 58.9 KB | 1.60 µs | 1.06 ms | 83.4 µs | 1.14 ms |
+| 10,000 | 586.3 KB | 20.0 µs | 12.23 ms | 347 µs | 12.60 ms |
+| 100,000 | 5.7 MB | 220 µs | 139.46 ms | 5.05 ms | **144.73 ms** |
+
+(N=1M は `--include-1m` で opt-in。decode が ~1.4 µs/validator で線形のため ~1.4 s/call ＋ 数 GB RSS と推定。常用せず。)
+
+### 判定 — §4b/§4c の予測を **訂正**
+
+§4c では「実運用 FFI コストの新規項は **marshal**(alloc+memcpy)で、mainnet で STF と肩を並べる」と予測した。**実測はこれを覆した**:
+
+1. **支配項は marshal ではなく decode**。N=100K で marshal 220 µs に対し **decode 139 ms** —— marshal の **約 630 倍**、STF (5 ms) の **約 28 倍**。memcpy は速い (~26 GB/s、§4c と一致) が、バイト列を **Aeneas の List-backed 型へ materialize する**コストが桁違いに大きい。
+2. **decode は N に線形 (~1.4 µs/validator)** だが定数が巨大。原因は Aeneas 表現: `pubkey : Array Std.U8 52` が **52 要素の連結リスト**で、それが N 個 + `validators : Vec` 自体も List。実データを入れると 1 validator あたり 52 ノードの list 構築が走る。
+3. **STF も §1 より重い** (100K で 5.05 ms vs §1 1.80 ms、~2.8×)。§1 は全 validator が `Array.repeat` の**同一共有オブジェクト**だったが、decode 版は各 validator が**別個のオブジェクト**。実データでは共有が効かず、STF の走査が distinct なキャッシュライン/参照カウントに当たるため。**§1 の 22 ms@1M は共有による楽観値**だった、という重要な含意。
+4. **marshal の相対的軽さが確定**: §4c 単独では「14 ms@1M は無視できない」と見えたが、decode と並べると marshal は誤差。**ボトルネックは一貫して Aeneas の List-backed 表現**で、これは fork-choice の O(B²)(§2)と同一の根本原因。
+
+### この経路の全体像
+
+```
+[Rust bytes] ──①marshal──▶ [ByteArray] ──②decode──▶ [typed State/Block] ──③STF──▶ sentinel
+  serialize       220µs@100K(誤差)      139ms@100K(支配項)        5ms@100K
+```
+
+「FFI を実データで使う」コストの正体は **越境でも memcpy でもなく、検証用 Aeneas 型への materialize**。改善は (a) decode 先を Array-backed の高速表現にする、(b) `validators` を flat buffer のまま保持し遅延デコードする、等。issue #4 の本質的課題はマーシャルではなく **decode 表現** にあることが定量的に判明した。
+
+### 限界
+
+- フラットコーデックで正準 SSZ wire 非互換 (offset/union 等は未対応)。実 devnet テストベクタとの互換は別途。
+- 片道のみ (結果 `State` のエンコード+復路は未計測)。
+- decode 先が List-backed なのは Aeneas 既定。Array-backed への変更で decode/STF とも大きく変わる見込み (future work)。
+
+### 再現
+
+```bash
+cd consensus-lean4 && lake build ConsensusLean4:static
+cd rust-ffi && cargo build --release --bin bench-ffi-ssz
+target/release/bench-ffi-ssz            # N=100..100K
+target/release/bench-ffi-ssz --include-1m
 ```
 
 ## 5. Future work

--- a/rust-ffi/Cargo.lock
+++ b/rust-ffi/Cargo.lock
@@ -3,6 +3,22 @@
 version = 4
 
 [[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,5 +28,12 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 name = "rust-ffi"
 version = "0.1.0"
 dependencies = [
+ "cc",
  "libc",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"

--- a/rust-ffi/Cargo.toml
+++ b/rust-ffi/Cargo.toml
@@ -30,6 +30,10 @@ path = "src/bin/bench-ffi-overhead.rs"
 name = "bench-ffi-marshal"
 path = "src/bin/bench-ffi-marshal.rs"
 
+[[bin]]
+name = "bench-ffi-ssz"
+path = "src/bin/bench-ffi-ssz.rs"
+
 [profile.release]
 debug = true
 lto = "thin"

--- a/rust-ffi/Cargo.toml
+++ b/rust-ffi/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [dependencies]
 libc = "0.2"
 
+[build-dependencies]
+cc = "1"
+
 [[bin]]
 name = "rust-ffi"
 path = "src/main.rs"
@@ -22,6 +25,10 @@ path = "src/bin/bench-fork-choice.rs"
 [[bin]]
 name = "bench-ffi-overhead"
 path = "src/bin/bench-ffi-overhead.rs"
+
+[[bin]]
+name = "bench-ffi-marshal"
+path = "src/bin/bench-ffi-marshal.rs"
 
 [profile.release]
 debug = true

--- a/rust-ffi/build.rs
+++ b/rust-ffi/build.rs
@@ -48,6 +48,22 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=stdc++");
     println!("cargo:rustc-link-lib=dylib=gmp");
     println!("cargo:rustc-link-arg=-Wl,-rpath,{}", lean_lib.display());
+
+    // Compile the marshalling C shim (csf_make_bytearray) against lean.h.
+    // lean_alloc_sarray / lean_sarray_cptr are `static inline`, so they must be
+    // used from C, not linked from Rust. The toolchain include dir is the
+    // sibling of <toolchain>/lib/lean.
+    let lean_include = lean_lib
+        .parent()
+        .and_then(Path::parent)
+        .expect("lean lib dir must be <toolchain>/lib/lean")
+        .join("include");
+    println!("cargo:rerun-if-changed=csf_marshal_shim.c");
+    cc::Build::new()
+        .file("csf_marshal_shim.c")
+        .include(&lean_include)
+        .opt_level(3)
+        .compile("csf_marshal_shim");
 }
 
 fn run_lake_build(repo_root: &Path) {

--- a/rust-ffi/csf_marshal_shim.c
+++ b/rust-ffi/csf_marshal_shim.c
@@ -1,0 +1,23 @@
+/* FFI marshalling shim for the M6 bench (see ConsensusLean4/Ffi.lean).
+ *
+ * `lean_alloc_sarray` / `lean_sarray_cptr` are `static inline` in lean.h, so
+ * Rust cannot link them directly. This shim, compiled against lean.h (build.rs
+ * adds <toolchain>/include), exposes a single non-inline entry point that
+ * builds an owned Lean `ByteArray` from a raw buffer.
+ *
+ * The returned object is passed (owned) to a `csf_bench_marshal_*` export,
+ * which Lean's runtime dec_refs on return — the caller must not free it.
+ */
+#include <lean/lean.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Build an owned Lean ByteArray (lean_sarray_object) holding a copy of `src`. */
+lean_object *csf_make_bytearray(const uint8_t *src, size_t n) {
+  lean_object *arr = lean_alloc_sarray(1, n, n);
+  if (n) {
+    memcpy(lean_sarray_cptr(arr), src, n);
+  }
+  return arr;
+}

--- a/rust-ffi/src/bin/bench-ffi-marshal.rs
+++ b/rust-ffi/src/bin/bench-ffi-marshal.rs
@@ -1,0 +1,161 @@
+// M6 — FFI marshalling-cost bench.
+//
+// bench-ffi-overhead showed the *primitive* boundary crossing is ~free. This
+// harness measures what the real SSZ-bytes boundary (issue #4) adds: building a
+// Lean `ByteArray` on the Rust side (alloc + memcpy O(size), via the
+// `csf_make_bytearray` C shim), crossing into Lean as an owned argument, and
+// Lean dec_ref'ing it on return — as a function of payload size.
+//
+// Two Lean exports per call (cf. ConsensusLean4/Ffi.lean M6):
+//   * `csf_bench_marshal_touch` — XOR-folds every byte (decode-scan lower bound)
+//   * `csf_bench_marshal_noop`  — consumes the arg only (alloc + memcpy + dec_ref)
+// per-call(touch) − per-call(noop) = the Lean-side byte scan.
+//
+// Size axis is keyed to the §1 validator count N: a Validator here is
+// pubkey(52) + index(8) = 60 bytes, so payload S = N * 60. This is a flat
+// representative buffer, NOT canonical SSZ — no codec, no hash_tree_root/SHA.
+// Methodology mirrors the other harnesses: calibrate iters to ~200ms/trial,
+// median of 11 trials, black_box to defeat DCE.
+
+use std::ffi::c_void;
+use std::hint::black_box;
+use std::ptr;
+use std::time::{Duration, Instant};
+
+#[link(name = "Init_shared")]
+extern "C" {
+    fn lean_initialize_runtime_module();
+    fn lean_initialize();
+    fn lean_io_mark_end_initialization();
+}
+
+extern "C" {
+    fn initialize_consensus_x2dlean4_ConsensusLean4_Ffi(builtin: u8, world: *mut c_void)
+        -> *mut c_void;
+
+    // C shim: build an owned Lean ByteArray (lean_sarray_object) from a buffer.
+    fn csf_make_bytearray(src: *const u8, n: usize) -> *mut c_void;
+
+    // Lean exports; each consumes (dec_refs) the passed ByteArray.
+    fn csf_bench_marshal_touch(data: *mut c_void) -> u8;
+    fn csf_bench_marshal_noop(data: *mut c_void) -> u8;
+}
+
+unsafe fn boot_lean() {
+    lean_initialize_runtime_module();
+    lean_initialize();
+    let _ = initialize_consensus_x2dlean4_ConsensusLean4_Ffi(1, ptr::null_mut());
+    lean_io_mark_end_initialization();
+}
+
+const VALIDATOR_BYTES: usize = 60; // pubkey(52) + index(8)
+const N_AXIS: &[u64] = &[1, 100, 1_000, 10_000, 100_000, 1_000_000];
+const TARGET_TRIAL: Duration = Duration::from_millis(200);
+const TRIALS: usize = 11;
+
+fn fmt_ns(ns: f64) -> String {
+    if ns < 1_000.0 {
+        format!("{:.1} ns", ns)
+    } else if ns < 1_000_000.0 {
+        format!("{:.2} µs", ns / 1_000.0)
+    } else {
+        format!("{:.2} ms", ns / 1_000_000.0)
+    }
+}
+
+fn fmt_bytes(b: usize) -> String {
+    if b < 1024 {
+        format!("{} B", b)
+    } else if b < 1024 * 1024 {
+        format!("{:.1} KB", b as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", b as f64 / (1024.0 * 1024.0))
+    }
+}
+
+/// Time `iters` calls of `(make_bytearray + export)` over `buf`, accumulating
+/// the sentinel through black_box. Returns total nanoseconds.
+fn time_loop(iters: u64, buf: &[u8], call: unsafe extern "C" fn(*mut c_void) -> u8) -> u128 {
+    let p = buf.as_ptr();
+    let n = buf.len();
+    let mut acc: u8 = 0;
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        let obj = unsafe { csf_make_bytearray(black_box(p), black_box(n)) };
+        acc ^= unsafe { call(obj) };
+    }
+    let elapsed = t0.elapsed().as_nanos();
+    black_box(acc);
+    elapsed
+}
+
+fn calibrate(buf: &[u8], call: unsafe extern "C" fn(*mut c_void) -> u8) -> u64 {
+    let _ = time_loop(2, buf, call); // warm pages / branch predictor
+    const SAMPLE: u64 = 5;
+    let ns = time_loop(SAMPLE, buf, call).max(1);
+    let per_call = (ns as f64 / SAMPLE as f64).max(1.0);
+    let raw = (TARGET_TRIAL.as_nanos() as f64 / per_call) as u64;
+    raw.clamp(1, 50_000_000)
+}
+
+fn bench(buf: &[u8], call: unsafe extern "C" fn(*mut c_void) -> u8) -> (u64, f64) {
+    let iters = calibrate(buf, call);
+    let mut per_call: Vec<f64> = Vec::with_capacity(TRIALS);
+    for _ in 0..TRIALS {
+        let ns = time_loop(iters, buf, call);
+        per_call.push(ns as f64 / iters as f64);
+    }
+    per_call.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    (iters, per_call[TRIALS / 2])
+}
+
+fn gbps(bytes: usize, ns: f64) -> f64 {
+    // bytes / seconds / 1e9
+    (bytes as f64 / (ns / 1e9)) / 1e9
+}
+
+fn main() {
+    unsafe { boot_lean(); }
+
+    // Sanity: a 3-byte ByteArray {1,2,3} XOR-folds to 0.
+    let probe = unsafe { csf_bench_marshal_touch(csf_make_bytearray([1u8, 2, 3].as_ptr(), 3)) };
+    assert_eq!(probe, 0, "XOR-fold of {{1,2,3}} should be 0, got {probe}");
+
+    println!("# FFI marshalling cost (Rust→Lean ByteArray, no SSZ codec / no SHA)");
+    println!();
+    println!("Validator = {VALIDATOR_BYTES} B (pubkey 52 + index 8); payload S = N · {VALIDATOR_BYTES}.");
+    println!();
+    println!("| N | payload S | marshal (noop) | full (marshal+scan) | scan Δ | marshal GB/s | marshal ns/byte |");
+    println!("|---:|---:|---:|---:|---:|---:|---:|");
+
+    for &n in N_AXIS {
+        let s = (n as usize) * VALIDATOR_BYTES;
+        // Distinct, non-zero content so memcpy/scan can't be elided as a zero page.
+        let buf: Vec<u8> = (0..s).map(|i| (i as u8).wrapping_mul(31).wrapping_add(7)).collect();
+
+        let (_it_n, noop) = bench(&buf, csf_bench_marshal_noop);
+        let (_it_f, full) = bench(&buf, csf_bench_marshal_touch);
+        let scan = (full - noop).max(0.0);
+
+        let marshal_gbps = if s > 0 { gbps(s, noop) } else { 0.0 };
+        let marshal_npb = if s > 0 { noop / s as f64 } else { 0.0 };
+
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {} |",
+            n,
+            fmt_bytes(s),
+            fmt_ns(noop),
+            fmt_ns(full),
+            fmt_ns(scan),
+            if s > 0 { format!("{:.1}", marshal_gbps) } else { "—".into() },
+            if s > 0 { format!("{:.3} ns", marshal_npb) } else { "—".into() },
+        );
+    }
+
+    println!();
+    println!(
+        "> marshal = alloc + memcpy + boundary + dec_ref (`_noop`). scan Δ = Lean XOR-fold over S bytes. \
+         Trials={TRIALS}, target {}ms/trial. Floor only: flat buffer, no SSZ codec / hash_tree_root.",
+        TARGET_TRIAL.as_millis(),
+    );
+}

--- a/rust-ffi/src/bin/bench-ffi-ssz.rs
+++ b/rust-ffi/src/bin/bench-ffi-ssz.rs
@@ -1,0 +1,203 @@
+// M7 — end-to-end SSZ-bytes pipeline: marshal → decode → pure STF.
+//
+// Connects what M6 (bench-ffi-marshal) left split: a State+Block is serialized
+// on the Rust side to a flat length-prefixed buffer, marshalled into a Lean
+// ByteArray (csf_make_bytearray), decoded into the typed `State`/`Block`
+// (ConsensusLean4/Ffi.lean M7), and fed to the pure `stateTransitionFast`.
+//
+// The fixture matches §1's buildBenchState(n)/buildBenchBlock(n) byte-for-byte
+// (N validators, empty justification/attestation vectors, block at slot 1,
+// proposer 1%N), so the decoded input is identical to the scalar-built one and
+// the STF cost is directly comparable. Correctness gate: ssz_run must return
+// sentinel 0 (Ok) — a wrong codec would yield a different sentinel or crash.
+//
+// Decomposition per N (each call = make_bytearray + one export):
+//   marshal    = make + csf_bench_marshal_noop                 (alloc+memcpy+dec_ref)
+//   ssz_decode = make + csf_bench_state_transition_ssz_decode  (+ decode)
+//   ssz_run    = make + csf_bench_state_transition_ssz_run     (+ decode + STF)
+// → decode = ssz_decode − marshal,  STF = ssz_run − ssz_decode.
+//
+// No SSZ canonical wire format and no hash_tree_root/SHA: decoding is pure byte
+// layout. Methodology mirrors the sibling harnesses (calibrate to ~200ms/trial,
+// median of 11 trials, black_box).
+
+use std::env;
+use std::ffi::c_void;
+use std::hint::black_box;
+use std::ptr;
+use std::time::{Duration, Instant};
+
+#[link(name = "Init_shared")]
+extern "C" {
+    fn lean_initialize_runtime_module();
+    fn lean_initialize();
+    fn lean_io_mark_end_initialization();
+}
+
+extern "C" {
+    fn initialize_consensus_x2dlean4_ConsensusLean4_Ffi(builtin: u8, world: *mut c_void)
+        -> *mut c_void;
+    fn csf_make_bytearray(src: *const u8, n: usize) -> *mut c_void;
+    fn csf_bench_marshal_noop(data: *mut c_void) -> u8;
+    fn csf_bench_state_transition_ssz_decode(data: *mut c_void) -> u8;
+    fn csf_bench_state_transition_ssz_run(data: *mut c_void) -> u8;
+}
+
+unsafe fn boot_lean() {
+    lean_initialize_runtime_module();
+    lean_initialize();
+    let _ = initialize_consensus_x2dlean4_ConsensusLean4_Ffi(1, ptr::null_mut());
+    lean_io_mark_end_initialization();
+}
+
+// ---- Rust serializer: must round-trip with ConsensusLean4/Ffi.lean M7 ----
+
+fn push_u64(b: &mut Vec<u8>, x: u64) {
+    b.extend_from_slice(&x.to_le_bytes());
+}
+fn push_zeros(b: &mut Vec<u8>, n: usize) {
+    b.resize(b.len() + n, 0);
+}
+
+/// Serialize State++Block matching buildBenchState(n)/buildBenchBlock(n).
+fn serialize_fixture(n: u64) -> Vec<u8> {
+    let mut b = Vec::new();
+    // --- State ---
+    push_u64(&mut b, 0); // config.genesis_time
+    push_u64(&mut b, 0); // slot
+    push_zeros(&mut b, 112); // latest_block_header (all zero)
+    push_zeros(&mut b, 40); // latest_justified  {ZERO, 0}
+    push_zeros(&mut b, 40); // latest_finalized  {ZERO, 0}
+    push_u64(&mut b, 0); // historical_block_hashes: count
+    push_u64(&mut b, 0); // justified_slots: count
+    push_u64(&mut b, n); // validators: count
+    for _ in 0..n {
+        push_zeros(&mut b, 52); // pubkey
+        push_u64(&mut b, 0); // index
+    }
+    push_u64(&mut b, 0); // justifications_roots: count
+    push_u64(&mut b, 0); // justifications_validators: count
+    // --- Block ---
+    push_u64(&mut b, 1); // slot
+    push_u64(&mut b, if n == 0 { 0 } else { 1 % n }); // proposer_index
+    push_zeros(&mut b, 32); // parent_root
+    push_zeros(&mut b, 32); // state_root
+    push_u64(&mut b, 0); // body.attestations: count
+    b
+}
+
+// ---- timing ----
+
+const N_AXIS: &[u64] = &[100, 1_000, 10_000, 100_000];
+const REFERENCE_N: u64 = 1_000_000;
+const TARGET_TRIAL: Duration = Duration::from_millis(200);
+const TRIALS: usize = 11;
+
+fn fmt_ns(ns: f64) -> String {
+    if ns < 1_000.0 {
+        format!("{:.1} ns", ns)
+    } else if ns < 1_000_000.0 {
+        format!("{:.2} µs", ns / 1_000.0)
+    } else {
+        format!("{:.2} ms", ns / 1_000_000.0)
+    }
+}
+
+fn time_loop(iters: u64, buf: &[u8], call: unsafe extern "C" fn(*mut c_void) -> u8) -> u128 {
+    let p = buf.as_ptr();
+    let n = buf.len();
+    let mut acc: u8 = 0;
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        let obj = unsafe { csf_make_bytearray(black_box(p), black_box(n)) };
+        acc ^= unsafe { call(obj) };
+    }
+    let elapsed = t0.elapsed().as_nanos();
+    black_box(acc);
+    elapsed
+}
+
+fn calibrate(buf: &[u8], call: unsafe extern "C" fn(*mut c_void) -> u8) -> u64 {
+    let _ = time_loop(2, buf, call);
+    const SAMPLE: u64 = 5;
+    let ns = time_loop(SAMPLE, buf, call).max(1);
+    let per_call = (ns as f64 / SAMPLE as f64).max(1.0);
+    ((TARGET_TRIAL.as_nanos() as f64 / per_call) as u64).clamp(1, 50_000_000)
+}
+
+fn bench(buf: &[u8], call: unsafe extern "C" fn(*mut c_void) -> u8) -> f64 {
+    let iters = calibrate(buf, call);
+    let mut v: Vec<f64> = Vec::with_capacity(TRIALS);
+    for _ in 0..TRIALS {
+        v.push(time_loop(iters, buf, call) as f64 / iters as f64);
+    }
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v[TRIALS / 2]
+}
+
+struct Row {
+    n: u64,
+    bytes: usize,
+    marshal: f64,
+    decode: f64,
+    stf: f64,
+    total: f64,
+}
+
+fn bench_cell(n: u64) -> Row {
+    let buf = serialize_fixture(n);
+
+    // Correctness gate: the decoded fixture must transition cleanly (Ok = 0).
+    let sentinel = unsafe { csf_bench_state_transition_ssz_run(csf_make_bytearray(buf.as_ptr(), buf.len())) };
+    assert_eq!(sentinel, 0, "N={n}: ssz_run sentinel must be 0 (Ok), got {sentinel} — codec mismatch");
+
+    let marshal = bench(&buf, csf_bench_marshal_noop);
+    let decode_total = bench(&buf, csf_bench_state_transition_ssz_decode);
+    let run_total = bench(&buf, csf_bench_state_transition_ssz_run);
+    Row {
+        n,
+        bytes: buf.len(),
+        marshal,
+        decode: (decode_total - marshal).max(0.0),
+        stf: (run_total - decode_total).max(0.0),
+        total: run_total,
+    }
+}
+
+fn main() {
+    let include_1m = env::args().any(|s| s == "--include-1m");
+    unsafe { boot_lean(); }
+
+    let mut rows: Vec<Row> = N_AXIS.iter().map(|&n| bench_cell(n)).collect();
+    if include_1m {
+        rows.push(bench_cell(REFERENCE_N));
+    }
+
+    println!("# End-to-end SSZ-bytes pipeline: marshal → decode → pure STF");
+    println!();
+    println!("Fixture = §1 buildBenchState(n)/buildBenchBlock(n), serialized. Codec gate: sentinel 0 (Ok).");
+    println!();
+    println!("| N | payload | marshal | decode | STF | total (e2e) |");
+    println!("|---:|---:|---:|---:|---:|---:|");
+    for r in &rows {
+        println!(
+            "| {} | {} | {} | {} | {} | **{}** |",
+            r.n,
+            if r.bytes < 1024 * 1024 {
+                format!("{:.1} KB", r.bytes as f64 / 1024.0)
+            } else {
+                format!("{:.1} MB", r.bytes as f64 / (1024.0 * 1024.0))
+            },
+            fmt_ns(r.marshal),
+            fmt_ns(r.decode),
+            fmt_ns(r.stf),
+            fmt_ns(r.total),
+        );
+    }
+    println!();
+    println!(
+        "> marshal = alloc+memcpy+dec_ref; decode = ssz_decode−marshal (bytes→typed State/Block); \
+         STF = ssz_run−ssz_decode (pure stateTransitionFast). Trials={TRIALS}. \
+         Flat codec, no canonical SSZ / hash_tree_root."
+    );
+}

--- a/rust-ffi/src/bin/bench-ffi-ssz.rs
+++ b/rust-ffi/src/bin/bench-ffi-ssz.rs
@@ -88,8 +88,11 @@ fn serialize_fixture(n: u64) -> Vec<u8> {
 
 // ---- timing ----
 
-const N_AXIS: &[u64] = &[100, 1_000, 10_000, 100_000];
-const REFERENCE_N: u64 = 1_000_000;
+// V is bounded by VALIDATOR_REGISTRY_LIMIT = 4096 (SSZ list cap; Funs/Types.lean).
+// leanSpec baseline is 4 validators; tests use 4/8. This axis spans the real
+// operating range (devnet baseline → spec max), not mainnet-beacon scale.
+const N_AXIS: &[u64] = &[4, 8, 64, 512, 4096];
+const REFERENCE_N: u64 = 4096;
 const TARGET_TRIAL: Duration = Duration::from_millis(200);
 const TRIALS: usize = 11;
 


### PR DESCRIPTION
## Summary

Follow-up to #18 §4b, which found the **primitive** FFI boundary crossing is essentially free (~1.9 ns, indistinguishable from a normal call) but flagged that the *real* SSZ-bytes boundary (#4) would add `lean_object*` marshalling + dec_ref — left unmeasured. This PR measures exactly that, as a function of payload size.

> Note: originally opened as #19 based on `feat/ffi-benchmarks` (#18). #18 is now merged to `main`; this PR re-targets `main` directly. Diff is the M6 work only (8 files, +774).

## What's added

- **`rust-ffi/csf_marshal_shim.c`** — `csf_make_bytearray` (alloc + memcpy). `lean_alloc_sarray`/`lean_sarray_cptr` are `static inline` in `lean.h`, so they can't be linked from Rust; the shim is compiled against `lean.h` by `build.rs` (via `cc`, toolchain include dir).
- **`ConsensusLean4/Ffi.lean`** — `csf_bench_marshal_touch` (XOR-fold every byte = decode-scan lower bound) and `csf_bench_marshal_noop` (consume only); difference = Lean-side scan.
- **`rust-ffi/src/bin/bench-ffi-marshal.rs`** — size axis keyed to §1's N (Validator = 60 B → S = N·60).

No SSZ codec, no `hash_tree_root`/SHA: `ByteArray` is a flat buffer, so serde is pure byte layout (hashing is only needed for merkleization, which this path doesn't touch).

## Results (S = N · 60 B)

| N | payload | marshal (noop) | full (marshal+scan) | scan Δ | marshal GB/s |
|---:|---:|---:|---:|---:|---:|
| 100 | 5.9 KB | 114 ns | 235 ns | 121 ns | 52.4 |
| 100,000 | 5.7 MB | 223 µs | 351 µs | 128 µs | 26.9 |
| 1,000,000 | 57.2 MB | **14.39 ms** | 16.64 ms | 2.25 ms | 4.2 |

**vs §1 STF compute:** at N=1M, marshal (14.4 ms) is **~65%** of the STF pipeline (22 ms); round-trip would exceed it.

## Verdict

Confirms the §4b prediction: **FFI overhead is ~0 for primitives but size-linear for data.** Small (devnet, KB) ≈ noise; mainnet (57 MB) reaches parity with the STF. The GB/s drop (52 → 4.2) reflects per-call alloc + first-touch page faults + memcpy + free, not raw memcpy bandwidth.

Limitations: flat representative buffer (not canonical SSZ), one-way only, owned-copy (zero-copy borrow could cut memcpy). Full typed SSZ decode + STF wiring remains #4.

Repro:
```bash
cd consensus-lean4 && lake build ConsensusLean4:static
cd rust-ffi && cargo build --release --bin bench-ffi-marshal
target/release/bench-ffi-marshal
```

Full writeup: `docs/rust-ffi-benchmarks.md` §4c.
