### PR TITLE
perf(ffi): re-measure benches at leanSpec-realistic V (≤ 4096) with A=8 votes

### DIFF
--- a/ConsensusLean4/Ffi.lean
+++ b/ConsensusLean4/Ffi.lean
@@ -313,6 +313,106 @@ def csfBenchComputeLmdGhostHeadBuildOnly
   let atts := buildForkChoiceAttestations b a
   consumeBlocksVec blocks ^^^ consumeAttsVec atts
 
+/-! ## M5b — spec-realistic attestation workload (A = MAX_ATTESTATIONS_DATA = 8).
+
+The §1 `csf_bench_state_transition_*` fixture runs a block with **zero**
+attestations, so `processAttestationsFast`'s O(A·V) hot loop never executes — it
+measures only validator-Vec construction, not the STF body. This fixture loads
+the block with the leanSpec maximum of 8 distinct, *valid* AggregatedAttestations
+so the fast path actually runs.
+
+The genesis is reverse-engineered from `is_valid_vote` / `slot_is_justifiable_after`
+/ `current_proposer` (Funs/StateTransition.lean) so all 8 votes pass `voteIsValid`
+and stay under the 2/3 finalize threshold (which would otherwise bail to the
+Aeneas slow path and measure the wrong thing):
+  * finalized slot F = 0; source = (slot 0, historical[0]); slot 0 ≤ F ⇒ justified.
+  * 8 targets at slots {1,2,3,4,5,6,9,12}: each > F and `slot_is_justifiable_after`
+    (1–5 are ≤ 5, 6/12 are pronic, 9 is a perfect square); `justified_slots`
+    starts empty ⇒ every target slot is unjustified.
+  * historical[i] = hashOfNat i (non-zero, distinct) ⇒ `checkpoint_exists` holds
+    for both source and every target.
+  * each `aggregation_bits` sets ⌈V/2⌉ of V bits: yes = ⌈V/2⌉ < 2/3·V ⇒ no bail,
+    yet the inner loop still scans all V bits (the O(8·V) cost we want to measure).
+  * block at slot 13 with `latest_block_header.slot` = 12 ⇒ `num_empty_slots` = 0,
+    so `process_block_header` appends exactly one (ZERO) historical entry and the
+    pre-seeded indices 0..12 stay intact. -/
+
+private def attTargetSlots : List Nat := [1, 2, 3, 4, 5, 6, 9, 12]
+
+private def buildAttHistorical : alloc.vec.Vec types.H256 :=
+  buildVecFromList ((List.range 13).map hashOfNat) (alloc.vec.Vec.new types.H256)
+
+private def buildAttBits (n : Nat) : alloc.vec.Vec Bool :=
+  let half := (n + 1) / 2
+  buildVecFromList (List.replicate half true ++ List.replicate (n - half) false)
+    (alloc.vec.Vec.new Bool)
+
+private def buildAttestation (n : Nat) (t : Nat) : types.AggregatedAttestation :=
+  let source : types.Checkpoint := { root := hashOfNat 0, slot := 0#u64 }
+  let target : types.Checkpoint :=
+    { root := hashOfNat t, slot := u64OfUInt64 (UInt64.ofNat t) }
+  { aggregation_bits := buildAttBits n
+    data := { slot := target.slot, head := target, target := target, source := source } }
+
+private def buildAttAttestations (n : Nat) :
+    alloc.vec.Vec types.AggregatedAttestation :=
+  buildVecFromList (attTargetSlots.map (buildAttestation n))
+    (alloc.vec.Vec.new types.AggregatedAttestation)
+
+private def buildBenchStateAtt (n : UInt64) : types.State :=
+  let finalizedCp : types.Checkpoint := { root := hashOfNat 0, slot := 0#u64 }
+  let header12 : types.BlockHeader :=
+    { slot := 12#u64
+      proposer_index := 0#u64
+      parent_root := types.H256.ZERO
+      state_root := types.H256.ZERO
+      body_root := types.H256.ZERO }
+  { config := { genesis_time := 0#u64 }
+    slot := 12#u64
+    latest_block_header := header12
+    latest_justified := finalizedCp
+    latest_finalized := finalizedCp
+    historical_block_hashes := buildAttHistorical
+    justified_slots := alloc.vec.Vec.new Bool
+    validators := buildBenchValidators n.toNat
+    justifications_roots := alloc.vec.Vec.new types.H256
+    justifications_validators := alloc.vec.Vec.new Bool }
+
+private def buildBenchBlockAtt (n : UInt64) : types.Block :=
+  -- Proposer for slot 13 = 13 % V (current_proposer = slot % num_validators).
+  let proposerRaw : UInt64 := if n = 0 then 0 else 13 % n
+  { slot := 13#u64
+    proposer_index := u64OfUInt64 proposerRaw
+    parent_root := types.H256.ZERO
+    state_root := types.H256.ZERO
+    body := { attestations := buildAttAttestations n.toNat } }
+
+/-- Build the V-validator genesis + 8-valid-vote block and run the fast pipeline.
+The `_a` slot is the fixed spec attestation count (8); it is ignored here because
+the count is baked into `attTargetSlots`, but kept in the signature so the Rust
+harness plumbing stays uniform with the other bench entry points. -/
+@[export csf_bench_state_transition_att_run]
+def csfBenchStateTransitionAttRun (n _a _seed : UInt64) : UInt8 :=
+  packStatePipeline
+    (ConsensusLean4.FastPath.stateTransitionFast
+      (buildBenchStateAtt n) (buildBenchBlockAtt n))
+
+/-- Paired-delta twin: build the same State + Block, skip the pipeline. -/
+@[export csf_bench_state_transition_att_buildonly]
+def csfBenchStateTransitionAttBuildOnly (n _a _seed : UInt64) : UInt8 :=
+  consumeState (buildBenchStateAtt n) ^^^ consumeBlock (buildBenchBlockAtt n)
+
+/-- Verification probe: `justifications_roots` length after the pipeline. With all
+8 votes processed (none skipped, no 2/3 bail) the serialiser prepends a ZERO
+sentinel root ⇒ length 9. The Rust harness asserts this before timing so a broken
+fixture (silently-skipped votes) can never be measured as a fast result. -/
+@[export csf_bench_state_transition_att_cells]
+def csfBenchStateTransitionAttCells (n : UInt64) : UInt8 :=
+  match ConsensusLean4.FastPath.stateTransitionFast
+      (buildBenchStateAtt n) (buildBenchBlockAtt n) with
+  | .ok (_, s) => (min s.justifications_roots.val.length 255).toUInt8
+  | _          => 0
+
 /-! ## M6 — FFI marshalling cost.
 
 The §1/§2 benches cross only primitive `UInt64`, so they measure Lean-side

--- a/README.md
+++ b/README.md
@@ -72,19 +72,25 @@ elan which lean
 lake build ConsensusLean4:static
 cd rust-ffi && cargo build --release
 
-# 3. Run the benches. Default cells are sized for ~30 s / process; opt-in flags
-#    extend the axis. Per-cell `ru_maxrss` isolation needs separate invocations.
-target/release/bench-state-transition                      # N ∈ {100, 1K, 10K, 100K}
-target/release/bench-state-transition --include-1m         # + N=1M (1 trial, ~0.1 s)
-target/release/bench-fork-choice                           # B=100 × A ∈ {32, 128}
+# 3. Run the benches. The V axis is bounded by the leanSpec validator registry
+#    limit (VALIDATOR_REGISTRY_LIMIT = 2^12 = 4096); `--include-1m` adds a
+#    mainnet out-of-spec reference. Per-cell `ru_maxrss` isolation needs separate
+#    invocations.
+target/release/bench-state-transition                      # V ∈ {4, 8, 64, 512, 4096}, A=8 valid attestations
+target/release/bench-state-transition --include-1m         # + V=1M (mainnet, out-of-spec; ~4 s, ~584 MB)
+target/release/bench-ffi-marshal                           # V ∈ {1, 4, 8, 64, 512, 4096} ByteArray marshal cost
+target/release/bench-fork-choice                           # B=100 × A ∈ {32, 128} (no V axis; B ≤ HISTORICAL_ROOTS_LIMIT=2^18)
 target/release/bench-fork-choice --include-1k              # + B=1K (~6 min/cell)
-target/release/bench-state-transition --single-n=100000    # one cell, ru_maxrss-clean
+target/release/bench-state-transition --single-n=4096      # one cell, ru_maxrss-clean
 ```
 
-Reference budgets and judgment criteria live in [`docs/timing-budget.md`](docs/timing-budget.md);
-detailed result tables are in [`docs/rust-ffi-benchmarks.md`](docs/rust-ffi-benchmarks.md).
-Crypto cost (`hash_tree_root_*`) is excluded — those return `H256.ZERO` per the spec stubs in
-`ConsensusLean4/Funs/Types.lean`.
+The `state_transition` bench loads each block with A = `MAX_ATTESTATIONS_DATA` = 8 valid
+attestations so the `O(A·V)` fast path actually runs, and asserts a fixture self-check
+(`att_cells == 9`) before timing. Reference budgets and judgment criteria live in
+[`docs/timing-budget.md`](docs/timing-budget.md); the spec-constant axis rationale and
+detailed result tables are in [`docs/rust-ffi-benchmarks.md`](docs/rust-ffi-benchmarks.md)
+(§0 pins the leanSpec / mainnet constants). Crypto cost (`hash_tree_root_*`) is excluded —
+those return `H256.ZERO` per the spec stubs in `ConsensusLean4/Funs/Types.lean`.
 
 ## Source
 

--- a/docs/assets/bench-scaling.svg
+++ b/docs/assets/bench-scaling.svg
@@ -1,0 +1,2788 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="655.091562pt" height="395.542266pt" viewBox="0 0 655.091562 395.542266" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-25T21:09:35.776327</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7+dfsg1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 395.542266 
+L 655.091562 395.542266 
+L 655.091562 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 66.061563 357.018203 
+L 647.891562 357.018203 
+L 647.891562 27.938203 
+L 66.061563 27.938203 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 408.571365 357.018203 
+L 647.891562 357.018203 
+L 647.891562 27.938203 
+L 408.571365 27.938203 
+z
+" clip-path="url(#p59eb4bfc70)" style="fill: #d62728; opacity: 0.06; stroke: #d62728; stroke-linejoin: miter"/>
+   </g>
+   <g id="line2d_1">
+    <path d="M 408.571365 357.018203 
+L 408.571365 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 4.81,2.08; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.3"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_2">
+      <path d="M 75.010124 357.018203 
+L 75.010124 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_3">
+      <defs>
+       <path id="m93be716bde" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m93be716bde" x="75.010124" y="357.018203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 1 -->
+      <g transform="translate(71.828874 371.616641) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_4">
+      <path d="M 130.603664 357.018203 
+L 130.603664 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m93be716bde" x="130.603664" y="357.018203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 4 -->
+      <g transform="translate(127.422414 371.616641) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_6">
+      <path d="M 158.400434 357.018203 
+L 158.400434 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m93be716bde" x="158.400434" y="357.018203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 8 -->
+      <g transform="translate(155.219184 371.616641) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_8">
+      <path d="M 241.790745 357.018203 
+L 241.790745 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m93be716bde" x="241.790745" y="357.018203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 64 -->
+      <g transform="translate(235.428245 371.616641) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_10">
+      <path d="M 325.181055 357.018203 
+L 325.181055 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m93be716bde" x="325.181055" y="357.018203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 512 -->
+      <g transform="translate(315.637305 371.616641) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_12">
+      <path d="M 408.571365 357.018203 
+L 408.571365 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m93be716bde" x="408.571365" y="357.018203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 4096 -->
+      <g transform="translate(395.846365 371.616641) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_14">
+      <path d="M 629.043354 357.018203 
+L 629.043354 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m93be716bde" x="629.043354" y="357.018203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 1M -->
+      <g transform="translate(621.548041 371.616641) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-4d" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_16">
+      <path d="M 66.061563 357.018203 
+L 66.061563 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_17">
+      <defs>
+       <path id="m521d93ea2a" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m521d93ea2a" x="66.061563" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_18">
+      <path d="M 70.784929 357.018203 
+L 70.784929 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="70.784929" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_20">
+      <path d="M 102.806894 357.018203 
+L 102.806894 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="102.806894" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_22">
+      <path d="M 119.066962 357.018203 
+L 119.066962 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="119.066962" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_24">
+      <path d="M 139.552225 357.018203 
+L 139.552225 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="139.552225" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_26">
+      <path d="M 146.863732 357.018203 
+L 146.863732 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="146.863732" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_28">
+      <path d="M 153.045523 357.018203 
+L 153.045523 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="153.045523" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_30">
+      <path d="M 163.1238 357.018203 
+L 163.1238 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="163.1238" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_32">
+      <path d="M 195.145766 357.018203 
+L 195.145766 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="195.145766" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_34">
+      <path d="M 211.405834 357.018203 
+L 211.405834 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="211.405834" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_36">
+      <path d="M 222.942536 357.018203 
+L 222.942536 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="222.942536" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_38">
+      <path d="M 231.891097 357.018203 
+L 231.891097 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="231.891097" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_40">
+      <path d="M 239.202604 357.018203 
+L 239.202604 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="239.202604" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_42">
+      <path d="M 245.384395 357.018203 
+L 245.384395 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="245.384395" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_44">
+      <path d="M 250.739306 357.018203 
+L 250.739306 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="250.739306" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_46">
+      <path d="M 255.462672 357.018203 
+L 255.462672 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="255.462672" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_48">
+      <path d="M 287.484637 357.018203 
+L 287.484637 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="287.484637" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_50">
+      <path d="M 303.744705 357.018203 
+L 303.744705 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="303.744705" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_52">
+      <path d="M 315.281407 357.018203 
+L 315.281407 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="315.281407" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_54">
+      <path d="M 324.229969 357.018203 
+L 324.229969 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="324.229969" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_56">
+      <path d="M 331.541475 357.018203 
+L 331.541475 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="331.541475" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_58">
+      <path d="M 337.723266 357.018203 
+L 337.723266 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="337.723266" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_60">
+      <path d="M 343.078177 357.018203 
+L 343.078177 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="343.078177" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_62">
+      <path d="M 347.801544 357.018203 
+L 347.801544 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="347.801544" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_64">
+      <path d="M 379.823509 357.018203 
+L 379.823509 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="379.823509" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_66">
+      <path d="M 396.083577 357.018203 
+L 396.083577 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_67">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="396.083577" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_68">
+      <path d="M 407.620279 357.018203 
+L 407.620279 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_69">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="407.620279" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_70">
+      <path d="M 416.56884 357.018203 
+L 416.56884 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_71">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="416.56884" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_72">
+      <path d="M 423.880347 357.018203 
+L 423.880347 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="423.880347" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_74">
+      <path d="M 430.062138 357.018203 
+L 430.062138 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_75">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="430.062138" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_76">
+      <path d="M 435.417049 357.018203 
+L 435.417049 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_77">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="435.417049" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_78">
+      <path d="M 440.140415 357.018203 
+L 440.140415 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_79">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="440.140415" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_80">
+      <path d="M 472.16238 357.018203 
+L 472.16238 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_81">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="472.16238" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_82">
+      <path d="M 488.422449 357.018203 
+L 488.422449 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_83">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="488.422449" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_84">
+      <path d="M 499.959151 357.018203 
+L 499.959151 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_85">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="499.959151" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_86">
+      <path d="M 508.907712 357.018203 
+L 508.907712 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="508.907712" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_88">
+      <path d="M 516.219219 357.018203 
+L 516.219219 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="516.219219" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_90">
+      <path d="M 522.40101 357.018203 
+L 522.40101 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="522.40101" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_92">
+      <path d="M 527.755921 357.018203 
+L 527.755921 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_93">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="527.755921" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_94">
+      <path d="M 532.479287 357.018203 
+L 532.479287 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_95">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="532.479287" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_96">
+      <path d="M 564.501252 357.018203 
+L 564.501252 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_97">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="564.501252" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_98">
+      <path d="M 580.76132 357.018203 
+L 580.76132 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_99">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="580.76132" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_100">
+      <path d="M 592.298022 357.018203 
+L 592.298022 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_101">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="592.298022" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_51">
+     <g id="line2d_102">
+      <path d="M 601.246583 357.018203 
+L 601.246583 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_103">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="601.246583" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_52">
+     <g id="line2d_104">
+      <path d="M 608.55809 357.018203 
+L 608.55809 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_105">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="608.55809" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_53">
+     <g id="line2d_106">
+      <path d="M 614.739881 357.018203 
+L 614.739881 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_107">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="614.739881" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_54">
+     <g id="line2d_108">
+      <path d="M 620.094792 357.018203 
+L 620.094792 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_109">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="620.094792" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_55">
+     <g id="line2d_110">
+      <path d="M 624.818159 357.018203 
+L 624.818159 27.938203 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_111">
+      <g>
+       <use xlink:href="#m521d93ea2a" x="624.818159" y="357.018203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- validator count  V -->
+     <g transform="translate(308.127109 386.054609) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(148.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(176.025391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(239.501953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(300.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(339.990234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(401.171875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(442.285156 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(474.072266 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(529.052734 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(590.234375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(653.613281 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(716.992188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(756.201172 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(787.988281 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(819.775391 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_112">
+      <path d="M 66.061563 353.542742 
+L 647.891562 353.542742 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_113">
+      <defs>
+       <path id="mf64324dd52" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="353.542742" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_114">
+      <path d="M 66.061563 317.679978 
+L 647.891562 317.679978 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_115">
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="317.679978" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_116">
+      <path d="M 66.061563 281.817213 
+L 647.891562 281.817213 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_117">
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="281.817213" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 1 µs -->
+      <g transform="translate(37.949063 285.616432) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_118">
+      <path d="M 66.061563 245.954449 
+L 647.891562 245.954449 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_119">
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="245.954449" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_120">
+      <path d="M 66.061563 210.091684 
+L 647.891562 210.091684 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_121">
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="210.091684" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_122">
+      <path d="M 66.061563 174.22892 
+L 647.891562 174.22892 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_123">
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="174.22892" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 1 ms -->
+      <g transform="translate(34.570938 178.028138) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_124">
+      <path d="M 66.061563 138.366155 
+L 647.891562 138.366155 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_125">
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="138.366155" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 10 ms -->
+      <g transform="translate(28.208438 142.165374) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_126">
+      <path d="M 66.061563 102.503391 
+L 647.891562 102.503391 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_127">
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="102.503391" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 100 ms -->
+      <g transform="translate(21.845938 106.302609) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_128">
+      <path d="M 66.061563 66.640626 
+L 647.891562 66.640626 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_129">
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="66.640626" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 1 s -->
+      <g transform="translate(44.311563 70.439845) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_130">
+      <path d="M 66.061563 30.777862 
+L 647.891562 30.777862 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_131">
+      <g>
+       <use xlink:href="#mf64324dd52" x="66.061563" y="30.777862" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 10 s -->
+      <g transform="translate(37.949063 34.57708) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_15">
+     <!-- time per call (log scale) -->
+     <g transform="translate(15.558281 257.331797) rotate(-90) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-74"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(39.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(66.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(164.404297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.927734 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(257.714844 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(321.191406 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(382.714844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(423.828125 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(455.615234 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(510.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(571.875 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(599.658203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(627.441406 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(659.228516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(698.242188 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(726.025391 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(787.207031 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(850.683594 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(882.470703 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(934.570312 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(989.550781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1050.830078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1078.613281 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1140.136719 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_132">
+    <path d="M 66.061563 91.707623 
+L 647.891562 91.707623 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_133">
+    <path d="M 66.061563 70.116087 
+L 647.891562 70.116087 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 66.061563 357.018203 
+L 66.061563 27.938203 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 647.891562 357.018203 
+L 647.891562 27.938203 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 66.061563 357.018203 
+L 647.891562 357.018203 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 66.061563 27.938203 
+L 647.891562 27.938203 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_16">
+    <!-- VALIDATOR_REGISTRY_LIMIT = 4096 -->
+    <g style="fill: #b01010" transform="translate(414.176135 343.661451) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-45" d="M 628 4666 
+L 3578 4666 
+L 3578 4134 
+L 1259 4134 
+L 1259 2753 
+L 3481 2753 
+L 3481 2222 
+L 1259 2222 
+L 1259 531 
+L 3634 531 
+L 3634 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-59" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(62.033203 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(130.441406 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(186.154297 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(215.646484 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(290.898438 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(351.556641 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(412.640625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(491.351562 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(560.833984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(610.833984 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(680.316406 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(743.5 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(820.990234 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(850.482422 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(913.958984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(975.042969 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1038.150391 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(1099.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1149.234375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1204.947266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(1234.439453 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1320.71875 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1350.210938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1411.294922 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(1443.082031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1526.871094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1558.658203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1622.28125 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(1685.904297 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1749.527344 0)"/>
+    </g>
+    <!-- (leanSpec cap) -->
+    <g style="fill: #b01010" transform="translate(414.176135 353.415998) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-28"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(39.013672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(66.796875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(128.320312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(189.599609 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(252.978516 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(316.455078 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(379.931641 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(441.455078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(496.435547 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(528.222656 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(583.203125 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(644.482422 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(707.958984 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- SLO target 200 ms -->
+    <g style="fill: #555555" transform="translate(264.671766 89.804083) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(194.275391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(226.0625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(265.271484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(326.550781 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(365.914062 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(429.390625 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(490.914062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(530.123047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(561.910156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(625.533203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(689.15625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(752.779297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(784.566406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(881.978516 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- outer limit 800 ms -->
+    <g style="fill: #555555" transform="translate(265.691766 68.212547) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-6f"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(61.181641 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(124.560547 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(163.769531 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(225.292969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(266.40625 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(298.193359 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(325.976562 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(353.759766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(451.171875 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(478.955078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(518.164062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(549.951172 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(613.574219 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(677.197266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(740.820312 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(772.607422 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(870.019531 0)"/>
+    </g>
+   </g>
+   <g id="line2d_134">
+    <path d="M 75.010124 340.10323 
+L 130.603664 339.972347 
+L 158.400434 339.842555 
+L 241.790745 320.69506 
+L 325.181055 283.69887 
+L 408.571365 251.509661 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.6; stroke-linecap: square"/>
+    <defs>
+     <path id="me40f52e9e4" d="M 0 -2.5 
+L -2.5 2.5 
+L 2.5 2.5 
+z
+" style="stroke: #ff7f0e; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p59eb4bfc70)">
+     <use xlink:href="#me40f52e9e4" x="75.010124" y="340.10323" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#me40f52e9e4" x="130.603664" y="339.972347" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#me40f52e9e4" x="158.400434" y="339.842555" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#me40f52e9e4" x="241.790745" y="320.69506" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#me40f52e9e4" x="325.181055" y="283.69887" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#me40f52e9e4" x="408.571365" y="251.509661" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_135">
+    <path d="M 408.571365 251.509661 
+L 629.043354 132.397511 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.2"/>
+    <defs>
+     <path id="m5c782187a0" d="M 0 -2.5 
+L -2.5 2.5 
+L 2.5 2.5 
+z
+" style="stroke: #ff7f0e; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p59eb4bfc70)">
+     <use xlink:href="#m5c782187a0" x="408.571365" y="251.509661" style="fill: #ffffff; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c782187a0" x="629.043354" y="132.397511" style="fill: #ffffff; stroke: #ff7f0e; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 616.0624 45.362987 
+Q 621.556171 44.955786 625.823468 44.639492 
+" style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 622.307109 43.195463 
+L 625.823468 44.639492 
+L 622.558429 46.586162 
+" style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_19">
+    <!-- V=1M (mainnet, out-of-spec) -->
+    <g style="fill: #b01010" transform="translate(460.625678 48.85795) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(215.820312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(302.099609 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(333.886719 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(372.900391 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(470.3125 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(531.591797 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(559.375 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(622.753906 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(686.132812 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(747.65625 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(786.865234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(818.652344 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(850.439453 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(911.621094 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(975 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1014.208984 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1052.167969 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(1113.349609 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1143.054688 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1179.138672 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1231.238281 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1294.714844 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1356.238281 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1411.21875 0)"/>
+    </g>
+    <!-- pipeline 4.17 s — over budget (red) -->
+    <g style="fill: #b01010" transform="translate(460.625678 58.376091) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-70"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(91.259766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(154.736328 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(216.259766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(244.042969 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(271.826172 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(335.205078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(396.728516 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(428.515625 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(492.138672 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(523.925781 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(587.548828 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(651.171875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(682.958984 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(735.058594 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(766.845703 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(866.845703 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(898.632812 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(959.814453 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1018.994141 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1080.517578 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1121.630859 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1153.417969 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1216.894531 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1280.273438 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1343.75 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1407.226562 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1468.75 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1507.958984 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1539.746094 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1578.759766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1617.623047 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1679.146484 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1742.623047 0)"/>
+    </g>
+   </g>
+   <g id="patch_9">
+    <path d="M 370.427434 115.03725 
+Q 388.585612 123.077477 405.619261 130.619774 
+" style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 403.198678 127.688771 
+L 405.619261 130.619774 
+L 401.822109 130.797639 
+" style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_20">
+    <!-- V=4096 (spec max) -->
+    <g style="fill: #0b6e0b" transform="translate(255.462672 100.941359) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(215.820312 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(279.443359 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(343.066406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(406.689453 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(438.476562 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(477.490234 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(529.589844 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(593.066406 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(654.589844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(709.570312 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(741.357422 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(838.769531 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(900.048828 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(959.228516 0)"/>
+    </g>
+    <!-- pipeline 15.1 ms — within budget (green) -->
+    <g style="fill: #0b6e0b" transform="translate(255.462672 110.4595) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-70"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(91.259766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(154.736328 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(216.259766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(244.042969 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(271.826172 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(335.205078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(396.728516 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(428.515625 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(492.138672 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(555.761719 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(587.548828 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(651.171875 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(682.958984 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(780.371094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(832.470703 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(864.257812 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(964.257812 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(996.044922 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1077.832031 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1105.615234 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1144.824219 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1208.203125 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1235.986328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1299.365234 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1331.152344 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1394.628906 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1458.007812 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1521.484375 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1584.960938 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1646.484375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1685.693359 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1717.480469 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1756.494141 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1819.970703 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1858.833984 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1920.357422 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1981.880859 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2045.259766 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- consensus-ffi-poc: state_transition scaling — leanSpec (V ≤ 4096) vs mainnet 1M -->
+    <g transform="translate(122.754805 15.938203) scale(0.115 -0.115)">
+     <defs>
+      <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2264" d="M 4684 3175 
+L 1684 2309 
+L 4684 1453 
+L 4684 897 
+L 678 2047 
+L 678 2578 
+L 4684 3725 
+L 4684 3175 
+z
+M 678 531 
+L 4684 531 
+L 4684 0 
+L 678 0 
+L 678 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-63"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(116.162109 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(179.541016 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(231.640625 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(293.164062 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(356.542969 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(408.642578 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(472.021484 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(524.121094 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(560.205078 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(595.410156 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(630.615234 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(658.398438 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(694.482422 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(757.958984 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(819.140625 0)"/>
+     <use xlink:href="#DejaVuSans-3a" transform="translate(874.121094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(907.8125 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(939.599609 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(991.699219 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1030.908203 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1092.1875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1131.396484 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(1192.919922 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1242.919922 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1282.128906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1323.242188 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1384.521484 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1447.900391 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1500 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1527.783203 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1566.992188 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1594.775391 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1655.957031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1719.335938 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1751.123047 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1803.222656 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1858.203125 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1919.482422 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1947.265625 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1975.048828 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2038.427734 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2101.904297 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(2133.691406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2233.691406 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2265.478516 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2293.261719 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2354.785156 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2416.064453 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(2479.443359 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2542.919922 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2606.396484 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(2667.919922 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2722.900391 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2754.6875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2793.701172 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2862.109375 0)"/>
+     <use xlink:href="#DejaVuSans-2264" transform="translate(2893.896484 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2977.685547 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(3009.472656 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3073.095703 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(3136.71875 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(3200.341797 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3263.964844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3302.978516 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(3334.765625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3393.945312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3446.044922 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3477.832031 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3575.244141 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3636.523438 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3664.306641 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3727.685547 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3791.064453 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3852.587891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3891.796875 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(3923.583984 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(3987.207031 0)"/>
+    </g>
+   </g>
+   <g id="line2d_136">
+    <path d="M 130.603664 260.225677 
+L 158.400434 259.465771 
+L 241.790745 244.75578 
+L 325.181055 217.263184 
+L 408.571365 185.247438 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #2ca02c; stroke-width: 1.6; stroke-linecap: square"/>
+    <defs>
+     <path id="m856989750c" d="M -2.5 2.5 
+L 2.5 2.5 
+L 2.5 -2.5 
+L -2.5 -2.5 
+z
+" style="stroke: #2ca02c; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p59eb4bfc70)">
+     <use xlink:href="#m856989750c" x="130.603664" y="260.225677" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m856989750c" x="158.400434" y="259.465771" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m856989750c" x="241.790745" y="244.75578" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m856989750c" x="325.181055" y="217.263184" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m856989750c" x="408.571365" y="185.247438" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_137">
+    <path d="M 408.571365 185.247438 
+L 629.043354 98.926091 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.2"/>
+    <defs>
+     <path id="m04ec848282" d="M -2.5 2.5 
+L 2.5 2.5 
+L 2.5 -2.5 
+L -2.5 -2.5 
+z
+" style="stroke: #2ca02c; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p59eb4bfc70)">
+     <use xlink:href="#m04ec848282" x="408.571365" y="185.247438" style="fill: #ffffff; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#m04ec848282" x="629.043354" y="98.926091" style="fill: #ffffff; stroke: #2ca02c; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_138">
+    <path d="M 130.603664 192.127228 
+L 158.400434 191.47276 
+L 241.790745 183.936008 
+L 325.181055 162.306757 
+L 408.571365 131.926931 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke: #1f77b4; stroke-width: 2.2; stroke-linecap: square"/>
+    <defs>
+     <path id="m8b05eda858" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p59eb4bfc70)">
+     <use xlink:href="#m8b05eda858" x="130.603664" y="192.127228" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m8b05eda858" x="158.400434" y="191.47276" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m8b05eda858" x="241.790745" y="183.936008" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m8b05eda858" x="325.181055" y="162.306757" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m8b05eda858" x="408.571365" y="131.926931" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_139">
+    <path d="M 408.571365 131.926931 
+L 629.043354 44.400833 
+" clip-path="url(#p59eb4bfc70)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #1f77b4; stroke-width: 1.6"/>
+    <defs>
+     <path id="m5779bb1ae4" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p59eb4bfc70)">
+     <use xlink:href="#m5779bb1ae4" x="408.571365" y="131.926931" style="fill: #ffffff; stroke: #1f77b4"/>
+     <use xlink:href="#m5779bb1ae4" x="629.043354" y="44.400833" style="fill: #ffffff; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_10">
+     <path d="M 72.221563 73.973203 
+L 314.607938 73.973203 
+Q 316.367938 73.973203 316.367938 72.213203 
+L 316.367938 34.098203 
+Q 316.367938 32.338203 314.607938 32.338203 
+L 72.221563 32.338203 
+Q 70.461563 32.338203 70.461563 34.098203 
+L 70.461563 72.213203 
+Q 70.461563 73.973203 72.221563 73.973203 
+z
+" style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_140">
+     <path d="M 73.981563 39.464828 
+L 82.781563 39.464828 
+L 91.581563 39.464828 
+" style="fill: none; stroke: #1f77b4; stroke-width: 2.2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m8b05eda858" x="82.781563" y="39.464828" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_22">
+     <!-- state_transition pipeline (A=8 valid attestations) -->
+     <g transform="translate(98.621563 42.544828) scale(0.088 -0.088)">
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(811.523438 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(875 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(902.783203 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(966.259766 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1027.783203 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1055.566406 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1083.349609 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1146.728516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1208.251953 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1240.039062 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1279.052734 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(1347.460938 0)"/>
+      <use xlink:href="#DejaVuSans-38" transform="translate(1431.25 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1494.873047 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(1526.660156 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1585.839844 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1647.119141 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1674.902344 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1702.685547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1766.162109 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1797.949219 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1859.228516 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1898.4375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1937.646484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1999.169922 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2051.269531 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2090.478516 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2151.757812 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(2190.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2218.75 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(2279.931641 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2343.310547 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2395.410156 0)"/>
+     </g>
+    </g>
+    <g id="line2d_141">
+     <path d="M 73.981563 52.626328 
+L 82.781563 52.626328 
+L 91.581563 52.626328 
+" style="fill: none; stroke: #2ca02c; stroke-width: 1.6; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m856989750c" x="82.781563" y="52.626328" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_23">
+     <!-- state construction (paired-delta twin) -->
+     <g transform="translate(98.621563 55.706328) scale(0.088 -0.088)">
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(253.320312 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(285.107422 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(340.087891 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(401.269531 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(464.648438 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(516.748047 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(555.957031 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(597.070312 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(660.449219 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(715.429688 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(754.638672 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(782.421875 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(843.603516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(906.982422 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(938.769531 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(977.783203 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1041.259766 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1102.539062 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1130.322266 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1169.185547 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1230.708984 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1294.185547 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1330.269531 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1393.746094 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1455.269531 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1483.052734 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1522.261719 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1583.541016 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1615.328125 0)"/>
+      <use xlink:href="#DejaVuSans-77" transform="translate(1654.537109 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1736.324219 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1764.107422 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1827.486328 0)"/>
+     </g>
+    </g>
+    <g id="line2d_142">
+     <path d="M 73.981563 65.543078 
+L 82.781563 65.543078 
+L 91.581563 65.543078 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 1.6; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#me40f52e9e4" x="82.781563" y="65.543078" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- ByteArray marshal (one-way) -->
+     <g transform="translate(98.621563 68.623078) scale(0.088 -0.088)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(68.603516 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(127.783203 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(166.992188 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(228.515625 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(296.923828 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(336.287109 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(377.400391 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(438.679688 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(497.859375 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(529.646484 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(627.058594 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(688.337891 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(729.451172 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(781.550781 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(844.929688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(906.208984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(933.992188 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(965.779297 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1004.792969 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1065.974609 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1129.353516 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1190.876953 0)"/>
+      <use xlink:href="#DejaVuSans-77" transform="translate(1226.960938 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1308.748047 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(1370.027344 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1429.207031 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p59eb4bfc70">
+   <rect x="66.061563" y="27.938203" width="581.83" height="329.08"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -35,41 +35,62 @@ tags:
 ## 重要な前提と限界
 
 1. **暗号コストは除外** (A3): `hash_tree_root_*` は ZERO スタブ (`Funs/Types.lean:138-156`)。本物の SSZ ハッシュ計算は加算されない。
-2. **Bench fixture は最小ワークロード** (M5 scope):
-   - `state_transition`: V (= n) validators の State + 0 attestations の Block。`processAttestationsFast` の inner V loop は 0 回 (justifications_roots が空 → cells 空)。N の支配項は `buildBenchValidators` の `List.replicate` + `collapseJustifications` の `R*V = 1*V` flat array allocation。
-   - `compute_lmd_ghost_head`: 線形チェーン B blocks + A attestations が最終 block にすべて投票。`alloc.vec.Vec` が `List`-backed のため、内部の block index は `List.indexOf` ベースで O(B)。
-   - 実運用相当のワークロード (multiple targets, valid checkpoints with real justification windows) は richer fixture を要し本タスクでは対象外。
+2. **Bench fixture は spec 標準ワークロード**:
+   - `state_transition`: V validators の State + **A = `MAX_ATTESTATIONS_DATA` = 8 個の有効 AggregatedAttestation** を載せた Block。`processAttestationsFast` の `O(A·V)` ホットループが実際に走る (§1)。8 票はすべて `voteIsValid` を通り、かつ 2/3 finalize 閾値未満を維持 (fast path 継続)。**旧版は A=0 の空ブロックで構築コストのみを測っていた**ため、本再測で STF 本体に置き換えた。
+   - `compute_lmd_ghost_head`: 線形チェーン B blocks + A attestations が最終 block にすべて投票。`alloc.vec.Vec` が `List`-backed のため、内部の block index は `List.indexOf` ベースで O(B)。**V 軸を持たない** (B blocks / A attestations でスケール、B ≤ `HISTORICAL_ROOTS_LIMIT = 2^18`) ため V 上限の修正対象外で、本再測では §2 の旧値を据え置く。
 3. **paired-delta** はビルド構築コストを差し引く (`@[noinline] consumeState/consumeBlock` で Lean の DCE を抑止して buildonly twin が実際にビルド工程を踏むことを保証)。
 
-## 1. `state_transition` (handwritten Array fast path)
+## 0. spec 定数 (計測軸の根拠)
 
-軸: N (validators), A=64 fixed (block has 0 attestations as noted above).
+計測軸は leanSpec (本プロジェクトが formalize する 3SF-mini) の定数で固定する。値は commit-pin で引用 (drift 防止)。
 
-| N | trials | iters/trial | run median | buildonly | **pipeline (Δ)** | IQR (run) | sentinel |
+leanSpec `main@cb862c0` (2026-06-24), `src/lean_spec/spec/forks/lstar/`:
+
+| 定数 | 値 | 役割 | 出典 |
+|---|---:|---|---|
+| `VALIDATOR_REGISTRY_LIMIT` | `2^12 = 4096` | validator 数 V の上限 (SSZ List LIMIT として強制) | `config.py` |
+| `MAX_ATTESTATIONS_DATA` | `8` | 1 ブロックの distinct AttestationData 上限 (= §1 の A) | `config.py` / `state_transition.py` で強制 |
+| `AggregatedAttestations` LIMIT | `= VALIDATOR_REGISTRY_LIMIT = 4096` | block.attestations リスト長の上限 | `containers/attestation.py` |
+| `ATTESTATION_COMMITTEE_COUNT` | `1` | 1 スロット 1 委員会 | `config.py` |
+| `HISTORICAL_ROOTS_LIMIT` | `2^18 = 262144` | historical block roots / fork-choice B の上限 | `config.py`、Lean `Funs/Types.lean:162` |
+
+`consensus-ffi-poc` の `types.VALIDATOR_REGISTRY_LIMIT` (`Funs/Types.lean:412`) も `4096`、`HISTORICAL_ROOTS_LIMIT` も `262144` で一致。
+
+**mainnet 対照** (ethereum/consensus-specs `master@42b9671`, 2026-06-25): mainnet の `VALIDATOR_REGISTRY_LIMIT = 2^40 ≈ 1.1e12` (実質無制限)、実 V は churn + 経済で動的に決まり現在 **~100 万**。よってベンチの **V=1M は mainnet 実数だが leanSpec モデルでは 4096 の約 244× で非物理**。各ベンチで V=1M は `--include-1m` の「mainnet 範囲外参考値」として明示分離する。
+
+## 1. `state_transition` (handwritten Array fast path, spec-realistic A=8)
+
+軸: **V (validators) ∈ {4, 8, 64, 512, 4096}** = leanSpec の許容範囲 (V ≤ `VALIDATOR_REGISTRY_LIMIT = 2^12 = 4096`、§0 spec 定数表)。ブロックは **A = `MAX_ATTESTATIONS_DATA` = 8 個の有効 AggregatedAttestation** を載せ、`processAttestationsFast` の `O(A·V)` ホットループを**実際に走らせる**。旧版は空ブロック (A=0) で `collapseJustifications` の構築コストのみを測っており STF 本体を踏んでいなかった (前提 §2)。
+
+fixture は `is_valid_vote` / `slot_is_justifiable_after` / `current_proposer` (`Funs/StateTransition.lean`) から逆算した genesis: finalized slot 0、source = (slot 0, `historical[0]`)、target slots {1,2,3,4,5,6,9,12} (すべて justifiable: 1–5 ≤ 5 / 6,12 pronic / 9 平方数)、各 attestation は ⌈V/2⌉ ビットを投票し 2/3 閾値未満を維持 → fast path 継続 (2/3 到達なら Aeneas slow path に bail し別物を測ってしまう)。**Rust harness は計測前に `csf_bench_state_transition_att_cells(64) == 9` を assert** — pipeline 後の `justifications_roots` 長 = zero sentinel + 8 distinct target roots = 9。8 票が確かに有効処理された証拠で、票が skip/bail されると ≠9 で abort し「速いが無意味」な数値を記録させない。
+
+| V | trials | iters/trial | run median | buildonly | **pipeline (Δ)** | IQR (run) | sentinel |
 |---:|---:|---:|---:|---:|---:|---:|:---:|
-| 100 | 5 | 2,714 | 42.2 µs | 884 ns | **41.3 µs** | 4.2 µs | 0 |
-| 1,000 | 5 | 1,974 | 91.6 µs | 15.1 µs | **76.5 µs** | 11.3 µs | 0 |
-| 10,000 | 5 | 179 | 421.1 µs | 140.4 µs | **280.7 µs** | 77.9 µs | 0 |
-| 100,000 | 5 | 34 | 3.32 ms | 1.52 ms | **1.80 ms** | 664.6 µs | 0 |
-| 1,000,000 | 1 | 1 | 35.20 ms | 13.18 ms | **22.02 ms** | n/a | 0 |
+| 4 (devnet baseline) | 5 | 199 | 320.9 µs | 4.0 µs | **316.9 µs** | 15.5 µs | 0 |
+| 8 | 5 | 324 | 334.7 µs | 4.2 µs | **330.5 µs** | 9.9 µs | 0 |
+| 64 | 5 | 198 | 547.0 µs | 10.8 µs | **536.2 µs** | 24.9 µs | 0 |
+| 512 | 5 | 44 | 2.21 ms | 63.1 µs | **2.15 ms** | 46.9 µs | 0 |
+| 4096 (spec max) | 5 | 6 | 15.61 ms | 492.9 µs | **15.12 ms** | 262.6 µs | 0 |
+| 1,000,000 ⚠ mainnet, out-of-spec | 1 | 1 | 4.30 s | 125.8 ms | **4.17 s** | n/a | 0 |
 
-`ru_maxrss` delta:
-- N=100→100K (1 process): **6 MB**
-- N=1M 単独 process: **68 MB** (List.replicate で 1M Validator records の連結リスト)
+`ru_maxrss`:
+- V=4→4096 (1 process): **+数 MB**
+- V=1M 単独 (`--include-1m`, out-of-spec): **+584 MB**。8 本の 1M-bit aggregation 配列 + `R·V = 9·1M` flat 配列が支配。旧空ブロック版 (68 MB) の ~8.6×。さらに List 再帰が 8 MB スタックを溢れさせるため harness は計測を 2 GiB スタックのワーカースレッド上で実行する。
 
 ### 判定 (vs `docs/timing-budget.md` §4 SLO target = <200ms, §3 outer = <800ms)
 
-| N | pipeline | target | outer | 判定 |
+| V | pipeline | target | outer | 判定 |
 |---:|---:|:---:|:---:|:---:|
-| 100 | 41.3 µs | ✓ | ✓ | 🟢 green |
-| 1,000 | 76.5 µs | ✓ | ✓ | 🟢 green |
-| 10,000 | 280.7 µs | ✓ | ✓ | 🟢 green |
-| 100,000 | 1.80 ms | ✓ | ✓ | 🟢 green |
-| 1,000,000 | 22.02 ms | ✓ | ✓ | 🟢 green |
+| 4 | 316.9 µs | ✓ | ✓ | 🟢 green |
+| 8 | 330.5 µs | ✓ | ✓ | 🟢 green |
+| 64 | 536.2 µs | ✓ | ✓ | 🟢 green |
+| 512 | 2.15 ms | ✓ | ✓ | 🟢 green |
+| 4096 (spec max) | 15.12 ms | ✓ | ✓ | 🟢 green |
+| 1,000,000 (out-of-spec) | 4.17 s | ✗ | ✗ | 🔴 red |
 
-→ **N=1M まで全て green** (パイプライン 22ms < target 200ms)。M5 計画が外挿していた値 (N=10K で ~100ms、N=100K で ~1s、N=1M で ~10s) より**2 桁速い**。本 fixture が attestation 処理を踏まないため、計算の支配項が `processAttestationsFast` の inner V loop ではなく `collapseJustifications` の `R*V` flat allocation (R=1, V=N) になっている点に留意 (上記限界 §2)。
+→ **spec 範囲 (V ≤ 4096) は全て green**。最悪の V=4096 でも 15 ms ≪ target 200 ms で、1 スロット ~4 s の世界では attestation 付き STF は余裕。scaling は V=512→4096 (8×) で 2.15→15.1 ms (~7×) ≈ linear (`O(8·V)` のホットループが見えている)、小 V (4/8/64) は ~300–540 µs の固定費 (8 票分の `voteIsValid`: H256 32-byte 比較 ×複数、`isqrt` ループ) が支配。
 
-外挿元の PR #3 fast-path 単独ベンチは attestation あり前提だったので、本数値は handwritten fast path の**構成的下限**(全 V を流す処理時間の floor) を示すと解釈すべき。実運用相当の attestation-rich workload で再測しても N=1M で <200ms を維持する保証はない。
+**mainnet 規模の参考値 V=1M は 4.17 s で red** — これは「計測すべき値」ではなく対照点。leanSpec モデルでは `validator_count > 4096` の state は SSZ 検証で不正であり**到達不能**。加えて List-backed fixture が 2 GiB スタック + 584 MB RSS を要し、約 244× の線形外挿 (15 ms × 244 ≈ 3.7 s) と概ね一致する。**spec が V を 4096 に抑える設計がこの List-backed モデルを tractable に保っている**ことの裏返し。
 
 ## 2. `compute_lmd_ghost_head` (Aeneas direct, no fast path)
 
@@ -107,11 +128,11 @@ A axis scaling check (B=100 fixed):
 
 ## 3. 主な観察
 
-1. **`stateTransitionFast` は M5 計画外挿より 2 桁速い**: N=1M で 22 ms (計画 ~10s)。理由は §限界 (2-i) — fixture が attestation 処理を踏まないため、計算支配項が `collapseJustifications` の R*V allocation のみ。**実運用相当 (R≥1 + valid attestations) で再測すれば桁が上がる可能性あり** (future work)。
-2. **`compute_lmd_ghost_head` は B=100 ですら SLO target 超過**: 313ms (A=32) / 1220ms (A=128) vs target 100ms。`Ffi.lean#L61` の "quadratic in blocks" が Lean の List-backed Vec で表面化しており、A 軸は実測 4× linear に従う。mainnet 級 B=32K は外挿で**時間単位**になり、専用 fast path (`compute_lmd_ghost_head_fast`、別 issue 候補) なしには実運用不可。
-3. **build cost (paired-delta の片側) は state_transition で支配的**: N=100K で 1.52 ms / 3.32 ms (run の 46%)、N=1M で 13.18 ms / 35.20 ms (37%)。`List.replicate n + Vec ⟨xs, ...⟩` の strict allocation。paired-delta による減算で正味 pipeline コストを抽出している。
-4. **メモリスケーリング**: state_transition `ru_maxrss` delta は N=100K で 6 MB、N=1M で 68 MB (約 11×、ほぼ N に linear)。`alloc.vec.Vec α := { l : List α // ... }` の List node × N + Validator struct × N が支配。
-5. **2 エントリポイントの実運用域は対極**: `state_transition` (handwritten fast path) は N=1M で余裕の green、`compute_lmd_ghost_head` (Aeneas 直) は B=100 で既に red 隣接の yellow。後者の fast path 実装が実運用への最大ボトルネック。
+1. **spec 範囲の `stateTransitionFast` (A=8) は余裕の green**: V=4096 (spec 上限) で **15 ms** ≪ target 200 ms。8 票の `O(8·V)` ホットループを実際に走らせた値で、旧空ブロック版 (構築コストのみ) の置き換え。V=512→4096 で ~linear (`O(8·V)` が支配)、小 V は 8 票分の `voteIsValid` 固定費 (~300 µs)。
+2. **`compute_lmd_ghost_head` は B=100 ですら SLO target 超過**: 313ms (A=32) / 1220ms (A=128) vs target 100ms。`Ffi.lean` の "quadratic in blocks" が Lean の List-backed Vec で表面化しており、A 軸は実測 4× linear に従う。**V 軸を持たず B (≤ `HISTORICAL_ROOTS_LIMIT = 2^18`) でスケール**するため今回の V 上限再測の対象外。専用 fast path (`compute_lmd_ghost_head_fast`、別 issue 候補) なしには実運用不可。
+3. **build cost (paired-delta の片側) は spec 範囲では小さい**: V=4096 で 493 µs / 15.6 ms (run の ~3%)。A=8 の STF 本体が支配的になり、`List.replicate V + Vec ⟨xs, ...⟩` の構築コストの比率は旧空ブロック版より低下。paired-delta による減算で正味 pipeline コストを抽出。
+4. **メモリ**: spec 範囲 (V ≤ 4096) は `ru_maxrss` delta 数 MB。out-of-spec の V=1M は **+584 MB** (8 本の 1M-bit aggregation + R·V=9M flat) で旧空ブロック 1M (68 MB) の ~8.6×、かつ List 再帰が 8 MB スタックを溢れさせ 2 GiB スタックスレッドを要する。**spec の V≤4096 がこの List-backed モデルを tractable に保つ**。
+5. **2 エントリポイントの実運用域は対極**: `state_transition` (handwritten fast path, A=8) は spec 上限 V=4096 で余裕の green、`compute_lmd_ghost_head` (Aeneas 直) は B=100 で既に red 隣接の yellow。後者の fast path 実装が実運用への最大ボトルネック。
 
 ## 4. 再現手順 (3 ステップ)
 
@@ -124,14 +145,15 @@ cd consensus-ffi-poc && lake build ConsensusLean4:static
 cd rust-ffi && cargo build --release
 
 # 3. ベンチ実行 (per-cell isolation 推奨: cargo run はせず target/release を直接呼ぶ)
-target/release/bench-state-transition                      # N=100,1K,10K,100K (~3 s)
-target/release/bench-state-transition --include-1m         # + N=1M (1 trial、別 process 推奨で N=1M 単独 ~0.1 s + ~70 MB rss)
-target/release/bench-fork-choice                           # B=100 × A=32,128 (~20 s)
+target/release/bench-state-transition                      # V=4,8,64,512,4096, A=8 valid (~4 s)
+target/release/bench-state-transition --include-1m         # + V=1M (out-of-spec ref、1 trial ~4 s + ~584 MB rss、2 GiB stack)
+target/release/bench-ffi-marshal                           # V=1..4096 marshal (~数 s)
+target/release/bench-ffi-marshal --include-1m              # + V=1M (out-of-spec, ~57 MB payload)
+target/release/bench-fork-choice                           # B=100 × A=32,128 (~20 s、V 軸なし)
 target/release/bench-fork-choice --include-1k              # + B=1K × A=32,128 (cell ~6+ 分、計 30 分超)
-target/release/bench-fork-choice --include-10k             # + B=10K × A=32,128 (cell 時間単位、推奨せず)
 
 # Per-cell ru_maxrss isolation (推奨):
-target/release/bench-state-transition --single-n=100000
+target/release/bench-state-transition --single-n=4096
 target/release/bench-state-transition --single-n=1000000
 target/release/bench-fork-choice --single-cell=100,32
 target/release/bench-fork-choice --single-cell=100,128
@@ -177,44 +199,43 @@ target/release/bench-ffi-overhead
 
 - `csf_make_bytearray` (C shim, `rust-ffi/csf_marshal_shim.c`): `lean_alloc_sarray` + `memcpy`。`lean_alloc_sarray`/`lean_sarray_cptr` は lean.h で `static inline` のため Rust から直接リンクできず、lean.h に対してコンパイルした C shim 経由で呼ぶ (build.rs が `cc` でビルド)。
 - Lean export 2 種 (`ConsensusLean4/Ffi.lean` M6): `csf_bench_marshal_touch` = 全バイトを XOR-fold (decode スキャンの下限)、`csf_bench_marshal_noop` = 引数を消費するだけ (alloc + memcpy + dec_ref)。差 = Lean 側スキャン。
-- サイズ軸は §1 の N に対応: Validator = pubkey(52)+index(8) = 60 B とし、ペイロード S = N·60。**正準 SSZ ではなく代表サイズのフラットバッファ。** 計測手法は §1/§4b と同様 (target 200ms/trial, 11 試行中央値, `black_box`)。
+- サイズ軸は §1 の V に対応 (Validator = pubkey 52 + index 8 = 60 B、ペイロード S = V·60) で **leanSpec の V ≤ 4096 に揃える** (§0)。**正準 SSZ ではなく代表サイズのフラットバッファ。** `--include-1m` で V=1M (57 MB) を mainnet 範囲外参考として追加。計測手法は §1/§4b と同様 (target 200ms/trial, 11 試行中央値, `black_box`)。
 
-### 計測結果
+### 計測結果 (spec V = 1 … 4096 + 1M 参考)
 
-| N | payload S | marshal (noop) | full (marshal+scan) | scan Δ | marshal GB/s | marshal ns/byte |
+| V | payload S | marshal (noop) | full (marshal+scan) | scan Δ | marshal GB/s | marshal ns/byte |
 |---:|---:|---:|---:|---:|---:|---:|
-| 1 | 60 B | 25.3 ns | 32.3 ns | 7.0 ns | 2.4 | 0.422 |
-| 100 | 5.9 KB | 114 ns | 235 ns | 121 ns | 52.4 | 0.019 |
-| 1,000 | 58.6 KB | 1.32 µs | 2.84 µs | 1.52 µs | 45.5 | 0.022 |
-| 10,000 | 585.9 KB | 20.5 µs | 32.1 µs | 11.6 µs | 29.3 | 0.034 |
-| 100,000 | 5.7 MB | 223 µs | 351 µs | 128 µs | 26.9 | 0.037 |
-| 1,000,000 | 57.2 MB | **14.39 ms** | 16.64 ms | 2.25 ms | 4.2 | 0.240 |
+| 1 | 60 B | 23.7 ns | 31.3 ns | 7.6 ns | 2.5 | 0.394 |
+| 4 | 240 B | 23.9 ns | 29.0 ns | 5.2 ns | 10.1 | 0.099 |
+| 8 | 480 B | 24.1 ns | 34.2 ns | 10.1 ns | 19.9 | 0.050 |
+| 64 | 3.8 KB | 82.4 ns | 148.1 ns | 65.7 ns | 46.6 | 0.021 |
+| 512 | 30.0 KB | 886.2 ns | 1.44 µs | 551.8 ns | 34.7 | 0.029 |
+| 4096 (spec max) | 240.0 KB | **7.00 µs** | 11.45 µs | 4.45 µs | 35.1 | 0.028 |
+| 1,000,000 ⚠ out-of-spec | 57.2 MB | 14.67 ms | 16.82 ms | 2.16 ms | 4.1 | 0.244 |
 
-### 判定 (vs §1 の STF 計算コスト)
+### 判定 (vs §1 の STF 計算コスト, A=8)
 
-| N | marshal (片道) | §1 STF pipeline | marshal / STF |
+| V | marshal (片道) | §1 STF pipeline | marshal / STF |
 |---:|---:|---:|---:|
-| 100 | 114 ns | 41.3 µs | 0.3% |
-| 100,000 | 223 µs | 1.80 ms | 12% |
-| 1,000,000 | **14.39 ms** | 22.02 ms | **65%** |
+| 4 | 23.9 ns | 316.9 µs | 0.008% |
+| 4096 (spec max) | **7.00 µs** | 15.12 ms | **0.05%** |
+| 1,000,000 (out-of-spec) | 14.67 ms | 4.17 s | 0.35% |
 
-→ **§4b の予測どおり、オーバーヘッドはサイズに比例して変化する。**
+→ **spec 範囲ではマーシャルは完全に誤差** (V=4096 で STF の 0.05%)。STF を空ブロックではなく A=8 の実負荷にしたことで STF 側が重くなり、marshal の相対比は §旧版よりさらに小さい。
 
-1. **小サイズ (devnet 相当, validator 数百 = KB 級)**: 100〜1,300 ns。§4b のプリミティブ越境と同様、**実質ノイズ**。SSZ 化しても体感不変。
-2. **大サイズ (mainnet 相当, validator 1M = ~57 MB)**: 片道 **14.4 ms** で、STF 計算本体 (22 ms) の **約 65%**。往復 (入力デコード + 結果エンコード) なら ~29 ms で STF を上回る。**この規模ではマーシャルが支配項の一つになる**。
-3. **スループットの劣化**: 小サイズで ~52 GB/s (L2/L3 内に収まる) → 57 MB で 4.2 GB/s。これは純粋な memcpy 帯域ではなく、**呼び出しごとに 57 MB を新規 alloc → first-touch ページフォルト → memcpy → dec_ref/free** するためで、per-call マーシャルの現実的なコスト構造を反映している。
-4. **Lean 側スキャン (scan Δ) は安価**: ~0.03–0.04 ns/byte (~25–30 GB/s)。decode の「全バイト走査」部分は memcpy と同オーダーで、マーシャルの支配項は alloc+copy 側。
+1. **spec 範囲 (V ≤ 4096, ≤ 240 KB)**: 24 ns 〜 7 µs。§4b のプリミティブ越境同様、STF に対して**実質ノイズ**。SSZ 化しても体感不変。
+2. **1M 参考 (out-of-spec, ~57 MB)**: 片道 **14.7 ms**。これは到達不能な mainnet 規模の size-scaling 特性で、`validator_count > 4096` の state は SSZ 検証で不正 (§1)。境界の帯域特性の参考としてのみ残す。
+3. **スループットの劣化**: 小サイズで ~35–47 GB/s (L2/L3 内に収まる) → 57 MB で 4.1 GB/s。これは純粋な memcpy 帯域ではなく、**呼び出しごとに新規 alloc → first-touch ページフォルト → memcpy → dec_ref/free** するためで、per-call マーシャルの現実的なコスト構造を反映している。
+4. **Lean 側スキャン (scan Δ) は安価**: ~0.03 ns/byte (~30 GB/s)。decode の「全バイト走査」部分は memcpy と同オーダーで、マーシャルの支配項は alloc+copy 側。
 
 ### §4b との関係 (FFI コストの全体像)
 
 | 入力形態 | 越境あたりのコスト | スケール |
 |---|---|---|
 | プリミティブ `UInt64` (§4b) | ~1.9 ns | サイズ非依存 (定数) |
-| `ByteArray` マーシャル (本節) | 25 ns 〜 14 ms | **O(payload size)** |
+| `ByteArray` マーシャル (本節, spec 範囲) | 24 ns 〜 7 µs | **O(payload size)** |
 
-「FFI は速い」は **プリミティブ境界に限った話**。データを渡すとコストは渡すバイト数に線形になる。
-
-> **spec スケールでの補正 (§4d 参照)**: 上表の N=10K 以上 (≥586 KB) は `VALIDATOR_REGISTRY_LIMIT = 4096` を超える非物理サイズ。このモデルの payload 上限は V=4096 ⇒ **≤ 240 KB** で、そこでの marshal は **≤ 6.8 µs** = 誤差。「14 ms@57 MB」は到達不能な規模の一般特性であり、実運用 marshal は無視できる。本節の大サイズ行は境界の size-scaling 特性の参考値として残す。
+「FFI は速い」は **プリミティブ境界に限った話**。データを渡すとコストは渡すバイト数に線形になるが、spec 上限 (V=4096 ⇒ payload ≤ 240 KB) では **≤ 7 µs** で STF の 0.05% に過ぎない。表末尾の「14 ms@57 MB」は `VALIDATOR_REGISTRY_LIMIT = 4096` を超える到達不能な mainnet 規模の size-scaling 特性であり、実運用 marshal は無視できる。
 
 ### 限界
 
@@ -235,7 +256,7 @@ target/release/bench-ffi-marshal
 §4b/§4c は「①marshal」だけを測り、「②decode → ③純粋関数」が未接続だった。本節でその全経路を繋いだ ——`ByteArray` を**型付き `State`/`Block` にデコードし、純粋 `stateTransitionFast` に渡す**。`bench-ffi-ssz` (`rust-ffi/src/bin/bench-ffi-ssz.rs`) + `ConsensusLean4/Ffi.lean` M7。
 
 - **コーデック**: フラットな length-prefixed バイナリ (正準 SSZ ではない) を Lean decode (`decodeState`/`decodeBlock`) と Rust serializer (`serialize_fixture`) で round-trip。`State`/`Block` の全フィールドを網羅。**`hash_tree_root`/SHA は不使用** (decode は純粋なバイト配置)。
-- **fixture は §1 と byte-for-byte 一致**: `buildBenchState(n)`/`buildBenchBlock(n)` と同一内容を直列化。よって decode 後の入力は §1 のスカラー生成版と等価で、STF コストを直接比較できる。
+- **fixture は空ブロック (A=0) 版**: `buildBenchState(n)`/`buildBenchBlock(n)` (attestations 空) と byte-for-byte 一致。**§1 の A=8 有効投票ワークロードとは別物**で、ここでの STF は構築コスト寄りの A=0 経路 (marshal/decode コストの相対比較が目的のため意図的に軽い fixture を使う)。A=8 経路の SSZ e2e は将来課題。
 - **正当性ゲート**: `csf_bench_state_transition_ssz_run` が全 N で sentinel **0 (Ok)** を返すことを assert。誤ったコーデックなら sentinel が変わるかクラッシュするため、これがパイプライン全体の正当性検証になっている。
 - **分解**: marshal = `_marshal_noop`、decode = `_ssz_decode` − marshal、STF = `_ssz_run` − `_ssz_decode`。
 

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -92,6 +92,12 @@ fixture は `is_valid_vote` / `slot_is_justifiable_after` / `current_proposer` (
 
 **mainnet 規模の参考値 V=1M は 4.17 s で red** — これは「計測すべき値」ではなく対照点。leanSpec モデルでは `validator_count > 4096` の state は SSZ 検証で不正であり**到達不能**。加えて List-backed fixture が 2 GiB スタック + 584 MB RSS を要し、約 244× の線形外挿 (15 ms × 244 ≈ 3.7 s) と概ね一致する。**spec が V を 4096 に抑える設計がこの List-backed モデルを tractable に保っている**ことの裏返し。
 
+### スケーリング図 (§1 STF + §1 construction + §4c marshal)
+
+![state_transition scaling: leanSpec V ≤ 4096 vs mainnet 1M](./assets/bench-scaling.svg)
+
+log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spec (V > 4096)。spec 上限 V=4096 でも STF pipeline は 15 ms で SLO target 200 ms の下、marshal は更に 3 桁下。V=1M は両 budget を突破 (4.17 s) し、leanSpec モデルでは到達不能。データは本節 §1 / §4c の実測値 (2026-06-25, AMD Ryzen 9 PRO 8945HS)。
+
 ## 2. `compute_lmd_ghost_head` (Aeneas direct, no fast path)
 
 軸: (B blocks, A attestations) ∈ `{100} × {32, 128}` × 5 試行 (default)。

--- a/docs/timing-budget.md
+++ b/docs/timing-budget.md
@@ -1,6 +1,6 @@
 ---
 title: 実運用 timing 予算リファレンス
-last_updated: 2026-05-05
+last_updated: 2026-06-25
 tags:
   - timing
   - budget
@@ -25,6 +25,8 @@ M5 ベンチ ([`docs/ffi-implementation-plan.md`](./ffi-implementation-plan.md) 
 
 将来 spec が更新されても、本 doc の数値は当該 SHA 時点で固定される。本 doc の `last_updated` を更新する際は SHA も併せて更新する。
 
+> **spec 進化メモ (2026-06-25)**: 本 §1 は `941abe7` 時点の凍結スナップショット。その後 leanSpec は (a) 設定ファイルを `src/lean_spec/subspecs/chain/config.py` → `src/lean_spec/spec/forks/lstar/config.py` に再編、(b) `MAX_ATTESTATIONS_DATA` を **16 → 8** に変更した (`cb862c0`, 2026-06-24)。**ベンチが使う現行の spec 定数は `docs/rust-ffi-benchmarks.md` §0 に `cb862c0` ピンで集約**してある。本 §1 は凍結ポリシーに従い `941abe7` の値を保持しつつ、変更点のみ下表に注記する。
+
 ## 1. leanSpec spec 定数 (本プロジェクトが formalize する仕様)
 
 出典: [`leanSpec@941abe7:src/lean_spec/subspecs/chain/config.py`](https://github.com/leanEthereum/leanSpec/blob/941abe7ba6d7ea81b5e0beb2eb6b7d4b8fcd08b8/src/lean_spec/subspecs/chain/config.py)
@@ -37,7 +39,7 @@ M5 ベンチ ([`docs/ffi-implementation-plan.md`](./ffi-implementation-plan.md) 
 | `MILLISECONDS_PER_INTERVAL` | 800 | [L39](https://github.com/leanEthereum/leanSpec/blob/941abe7ba6d7ea81b5e0beb2eb6b7d4b8fcd08b8/src/lean_spec/subspecs/chain/config.py#L39) |
 | `GOSSIP_DISPARITY_INTERVALS` | 1 (~800ms) | [L23](https://github.com/leanEthereum/leanSpec/blob/941abe7ba6d7ea81b5e0beb2eb6b7d4b8fcd08b8/src/lean_spec/subspecs/chain/config.py#L23) |
 | `JUSTIFICATION_LOOKBACK_SLOTS` | 3 | [L42](https://github.com/leanEthereum/leanSpec/blob/941abe7ba6d7ea81b5e0beb2eb6b7d4b8fcd08b8/src/lean_spec/subspecs/chain/config.py#L42) |
-| `MAX_ATTESTATIONS_DATA` | 16 / block | [L56](https://github.com/leanEthereum/leanSpec/blob/941abe7ba6d7ea81b5e0beb2eb6b7d4b8fcd08b8/src/lean_spec/subspecs/chain/config.py#L56) |
+| `MAX_ATTESTATIONS_DATA` | 16 / block (941abe7) → **8 (現行 cb862c0)** | [L56@941abe7](https://github.com/leanEthereum/leanSpec/blob/941abe7ba6d7ea81b5e0beb2eb6b7d4b8fcd08b8/src/lean_spec/subspecs/chain/config.py#L56) / [現行](https://github.com/leanEthereum/leanSpec/blob/cb862c01e56ef9b95d69f77cc97746a0fa06010c/src/lean_spec/spec/forks/lstar/config.py#L58) |
 
 ## 2. Slot 内 schedule
 

--- a/rust-ffi/src/bin/bench-ffi-marshal.rs
+++ b/rust-ffi/src/bin/bench-ffi-marshal.rs
@@ -11,12 +11,15 @@
 //   * `csf_bench_marshal_noop`  — consumes the arg only (alloc + memcpy + dec_ref)
 // per-call(touch) − per-call(noop) = the Lean-side byte scan.
 //
-// Size axis is keyed to the §1 validator count N: a Validator here is
-// pubkey(52) + index(8) = 60 bytes, so payload S = N * 60. This is a flat
-// representative buffer, NOT canonical SSZ — no codec, no hash_tree_root/SHA.
-// Methodology mirrors the other harnesses: calibrate iters to ~200ms/trial,
-// median of 11 trials, black_box to defeat DCE.
+// Size axis is keyed to the §1 validator count V (Validator = pubkey 52 +
+// index 8 = 60 bytes, so payload S = V * 60) and bounded by leanSpec's
+// VALIDATOR_REGISTRY_LIMIT = 4096. This is a flat representative buffer, NOT
+// canonical SSZ — no codec, no hash_tree_root/SHA. Pass `--include-1m` to add
+// V=1M as a mainnet out-of-spec reference (real beacon chain ~1M validators,
+// unreachable in this model). Methodology mirrors the other harnesses:
+// calibrate iters to ~200ms/trial, median of 11 trials, black_box to defeat DCE.
 
+use std::env;
 use std::ffi::c_void;
 use std::hint::black_box;
 use std::ptr;
@@ -49,7 +52,8 @@ unsafe fn boot_lean() {
 }
 
 const VALIDATOR_BYTES: usize = 60; // pubkey(52) + index(8)
-const N_AXIS: &[u64] = &[1, 100, 1_000, 10_000, 100_000, 1_000_000];
+const N_AXIS: &[u64] = &[1, 4, 8, 64, 512, 4096]; // leanSpec V range (≤ VALIDATOR_REGISTRY_LIMIT)
+const REFERENCE_N: u64 = 1_000_000; // mainnet out-of-spec reference (opt-in via --include-1m)
 const TARGET_TRIAL: Duration = Duration::from_millis(200);
 const TRIALS: usize = 11;
 
@@ -115,20 +119,31 @@ fn gbps(bytes: usize, ns: f64) -> f64 {
 }
 
 fn main() {
+    let include_1m = env::args().any(|s| s == "--include-1m");
+
     unsafe { boot_lean(); }
 
     // Sanity: a 3-byte ByteArray {1,2,3} XOR-folds to 0.
     let probe = unsafe { csf_bench_marshal_touch(csf_make_bytearray([1u8, 2, 3].as_ptr(), 3)) };
     assert_eq!(probe, 0, "XOR-fold of {{1,2,3}} should be 0, got {probe}");
 
+    let axis: Vec<u64> = N_AXIS
+        .iter()
+        .copied()
+        .chain(if include_1m { Some(REFERENCE_N) } else { None })
+        .collect();
+
     println!("# FFI marshalling cost (Rust→Lean ByteArray, no SSZ codec / no SHA)");
     println!();
-    println!("Validator = {VALIDATOR_BYTES} B (pubkey 52 + index 8); payload S = N · {VALIDATOR_BYTES}.");
+    println!(
+        "Validator = {VALIDATOR_BYTES} B (pubkey 52 + index 8); payload S = V · {VALIDATOR_BYTES}. \
+         V ≤ leanSpec VALIDATOR_REGISTRY_LIMIT=4096."
+    );
     println!();
-    println!("| N | payload S | marshal (noop) | full (marshal+scan) | scan Δ | marshal GB/s | marshal ns/byte |");
+    println!("| V | payload S | marshal (noop) | full (marshal+scan) | scan Δ | marshal GB/s | marshal ns/byte |");
     println!("|---:|---:|---:|---:|---:|---:|---:|");
 
-    for &n in N_AXIS {
+    for &n in &axis {
         let s = (n as usize) * VALIDATOR_BYTES;
         // Distinct, non-zero content so memcpy/scan can't be elided as a zero page.
         let buf: Vec<u8> = (0..s).map(|i| (i as u8).wrapping_mul(31).wrapping_add(7)).collect();
@@ -140,9 +155,15 @@ fn main() {
         let marshal_gbps = if s > 0 { gbps(s, noop) } else { 0.0 };
         let marshal_npb = if s > 0 { noop / s as f64 } else { 0.0 };
 
+        let note = if n > 4096 {
+            " ⚠ mainnet, out-of-spec (> 4096)"
+        } else {
+            ""
+        };
         println!(
-            "| {} | {} | {} | {} | {} | {} | {} |",
+            "| {}{} | {} | {} | {} | {} | {} | {} |",
             n,
+            note,
             fmt_bytes(s),
             fmt_ns(noop),
             fmt_ns(full),

--- a/rust-ffi/src/bin/bench-state-transition.rs
+++ b/rust-ffi/src/bin/bench-state-transition.rs
@@ -1,12 +1,17 @@
-// M5 — state_transition N-axis bench harness.
+// M5b — state_transition V-axis bench harness (spec-realistic).
 //
-// Drives `csf_bench_state_transition_run` and its `_buildonly` paired-delta
-// twin across the N axis defined in docs/ffi-implementation-plan.md M5.
-// Builders live entirely on the Lean side (cf. ConsensusLean4/Ffi.lean
-// preamble) so the harness only passes primitive `u64` arguments.
+// Drives `csf_bench_state_transition_att_run` and its `_buildonly` paired-delta
+// twin. The block carries A = MAX_ATTESTATIONS_DATA = 8 *valid* attestations so
+// the O(A·V) fast path (processAttestationsFast) actually runs — unlike the
+// earlier empty-block fixture, which measured only validator-Vec construction.
+// Builders live entirely on the Lean side (cf. ConsensusLean4/Ffi.lean M5b
+// section) so the harness only passes primitive `u64` arguments.
 //
-// Default cells: N ∈ {100, 1K, 10K, 100K} × 5 trials, A=64 fixed.
-// Pass `--include-1m` to add N=1M with 1 trial (reference value).
+// V axis is leanSpec-bounded: VALIDATOR_REGISTRY_LIMIT = 2^12 = 4096
+// (forks/lstar/config.py). Default cells: V ∈ {4, 8, 64, 512, 4096} × 5 trials.
+// Pass `--include-1m` to add V=1M with 1 trial — a *mainnet out-of-spec
+// reference* (real beacon chain ~1M validators), physically unreachable in this
+// model where state with validator_count > 4096 fails SSZ validation.
 // Pass `--single-n=N` to run only one cell — used for per-process
 // `ru_maxrss` isolation as required by docs/ffi-feasibility.md A10.
 
@@ -28,8 +33,11 @@ extern "C" {
         world: *mut c_void,
     ) -> *mut c_void;
 
-    fn csf_bench_state_transition_run(n: u64, a: u64, seed: u64) -> u8;
-    fn csf_bench_state_transition_buildonly(n: u64, a: u64, seed: u64) -> u8;
+    fn csf_bench_state_transition_att_run(n: u64, a: u64, seed: u64) -> u8;
+    fn csf_bench_state_transition_att_buildonly(n: u64, a: u64, seed: u64) -> u8;
+    // Verification probe: justifications_roots length after the pipeline.
+    // 8 valid votes processed (no skip, no 2/3 bail) ⇒ 9 (incl. zero sentinel).
+    fn csf_bench_state_transition_att_cells(n: u64) -> u8;
 }
 
 unsafe fn boot_lean() {
@@ -39,10 +47,10 @@ unsafe fn boot_lean() {
     lean_io_mark_end_initialization();
 }
 
-const A_FIXED: u64 = 64;
+const A_FIXED: u64 = 8; // spec MAX_ATTESTATIONS_DATA (distinct AttestationData / block)
 const TARGET_TRIAL_DURATION: Duration = Duration::from_millis(100);
-const DEFAULT_N_AXIS: &[u64] = &[100, 1_000, 10_000, 100_000];
-const REFERENCE_N: u64 = 1_000_000;
+const DEFAULT_N_AXIS: &[u64] = &[4, 8, 64, 512, 4096]; // leanSpec V range (≤ VALIDATOR_REGISTRY_LIMIT)
+const REFERENCE_N: u64 = 1_000_000; // mainnet out-of-spec reference (opt-in via --include-1m)
 
 fn fmt_duration_ns(ns: u128) -> String {
     if ns < 1_000 {
@@ -66,12 +74,12 @@ fn calibrate_iters(n: u64, a: u64) -> usize {
     // 5 warmup calls to settle branch predictor / TLB, then time 20 calls
     // and back out an iter count that hits the target trial duration.
     for _ in 0..5 {
-        let _ = unsafe { csf_bench_state_transition_run(n, a, 0) };
+        let _ = unsafe { csf_bench_state_transition_att_run(n, a, 0) };
     }
     const SAMPLE: usize = 20;
     let t0 = Instant::now();
     for k in 0..SAMPLE {
-        let _ = unsafe { csf_bench_state_transition_run(n, a, k as u64) };
+        let _ = unsafe { csf_bench_state_transition_att_run(n, a, k as u64) };
     }
     let elapsed = t0.elapsed();
     let per_call_ns = (elapsed.as_nanos() / SAMPLE as u128).max(1);
@@ -94,7 +102,7 @@ struct CellResult {
 
 fn bench_cell(n: u64, a: u64, trials: usize) -> CellResult {
     // Sentinel sanity: confirm the pipeline returns Ok before timing.
-    let sentinel = unsafe { csf_bench_state_transition_run(n, a, 0) };
+    let sentinel = unsafe { csf_bench_state_transition_att_run(n, a, 0) };
 
     let iters = if trials == 1 { 1 } else { calibrate_iters(n, a) };
     let mut run_per_iter: Vec<u128> = Vec::with_capacity(trials);
@@ -106,7 +114,7 @@ fn bench_cell(n: u64, a: u64, trials: usize) -> CellResult {
         let t0 = Instant::now();
         for k in 0..iters {
             let _ = unsafe {
-                csf_bench_state_transition_run(n, a, seed_base + k as u64)
+                csf_bench_state_transition_att_run(n, a, seed_base + k as u64)
             };
         }
         let elapsed = t0.elapsed();
@@ -115,7 +123,7 @@ fn bench_cell(n: u64, a: u64, trials: usize) -> CellResult {
         let t0 = Instant::now();
         for k in 0..iters {
             let _ = unsafe {
-                csf_bench_state_transition_buildonly(n, a, seed_base + k as u64)
+                csf_bench_state_transition_att_buildonly(n, a, seed_base + k as u64)
             };
         }
         let elapsed = t0.elapsed();
@@ -149,10 +157,21 @@ fn bench_cell(n: u64, a: u64, trials: usize) -> CellResult {
     }
 }
 
+fn spec_note(n: u64) -> &'static str {
+    if n > 4096 {
+        " ⚠ mainnet, out-of-spec (> VALIDATOR_REGISTRY_LIMIT=4096)"
+    } else {
+        ""
+    }
+}
+
 fn print_results_table(results: &[CellResult]) {
-    println!("# state_transition bench (handwritten Array fast path, A={A_FIXED})");
+    println!(
+        "# state_transition bench (Array fast path, A={A_FIXED} valid attestations, \
+         V ≤ leanSpec VALIDATOR_REGISTRY_LIMIT=4096)"
+    );
     println!();
-    println!("| N | trials | iters/trial | run median | buildonly | **pipeline (Δ)** | IQR (run) | sentinel |");
+    println!("| V | trials | iters/trial | run median | buildonly | **pipeline (Δ)** | IQR (run) | sentinel |");
     println!("|---:|---:|---:|---:|---:|---:|---:|:---:|");
     for r in results {
         let iqr = if r.run_iqr_ns > 0 {
@@ -161,8 +180,9 @@ fn print_results_table(results: &[CellResult]) {
             "n/a".to_string()
         };
         println!(
-            "| {} | {} | {} | {} | {} | **{}** | {} | {} |",
+            "| {}{} | {} | {} | {} | {} | **{}** | {} | {} |",
             r.n,
+            spec_note(r.n),
             r.trials,
             r.iters,
             fmt_duration_ns(r.run_median_ns),
@@ -178,7 +198,7 @@ fn print_budget_table(results: &[CellResult]) {
     println!();
     println!("## Budget judgment (per docs/timing-budget.md §5)");
     println!();
-    println!("| N | pipeline | target <200ms | outer <800ms | judgment |");
+    println!("| V | pipeline | target <200ms | outer <800ms | judgment |");
     println!("|---:|---:|:---:|:---:|:---:|");
     for r in results {
         let pipeline_ms = r.pipeline_ns as f64 / 1_000_000.0;
@@ -190,8 +210,9 @@ fn print_budget_table(results: &[CellResult]) {
             (false, false) => "🔴 red",
         };
         println!(
-            "| {} | {} | {} | {} | {} |",
+            "| {}{} | {} | {} | {} | {} |",
             r.n,
+            spec_note(r.n),
             fmt_duration_ns(r.pipeline_ns),
             if target_ok { "✓" } else { "✗" },
             if outer_ok { "✓" } else { "✗" },
@@ -200,7 +221,7 @@ fn print_budget_table(results: &[CellResult]) {
     }
 }
 
-fn main() {
+fn run() {
     let args: Vec<String> = env::args().skip(1).collect();
     let include_1m = args.iter().any(|s| s == "--include-1m");
     let single_n: Option<u64> = args
@@ -209,6 +230,20 @@ fn main() {
         .and_then(|v| v.parse().ok());
 
     unsafe { boot_lean(); }
+
+    // Fixture self-check: the A=8 workload only measures the STF if all 8 votes
+    // are *valid*. After the pipeline `justifications_roots` must hold 9 entries
+    // (zero sentinel + 8 distinct target roots). Anything else means votes were
+    // skipped (invalid) or the 2/3 threshold bailed to the slow path — either way
+    // the timings below would be meaningless, so refuse to measure.
+    let cells = unsafe { csf_bench_state_transition_att_cells(64) };
+    assert_eq!(
+        cells, 9,
+        "valid-vote fixture broken: expected 9 justification roots (zero sentinel + 8 \
+         targets), got {cells} — votes were skipped or the 2/3 threshold bailed"
+    );
+    println!("[fixture] att_cells(V=64) = {cells} ✓ (8 valid votes on the fast path)");
+    println!();
 
     let rss_start = ru_maxrss_kb();
     let t_total = Instant::now();
@@ -243,4 +278,18 @@ fn main() {
     println!("| ru_maxrss start | {} MB |", rss_start / 1024);
     println!("| ru_maxrss end | {} MB |", rss_end / 1024);
     println!("| ru_maxrss delta | {} MB |", (rss_end - rss_start) / 1024);
+}
+
+fn main() {
+    // The A=8 fixture builds Lean `List`-backed structures (validators,
+    // aggregation bitfields, the R·V justification array). At the out-of-spec
+    // V=1M reference these recurse deep enough to blow the 8 MB main-thread
+    // stack, so run everything (including Lean init) on one large-stack worker
+    // thread. Lean's per-thread runtime is initialized inside that thread.
+    std::thread::Builder::new()
+        .stack_size(2 << 30) // 2 GiB; spec range needs far less, 1M needs headroom
+        .spawn(run)
+        .expect("failed to spawn bench worker thread")
+        .join()
+        .expect("bench worker thread panicked");
 }


### PR DESCRIPTION
> **Stacked on #21** (project rename, a dependency for the FFI symbol names). Base auto-retargets to `main` once #21 merges.

## Why

The `state_transition` / `ffi-marshal` benches swept validator count **V up to 1M** (mainnet beacon-chain scale), but this project formalizes **leanSpec (3SF-mini)**, which caps the validator registry at `VALIDATOR_REGISTRY_LIMIT = 2^12 = 4096` (SSZ `List` LIMIT, enforced — a `validator_count > 4096` state fails validation). So the 1M cells were ~244× over the spec ceiling and physically unreachable in this model.

Worse: the `state_transition` fixture used an **empty block**, so `processAttestationsFast`'s `O(A·V)` hot loop never ran — it measured only validator-`Vec` construction, not the STF body.

## What

- **`Ffi.lean`**: new `csf_bench_state_transition_att_{run,buildonly,cells}`. The genesis is reverse-engineered from `is_valid_vote` / `slot_is_justifiable_after` / `current_proposer` so a block with **A = `MAX_ATTESTATIONS_DATA` = 8 valid attestations** stays on the fast path (votes under the 2/3 finalize threshold) and actually exercises `O(8·V)`.
- **`bench-state-transition.rs`**: V axis `{4,8,64,512,4096}`; 1M kept behind `--include-1m` as a **labelled mainnet out-of-spec reference**; asserts `att_cells == 9` (zero sentinel + 8 distinct target roots) before timing so a broken fixture can never be recorded as "fast"; runs on a 2 GiB-stack thread (1M overflows the default 8 MB stack).
- **`bench-ffi-marshal.rs`**: V axis `{1,4,8,64,512,4096}` + `--include-1m`.
- **docs**: new §0 spec-constants table (leanSpec `cb862c0` / mainnet `42b9671` pins); §1 & §4c rewritten with measured A=8 numbers; scaling chart (SVG); `timing-budget.md` annotated for the real spec drift `MAX_ATTESTATIONS_DATA` 16→8 (between `941abe7` and `cb862c0`, file also moved).

`fork-choice` is intentionally unchanged — it has **no V axis** (scales by B blocks ≤ `HISTORICAL_ROOTS_LIMIT = 2^18`, A attestations).

## Scaling chart

![state_transition scaling — leanSpec V ≤ 4096 vs mainnet 1M](https://raw.githubusercontent.com/NyxFoundation/consensus-ffi-poc/feat/spec-realistic-benchmarks/docs/assets/bench-scaling.svg)

> If the SVG does not render inline above, view it at [`docs/assets/bench-scaling.svg`](https://github.com/NyxFoundation/consensus-ffi-poc/blob/feat/spec-realistic-benchmarks/docs/assets/bench-scaling.svg) (embedded in `docs/rust-ffi-benchmarks.md` §1).

## Results (AMD Ryzen 9 PRO 8945HS, release + thin LTO, 2026-06-25)

### `state_transition` pipeline — A = 8 valid attestations

| V | trials | iters/trial | run median | buildonly | **pipeline (Δ)** | IQR (run) | sentinel |
|---:|---:|---:|---:|---:|---:|---:|:---:|
| 4 (devnet baseline) | 5 | 199 | 320.9 µs | 4.0 µs | **316.9 µs** | 15.5 µs | 0 |
| 8 | 5 | 324 | 334.7 µs | 4.2 µs | **330.5 µs** | 9.9 µs | 0 |
| 64 | 5 | 198 | 547.0 µs | 10.8 µs | **536.2 µs** | 24.9 µs | 0 |
| 512 | 5 | 44 | 2.21 ms | 63.1 µs | **2.15 ms** | 46.9 µs | 0 |
| **4096 (spec max)** | 5 | 6 | 15.61 ms | 492.9 µs | **15.12 ms** | 262.6 µs | 0 |
| 1,000,000 ⚠ out-of-spec | 1 | 1 | 4.30 s | 125.8 ms | **4.17 s** | n/a | 0 |

### Budget judgment (`docs/timing-budget.md`: target < 200 ms, outer < 800 ms)

| V | pipeline | target | outer | judgment |
|---:|---:|:---:|:---:|:---:|
| 4 | 316.9 µs | ✓ | ✓ | 🟢 green |
| 8 | 330.5 µs | ✓ | ✓ | 🟢 green |
| 64 | 536.2 µs | ✓ | ✓ | 🟢 green |
| 512 | 2.15 ms | ✓ | ✓ | 🟢 green |
| 4096 (spec max) | 15.12 ms | ✓ | ✓ | 🟢 green |
| 1,000,000 (out-of-spec) | 4.17 s | ✗ | ✗ | 🔴 red |

### `ffi-marshal` — Rust → Lean `ByteArray`, one-way (no SSZ codec / no SHA)

| V | payload S | marshal (noop) | full (marshal+scan) | scan Δ | GB/s | marshal / STF |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 60 B | 23.7 ns | 31.3 ns | 7.6 ns | 2.5 | — |
| 4 | 240 B | 23.9 ns | 29.0 ns | 5.2 ns | 10.1 | 0.008% |
| 8 | 480 B | 24.1 ns | 34.2 ns | 10.1 ns | 19.9 | — |
| 64 | 3.8 KB | 82.4 ns | 148.1 ns | 65.7 ns | 46.6 | — |
| 512 | 30.0 KB | 886.2 ns | 1.44 µs | 551.8 ns | 34.7 | — |
| **4096 (spec max)** | 240.0 KB | **7.00 µs** | 11.45 µs | 4.45 µs | 35.1 | **0.05%** |
| 1,000,000 ⚠ out-of-spec | 57.2 MB | 14.67 ms | 16.82 ms | 2.16 ms | 4.1 | 0.35% |

## Takeaway

The spec range (V ≤ 4096) stays comfortably green — STF ≤ 15 ms (≪ 200 ms SLO), and marshal is ≤ 7 µs = **0.05 % of STF**. The 1M reference is red (4.17 s, +584 MB RSS, needs a 2 GiB stack) — confirming the spec's 4096 cap is what keeps the `List`-backed model tractable.

## Verification

`lake build ConsensusLean4:static && (cd rust-ffi && cargo build --release)`; `bench-state-transition` prints `att_cells(V=64) = 9 ✓` and every cell returns sentinel 0; smoke (`rust-ffi`) still passes.
