### PR TITLE
feat(ffi): real SSZ hash_tree_root (SHA-256) in the STF — issue #5

### DIFF
--- a/ConsensusLean4.lean
+++ b/ConsensusLean4.lean
@@ -3,5 +3,7 @@
 import ConsensusLean4.Types
 import ConsensusLean4.FunsExternal
 import ConsensusLean4.Funs
+import ConsensusLean4.Sha
+import ConsensusLean4.Merkleization
 import ConsensusLean4.FastPath
 import ConsensusLean4.Ffi

--- a/ConsensusLean4/Ffi.lean
+++ b/ConsensusLean4/Ffi.lean
@@ -30,6 +30,31 @@ set_option maxHeartbeats 1000000
 @[export csf_ping]
 def csfPing (n : UInt64) : UInt64 := n + 1
 
+/-! ## Real SHA-256 via Rust `@[extern]` (leanSpec `hash_tree_root` primitive).
+
+leanSpec's `hash_tree_root` (spec/crypto/merkleization.py) is SHA-256. The heavy
+primitive is provided by Rust (`csf_sha256_raw`, sha2 crate) behind the
+`csf_sha256` C shim; the SSZ merkleization *structure* (chunking / binary tree /
+mix_in_length) stays in Lean. This declaration is the boundary; the self-test
+below proves the Lean → C shim → Rust path links and computes correctly before
+any merkleization is built on top. -/
+@[extern "csf_sha256"]
+opaque csfSha256 (data : ByteArray) : ByteArray
+
+/-- Self-test: SHA-256("abc") = ba7816bf…20015ad (NIST FIPS-180 vector).
+Returns 0 on match, 1 on mismatch. The Rust harness asserts 0 at startup, which
+verifies the `@[extern]` primitive is wired before relying on it. -/
+@[export csf_selftest_sha256]
+def csfSelftestSha256 (_seed : UInt64) : UInt8 :=
+  let input : ByteArray := ⟨#[0x61, 0x62, 0x63]⟩ -- "abc"
+  let got := csfSha256 input
+  let want : ByteArray := ⟨#[
+    0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+    0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+    0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+    0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad]⟩
+  if got.size == 32 && (List.range 32).all (fun i => got.get! i == want.get! i) then 0 else 1
+
 @[inline] private def packStatePipeline
     (r : Aeneas.Std.Result ((core.result.Result Unit state_transition.Error)
         × types.State)) : UInt8 :=

--- a/ConsensusLean4/Ffi.lean
+++ b/ConsensusLean4/Ffi.lean
@@ -49,6 +49,24 @@ def csfPing (n : UInt64) : UInt64 := n + 1
   | .fail _  => 2
   | .div     => 3
 
+/-- Fill `blk0`'s `parent_root` / `state_root` so the real (no longer stubbed)
+`hash_tree_root` checks in `process_block_header` and the final state-root
+comparison both pass. No circularity: the post-state never reads
+`block.state_root`, so we (1) set `parent_root = htr(header process_slots
+advances to)`, (2) run the pipeline once to obtain the post-state, (3) set
+`state_root = htr(post-state)`. Used by every fixture whose block must be
+accepted now that `hash_tree_root` is live (SHA-256, ConsensusLean4.Merkle). -/
+private def mkConsistentBlock (state : types.State) (blk0 : types.Block) : types.Block :=
+  let advancedHeader : types.BlockHeader :=
+    { state.latest_block_header with
+        state_root := ConsensusLean4.Merkle.hashTreeRootState state }
+  let parentRoot := ConsensusLean4.Merkle.hashTreeRootBlockHeader advancedHeader
+  let blk1 := { blk0 with parent_root := parentRoot, state_root := types.H256.ZERO }
+  match ConsensusLean4.FastPath.stateTransitionFast state blk1 with
+  | .ok (_, s2) => { blk1 with state_root := ConsensusLean4.Merkle.hashTreeRootState s2 }
+  | .fail _     => blk1  -- unreachable for these fixtures
+  | .div        => blk1
+
 /-- Run the handwritten Array-backed pipeline and pack the result. -/
 @[export csf_state_transition]
 def csfStateTransition (state : types.State) (block : types.Block) : UInt8 :=
@@ -131,11 +149,13 @@ private def smokeBlockBadSlot : types.Block :=
 -- `extern static` on the Rust side); a function with one scalar arg gets
 -- a proper TEXT symbol that Rust can `extern fn` against.
 
-/-- Smoke entry: 2-validator genesis, advance one slot, no attestations. -/
+/-- Smoke entry: 2-validator genesis, advance one slot, no attestations. The block
+gets consistent SSZ roots (real hash_tree_root is live) so it is accepted. -/
 @[export csf_smoke_state_transition_ok]
 def csfSmokeStateTransitionOk (_seed : UInt64) : UInt8 :=
   packStatePipeline
-    (ConsensusLean4.FastPath.stateTransitionFast smokeGenesisState smokeBlockAtSlot1)
+    (ConsensusLean4.FastPath.stateTransitionFast smokeGenesisState
+      (mkConsistentBlock smokeGenesisState smokeBlockAtSlot1))
 
 /-- Smoke entry: same state, broken block.slot → domain error sentinel 1. -/
 @[export csf_smoke_state_transition_err]
@@ -382,6 +402,8 @@ private def buildBenchStateAtt (n : UInt64) : types.State :=
 
 private def buildBenchBlockAtt (n : UInt64) : types.Block :=
   -- Proposer for slot 13 = 13 % V (current_proposer = slot % num_validators).
+  -- parent_root / state_root are placeholders; mkConsistentBlock fills the real
+  -- SSZ roots so the now-live hash_tree_root checks pass.
   let proposerRaw : UInt64 := if n = 0 then 0 else 13 % n
   { slot := 13#u64
     proposer_index := u64OfUInt64 proposerRaw
@@ -389,29 +411,34 @@ private def buildBenchBlockAtt (n : UInt64) : types.Block :=
     state_root := types.H256.ZERO
     body := { attestations := buildAttAttestations n.toNat } }
 
-/-- Build the V-validator genesis + 8-valid-vote block and run the fast pipeline.
-The `_a` slot is the fixed spec attestation count (8); it is ignored here because
-the count is baked into `attTargetSlots`, but kept in the signature so the Rust
-harness plumbing stays uniform with the other bench entry points. -/
+/-- Build the V-validator genesis + 8-valid-vote block (with consistent SSZ roots)
+and run the fast pipeline — now including real `hash_tree_root` (SHA-256). The
+`_a` slot is the fixed spec attestation count (8), baked into `attTargetSlots`;
+kept in the signature so the Rust harness plumbing stays uniform. -/
 @[export csf_bench_state_transition_att_run]
 def csfBenchStateTransitionAttRun (n _a _seed : UInt64) : UInt8 :=
-  packStatePipeline
-    (ConsensusLean4.FastPath.stateTransitionFast
-      (buildBenchStateAtt n) (buildBenchBlockAtt n))
+  let state := buildBenchStateAtt n
+  let block := mkConsistentBlock state (buildBenchBlockAtt n)  -- prep (cancels in Δ)
+  packStatePipeline (ConsensusLean4.FastPath.stateTransitionFast state block)
 
-/-- Paired-delta twin: build the same State + Block, skip the pipeline. -/
+/-- Paired-delta twin: run the identical prep (state build + mkConsistentBlock,
+which itself runs one pipeline) but skip the *measured* pipeline. Δ = run −
+buildonly isolates exactly one real-HTR state transition. -/
 @[export csf_bench_state_transition_att_buildonly]
 def csfBenchStateTransitionAttBuildOnly (n _a _seed : UInt64) : UInt8 :=
-  consumeState (buildBenchStateAtt n) ^^^ consumeBlock (buildBenchBlockAtt n)
+  let state := buildBenchStateAtt n
+  let block := mkConsistentBlock state (buildBenchBlockAtt n)
+  consumeState state ^^^ consumeBlock block
 
 /-- Verification probe: `justifications_roots` length after the pipeline. With all
 8 votes processed (none skipped, no 2/3 bail) the serialiser prepends a ZERO
 sentinel root ⇒ length 9. The Rust harness asserts this before timing so a broken
-fixture (silently-skipped votes) can never be measured as a fast result. -/
+fixture (skipped votes, or a root-mismatch early-out) can't be measured as fast. -/
 @[export csf_bench_state_transition_att_cells]
 def csfBenchStateTransitionAttCells (n : UInt64) : UInt8 :=
-  match ConsensusLean4.FastPath.stateTransitionFast
-      (buildBenchStateAtt n) (buildBenchBlockAtt n) with
+  let state := buildBenchStateAtt n
+  let block := mkConsistentBlock state (buildBenchBlockAtt n)
+  match ConsensusLean4.FastPath.stateTransitionFast state block with
   | .ok (_, s) => (min s.justifications_roots.val.length 255).toUInt8
   | _          => 0
 

--- a/ConsensusLean4/Ffi.lean
+++ b/ConsensusLean4/Ffi.lean
@@ -23,37 +23,14 @@
 import ConsensusLean4.FastPath
 import ConsensusLean4.Funs
 import ConsensusLean4.Types
+import ConsensusLean4.Sha
+import ConsensusLean4.Merkleization
 open Aeneas Aeneas.Std ethlambda_verification
 
 set_option maxHeartbeats 1000000
 
 @[export csf_ping]
 def csfPing (n : UInt64) : UInt64 := n + 1
-
-/-! ## Real SHA-256 via Rust `@[extern]` (leanSpec `hash_tree_root` primitive).
-
-leanSpec's `hash_tree_root` (spec/crypto/merkleization.py) is SHA-256. The heavy
-primitive is provided by Rust (`csf_sha256_raw`, sha2 crate) behind the
-`csf_sha256` C shim; the SSZ merkleization *structure* (chunking / binary tree /
-mix_in_length) stays in Lean. This declaration is the boundary; the self-test
-below proves the Lean → C shim → Rust path links and computes correctly before
-any merkleization is built on top. -/
-@[extern "csf_sha256"]
-opaque csfSha256 (data : ByteArray) : ByteArray
-
-/-- Self-test: SHA-256("abc") = ba7816bf…20015ad (NIST FIPS-180 vector).
-Returns 0 on match, 1 on mismatch. The Rust harness asserts 0 at startup, which
-verifies the `@[extern]` primitive is wired before relying on it. -/
-@[export csf_selftest_sha256]
-def csfSelftestSha256 (_seed : UInt64) : UInt8 :=
-  let input : ByteArray := ⟨#[0x61, 0x62, 0x63]⟩ -- "abc"
-  let got := csfSha256 input
-  let want : ByteArray := ⟨#[
-    0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
-    0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
-    0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
-    0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad]⟩
-  if got.size == 32 && (List.range 32).all (fun i => got.get! i == want.get! i) then 0 else 1
 
 @[inline] private def packStatePipeline
     (r : Aeneas.Std.Result ((core.result.Result Unit state_transition.Error)

--- a/ConsensusLean4/Funs/Types.lean
+++ b/ConsensusLean4/Funs/Types.lean
@@ -4,6 +4,7 @@
 import Aeneas
 import ConsensusLean4.Types
 import ConsensusLean4.FunsExternal
+import ConsensusLean4.Merkleization
 open Aeneas Aeneas.Std Result ControlFlow Error
 set_option linter.dupNamespace false
 set_option linter.hashCommand false
@@ -138,22 +139,26 @@ def types.H256.ZERO : types.H256 := let a := Array.repeat 32#usize 0#u8
 /-- [ethlambda_verification::types::hash_tree_root_state]:
     Source: 'crates/verification/src/types.rs', lines 153:0-155:1
     Visibility: public -/
-def types.hash_tree_root_state (_state : types.State) : Result types.H256 := do
-  ok types.H256.ZERO
+-- PoC: the original Aeneas stub returned `ok H256.ZERO`. Replaced with the real
+-- SSZ hash_tree_root (ConsensusLean4.Merkleization, SHA-256 via Rust @[extern]).
+-- NOTE: this is a generated file — re-running Aeneas overwrites this back to the
+-- ZERO stub; redo this swap (3 functions below) after any regen.
+def types.hash_tree_root_state (state : types.State) : Result types.H256 := do
+  ok (ConsensusLean4.Merkle.hashTreeRootState state)
 
 /-- [ethlambda_verification::types::hash_tree_root_block_body]:
     Source: 'crates/verification/src/types.rs', lines 161:0-163:1
     Visibility: public -/
 def types.hash_tree_root_block_body
-  (_body : types.BlockBody) : Result types.H256 := do
-  ok types.H256.ZERO
+  (body : types.BlockBody) : Result types.H256 := do
+  ok (ConsensusLean4.Merkle.hashTreeRootBlockBody body)
 
 /-- [ethlambda_verification::types::hash_tree_root_block_header]:
     Source: 'crates/verification/src/types.rs', lines 157:0-159:1
     Visibility: public -/
 def types.hash_tree_root_block_header
-  (_header : types.BlockHeader) : Result types.H256 := do
-  ok types.H256.ZERO
+  (header : types.BlockHeader) : Result types.H256 := do
+  ok (ConsensusLean4.Merkle.hashTreeRootBlockHeader header)
 
 /-- [ethlambda_verification::types::HISTORICAL_ROOTS_LIMIT]
     Source: 'crates/verification/src/types.rs', lines 129:0-129:50

--- a/ConsensusLean4/Merkleization.lean
+++ b/ConsensusLean4/Merkleization.lean
@@ -1,0 +1,268 @@
+-- SSZ Merkleization (`hash_tree_root`) in pure Lean, faithful to leanSpec's
+-- spec/crypto/merkleization.py, built on the Rust SHA-256 primitive (Sha.lean).
+--
+-- Mirrors leanSpec exactly for the structure that drives cost:
+--   * merkleize: pad chunk count to next_pow2(limit or count); reduce with
+--     sha256(left ++ right); missing right siblings use cached zero-subtree roots.
+--   * mix_in_length(root, n) = sha256(root ++ n_as_uint256_LE) for variable lists.
+--   * basic types pack into 32-byte chunks (uint64 = 8 LE + zero pad, etc.).
+--   * containers merkleize their field roots in declaration order.
+--
+-- Scope note: this hashes *our* Aeneas-extracted State/Block type tree (which is
+-- an SSZ-compatible subset, not byte-identical to leanSpec's State container), so
+-- roots are internally consistent rather than cross-validated against a leanSpec
+-- node. The dominant cost — the O(V) validators list and O(R·V) justification
+-- bits — is captured with the correct chunk counts and tree shapes.
+import ConsensusLean4.Sha
+import ConsensusLean4.Types
+open Aeneas Aeneas.Std ethlambda_verification
+
+namespace ConsensusLean4.Merkle
+
+set_option linter.unusedVariables false
+
+/-- SSZ list limits (mirror `types.VALIDATOR_REGISTRY_LIMIT` / `HISTORICAL_ROOTS_LIMIT`
+in `Funs/Types.lean`; kept as literals to avoid importing the Funs umbrella). -/
+def regLimit : Nat := 4096      -- 2^12
+def histLimit : Nat := 262144   -- 2^18
+
+/-! ## Chunk primitives -/
+
+/-- 32 zero bytes (the SSZ zero leaf). -/
+def zeroChunk : ByteArray := ⟨Array.replicate 32 0⟩
+
+/-- sha256(left ++ right) over two 32-byte chunks. -/
+@[inline] def hashPair (a b : ByteArray) : ByteArray := csfSha256 (a ++ b)
+
+/-- Smallest power of two ≥ x; 1 for x ≤ 1 (matches leanSpec `_next_pow2`). -/
+def nextPow2 (x : Nat) : Nat :=
+  if x ≤ 1 then 1
+  else if Nat.land x (x - 1) == 0 then x
+  else 2 ^ (Nat.log2 x + 1)
+
+/-- bit_length(n): 0 for n=0, else ⌊log2 n⌋+1. -/
+@[inline] def bitLen (n : Nat) : Nat := if n == 0 then 0 else Nat.log2 n + 1
+
+/-- Zero-subtree roots indexed by depth: zh[0] = zeroChunk, zh[d] = sha256(zh[d-1]‖zh[d-1]).
+Built once per top-level hash_tree_root and threaded through (≤ ~40 hashes). -/
+def zeroHashes (maxDepth : Nat) : Array ByteArray := Id.run do
+  let mut arr := #[zeroChunk]
+  for _ in [0:maxDepth] do
+    arr := arr.push (hashPair arr.back! arr.back!)
+  arr
+
+/-- Root of an all-zero perfect tree of `width` leaves (`width` a power of two). -/
+@[inline] def zeroTreeRoot (zh : Array ByteArray) (width : Nat) : ByteArray :=
+  if width ≤ 1 then zeroChunk else zh[bitLen (width - 1)]!
+
+/-- SSZ Merkle root over 32-byte chunks, with optional leaf-count `limit`. -/
+def merkleize (zh : Array ByteArray) (chunks : Array ByteArray) (limit : Option Nat) :
+    ByteArray :=
+  let n := chunks.size
+  if n == 0 then
+    match limit with
+    | some L => zeroTreeRoot zh (nextPow2 L)
+    | none   => zeroChunk
+  else
+    let width := match limit with | some L => nextPow2 L | none => nextPow2 n
+    if width == 1 then chunks[0]!
+    else Id.run do
+      let mut level := chunks
+      let mut subtree := 1
+      while subtree < width do
+        let mut next : Array ByteArray := Array.mkEmpty ((level.size + 1) / 2)
+        let mut i := 0
+        while i < level.size do
+          let left := level[i]!
+          let right := if i + 1 < level.size then level[i + 1]! else zeroTreeRoot zh subtree
+          next := next.push (hashPair left right)
+          i := i + 2
+        level := next
+        subtree := subtree * 2
+      level[0]!
+
+/-- mix_in_length: sha256(root ‖ length-as-uint256-LE). -/
+def mixInLength (root : ByteArray) (len : Nat) : ByteArray :=
+  let lenLE : ByteArray := Id.run do
+    let mut b := ByteArray.empty
+    let mut i := 0
+    while i < 32 do
+      b := b.push (UInt8.ofNat (Nat.land (len >>> (8 * i)) 0xff))
+      i := i + 1
+    b
+  csfSha256 (root ++ lenLE)
+
+/-! ## Packing basic values into chunks -/
+
+/-- Split `b` into 32-byte chunks, zero-padding the final chunk. -/
+def packBytes (b : ByteArray) : Array ByteArray := Id.run do
+  let n := b.size
+  let mut chunks : Array ByteArray := #[]
+  let mut i := 0
+  while i < n do
+    let mut c := ByteArray.empty
+    let mut j := 0
+    while j < 32 do
+      c := c.push (if i + j < n then b.get! (i + j) else 0)
+      j := j + 1
+    chunks := chunks.push c
+    i := i + 32
+  chunks
+
+/-- Pack bits little-endian into bytes, then into 32-byte chunks. -/
+def packBits (bits : List Bool) : Array ByteArray := Id.run do
+  let arr := bits.toArray
+  let nbytes := (arr.size + 7) / 8
+  let mut bytes := ByteArray.empty
+  let mut k := 0
+  while k < nbytes do
+    let mut byte : UInt8 := 0
+    let mut j := 0
+    while j < 8 do
+      if (arr[k * 8 + j]?).getD false then
+        byte := byte ||| (1 <<< j.toUInt8)
+      j := j + 1
+    bytes := bytes.push byte
+    k := k + 1
+  packBytes bytes
+
+/-! ## Per-type hash_tree_root (returns a 32-byte chunk) -/
+
+@[inline] def u8ToByte (x : Std.U8) : UInt8 := UInt8.ofNat x.val
+
+/-- htr(H256) = the 32 raw bytes (single chunk). -/
+def htrH256 (h : types.H256) : ByteArray := ⟨(h.val.map u8ToByte).toArray⟩
+
+/-- htr(U64) = 8 LE bytes + 24 zero (single chunk). -/
+def htrU64 (x : Std.U64) : ByteArray := Id.run do
+  let v := x.val
+  let mut b := ByteArray.empty
+  let mut i := 0
+  while i < 32 do
+    b := b.push (if i < 8 then UInt8.ofNat (Nat.land (v >>> (8 * i)) 0xff) else 0)
+    i := i + 1
+  b
+
+/-- htr(Bytes52 pubkey) = merkleize of its 2 packed chunks. -/
+def htrPubkey (zh : Array ByteArray) (pk : Array Std.U8 52#usize) : ByteArray :=
+  merkleize zh (packBytes ⟨(pk.val.map u8ToByte).toArray⟩) none
+
+def htrCheckpoint (zh : Array ByteArray) (c : types.Checkpoint) : ByteArray :=
+  merkleize zh #[htrH256 c.root, htrU64 c.slot] none
+
+def htrChainConfig (zh : Array ByteArray) (c : types.ChainConfig) : ByteArray :=
+  merkleize zh #[htrU64 c.genesis_time] none
+
+def htrValidator (zh : Array ByteArray) (v : types.Validator) : ByteArray :=
+  merkleize zh #[htrPubkey zh v.pubkey, htrU64 v.index] none
+
+def htrBlockHeader (zh : Array ByteArray) (h : types.BlockHeader) : ByteArray :=
+  merkleize zh
+    #[htrU64 h.slot, htrU64 h.proposer_index, htrH256 h.parent_root,
+      htrH256 h.state_root, htrH256 h.body_root] none
+
+def htrAttData (zh : Array ByteArray) (d : types.AttestationData) : ByteArray :=
+  merkleize zh
+    #[htrU64 d.slot, htrCheckpoint zh d.head, htrCheckpoint zh d.target,
+      htrCheckpoint zh d.source] none
+
+/-- htr(bitlist) = mix_in_length(merkleize(packed bits, limit chunks), bit count). -/
+def htrBitlist (zh : Array ByteArray) (bits : List Bool) (limitBits : Nat) : ByteArray :=
+  let limitChunks := (limitBits + 255) / 256
+  mixInLength (merkleize zh (packBits bits) (some limitChunks)) bits.length
+
+def htrAggAtt (zh : Array ByteArray) (a : types.AggregatedAttestation) : ByteArray :=
+  merkleize zh
+    #[htrBitlist zh a.aggregation_bits.val regLimit,
+      htrAttData zh a.data] none
+
+/-- htr(list of composite) = mix_in_length(merkleize(element roots, limit), len). -/
+@[inline] def htrListComposite (zh : Array ByteArray)
+    (roots : Array ByteArray) (limit : Nat) : ByteArray :=
+  mixInLength (merkleize zh roots (some limit)) roots.size
+
+def htrVecH256 (zh : Array ByteArray) (v : alloc.vec.Vec types.H256) (limit : Nat) : ByteArray :=
+  htrListComposite zh ((v.val.map htrH256).toArray) limit
+
+def htrVecValidator (zh : Array ByteArray) (v : alloc.vec.Vec types.Validator) : ByteArray :=
+  htrListComposite zh ((v.val.map (htrValidator zh)).toArray) regLimit
+
+def htrVecAggAtt (zh : Array ByteArray)
+    (v : alloc.vec.Vec types.AggregatedAttestation) : ByteArray :=
+  htrListComposite zh ((v.val.map (htrAggAtt zh)).toArray) regLimit
+
+def htrBlockBody (zh : Array ByteArray) (b : types.BlockBody) : ByteArray :=
+  merkleize zh #[htrVecAggAtt zh b.attestations] none
+
+def htrBlock (zh : Array ByteArray) (b : types.Block) : ByteArray :=
+  merkleize zh
+    #[htrU64 b.slot, htrU64 b.proposer_index, htrH256 b.parent_root,
+      htrH256 b.state_root, htrBlockBody zh b.body] none
+
+/-- State container. Field order follows `types.State` (Funs/Types.lean). The two
+bool vectors are treated as bitlists; list limits use the spec constants where
+known. -/
+def htrState (zh : Array ByteArray) (s : types.State) : ByteArray :=
+  let hist := histLimit
+  let reg := regLimit
+  merkleize zh
+    #[htrChainConfig zh s.config,
+      htrU64 s.slot,
+      htrBlockHeader zh s.latest_block_header,
+      htrCheckpoint zh s.latest_justified,
+      htrCheckpoint zh s.latest_finalized,
+      htrVecH256 zh s.historical_block_hashes hist,
+      htrBitlist zh s.justified_slots.val hist,
+      htrVecValidator zh s.validators,
+      htrVecH256 zh s.justifications_roots reg,
+      htrBitlist zh s.justifications_validators.val (hist * reg)] none
+
+/-! ## Public entry points (build zero-hash cache once, return H256). -/
+
+private def maxTreeDepth : Nat := 48
+
+@[inline] def byteToU8 (b : UInt8) : Std.U8 :=
+  Std.U8.ofNat b.toNat (by
+    have hlt : b.toNat < UInt8.size := b.toNat_lt
+    have hsize : UInt8.size = 256 := by decide
+    rw [Std.UScalar.cMax_eq_pow_cNumBits]
+    show b.toNat ≤ 2 ^ Std.UScalarTy.U8.cNumBits - 1
+    have hbits : Std.UScalarTy.U8.cNumBits = 8 := rfl
+    rw [hbits]; omega)
+
+/-- Convert a 32-byte chunk back into the Aeneas `H256` array type. -/
+def chunkToH256 (b : ByteArray) : types.H256 :=
+  Array.make 32#usize ((List.range 32).map (fun i => byteToU8 (b.get! i)))
+
+def hashTreeRootState (s : types.State) : types.H256 :=
+  chunkToH256 (htrState (zeroHashes maxTreeDepth) s)
+
+def hashTreeRootBlockHeader (h : types.BlockHeader) : types.H256 :=
+  chunkToH256 (htrBlockHeader (zeroHashes maxTreeDepth) h)
+
+def hashTreeRootBlockBody (b : types.BlockBody) : types.H256 :=
+  chunkToH256 (htrBlockBody (zeroHashes maxTreeDepth) b)
+
+/-- Self-test against known SSZ values; returns 0 iff all pass. Validates uint64
+LE packing, the 2-leaf merkleize, the SHA-256 wiring, and the zero-hash cache:
+`htr(uint64 0)` = 32 zeros; `htr(uint64 1)` = 01‖00·31; `merkleize([0,0])` =
+sha256(64 zeros) = f5a5fd42…fb4b (the canonical SSZ zerohashes[1]). -/
+@[export csf_selftest_htr]
+def csfSelftestHtr (_seed : UInt64) : UInt8 :=
+  let zh := zeroHashes maxTreeDepth
+  let c0 := htrU64 0#u64
+  let ok1 := c0.size == 32 && (List.range 32).all (fun i => c0.get! i == 0)
+  let c1 := htrU64 1#u64
+  let ok2 := c1.get! 0 == 1 && (List.range 31).all (fun i => c1.get! (i + 1) == 0)
+  let cp : types.Checkpoint := { root := chunkToH256 zeroChunk, slot := 0#u64 }
+  let got := htrCheckpoint zh cp
+  let want : ByteArray := ⟨#[
+    0xf5, 0xa5, 0xfd, 0x42, 0xd1, 0x6a, 0x20, 0x30,
+    0x27, 0x98, 0xef, 0x6e, 0xd3, 0x09, 0x97, 0x9b,
+    0x43, 0x00, 0x3d, 0x23, 0x20, 0xd9, 0xf0, 0xe8,
+    0xea, 0x98, 0x31, 0xa9, 0x27, 0x59, 0xfb, 0x4b]⟩
+  let ok3 := got.size == 32 && (List.range 32).all (fun i => got.get! i == want.get! i)
+  let ok4 := (List.range 32).all (fun i => (zh[1]!).get! i == want.get! i)
+  if ok1 && ok2 && ok3 && ok4 then 0 else 1
+
+end ConsensusLean4.Merkle

--- a/ConsensusLean4/Sha.lean
+++ b/ConsensusLean4/Sha.lean
@@ -1,0 +1,29 @@
+-- SHA-256 primitive, provided by Rust via FFI (sha2 crate) behind the
+-- `csf_sha256` C shim (rust-ffi/csf_marshal_shim.c + src/sha_extern.rs).
+--
+-- leanSpec's `hash_tree_root` (spec/crypto/merkleization.py) is SHA-256. The
+-- SSZ merkleization *structure* lives in `ConsensusLean4.Merkleization` (pure
+-- Lean); this module is just the boundary to the native primitive. Kept in its
+-- own module so both `Merkleization` and `Ffi` can import it without a cycle.
+--
+-- `lean_alloc_sarray`/`lean_sarray_cptr` are static-inline in lean.h, so the
+-- Lean object ABI (read input sarray, allocate the 32-byte output, dec_ref the
+-- owned argument) is done in the C shim; the shim calls Rust for the hashing.
+
+/-- SHA-256 of `data`, returning the 32-byte digest as a `ByteArray`. -/
+@[extern "csf_sha256"]
+opaque csfSha256 (data : ByteArray) : ByteArray
+
+/-- Self-test: SHA-256("abc") = ba7816bf…20015ad (NIST FIPS-180 vector).
+Returns 0 on match, 1 on mismatch. The Rust harness asserts 0 at startup to
+verify the `@[extern]` primitive is wired before anything relies on it. -/
+@[export csf_selftest_sha256]
+def csfSelftestSha256 (_seed : UInt64) : UInt8 :=
+  let input : ByteArray := ⟨#[0x61, 0x62, 0x63]⟩ -- "abc"
+  let got := csfSha256 input
+  let want : ByteArray := ⟨#[
+    0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+    0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+    0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+    0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad]⟩
+  if got.size == 32 && (List.range 32).all (fun i => got.get! i == want.get! i) then 0 else 1

--- a/README.md
+++ b/README.md
@@ -89,8 +89,16 @@ attestations so the `O(A·V)` fast path actually runs, and asserts a fixture sel
 (`att_cells == 9`) before timing. Reference budgets and judgment criteria live in
 [`docs/timing-budget.md`](docs/timing-budget.md); the spec-constant axis rationale and
 detailed result tables are in [`docs/rust-ffi-benchmarks.md`](docs/rust-ffi-benchmarks.md)
-(§0 pins the leanSpec / mainnet constants). Crypto cost (`hash_tree_root_*`) is excluded —
-those return `H256.ZERO` per the spec stubs in `ConsensusLean4/Funs/Types.lean`.
+(§0 pins the leanSpec / mainnet constants). `hash_tree_root` is computed for real
+(SSZ merkleization in `ConsensusLean4/Merkleization.lean` over a Rust `@[extern]`
+SHA-256), so the state-root and parent-root checks are live; see §1b for the
+HTR-included numbers. Signature verification (XMSS) is still outside the STF and
+not measured.
+
+> **Regen note**: the real HTR is wired in by hand-swapping the three
+> `hash_tree_root_*` stubs in the **Aeneas-generated** `ConsensusLean4/Funs/Types.lean`
+> from `ok H256.ZERO` to `ConsensusLean4.Merkle.*` calls. Re-running Aeneas reverts
+> them to the ZERO stub — redo the swap (3 functions) after any regen.
 
 ## Source
 

--- a/docs/assets/htr-cost.svg
+++ b/docs/assets/htr-cost.svg
@@ -1,0 +1,2645 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="612.127656pt" height="381.189219pt" viewBox="0 0 612.127656 381.189219" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-26T00:35:43.617893</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7+dfsg1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 381.189219 
+L 612.127656 381.189219 
+L 612.127656 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 65.577656 342.857031 
+L 604.927656 342.857031 
+L 604.927656 27.558281 
+L 65.577656 27.558281 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="FillBetweenPolyCollection_1">
+    <defs>
+     <path id="m701ab73f8e" d="M 77.531687 -57.985116 
+L 77.531687 -58.176005 
+L 128.515918 -59.987652 
+L 281.46861 -80.850314 
+L 434.421302 -140.722759 
+L 587.373994 -224.817879 
+L 587.373994 -250.685314 
+L 587.373994 -250.685314 
+L 434.421302 -162.343322 
+L 281.46861 -95.996446 
+L 128.515918 -64.808378 
+L 77.531687 -57.985116 
+z
+" style="stroke: #1f77b4; stroke-opacity: 0.08"/>
+    </defs>
+    <g clip-path="url(#pad614e34c7)">
+     <use xlink:href="#m701ab73f8e" x="0" y="381.189219" style="fill: #1f77b4; fill-opacity: 0.08; stroke: #1f77b4; stroke-opacity: 0.08"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 77.531687 342.857031 
+L 77.531687 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m0995839680" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m0995839680" x="77.531687" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 4 -->
+      <g transform="translate(74.350437 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 128.515918 342.857031 
+L 128.515918 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m0995839680" x="128.515918" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 8 -->
+      <g transform="translate(125.334668 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 281.46861 342.857031 
+L 281.46861 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m0995839680" x="281.46861" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 64 -->
+      <g transform="translate(275.10611 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 434.421302 342.857031 
+L 434.421302 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m0995839680" x="434.421302" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 512 -->
+      <g transform="translate(424.877552 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 587.373994 342.857031 
+L 587.373994 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m0995839680" x="587.373994" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4096 -->
+      <g transform="translate(574.648994 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 93.944943 342.857031 
+L 93.944943 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m22de06c167" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m22de06c167" x="93.944943" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 107.35555 342.857031 
+L 107.35555 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m22de06c167" x="107.35555" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 118.694056 342.857031 
+L 118.694056 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m22de06c167" x="118.694056" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 137.179413 342.857031 
+L 137.179413 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m22de06c167" x="137.179413" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 195.913405 342.857031 
+L 195.913405 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m22de06c167" x="195.913405" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 225.737268 342.857031 
+L 225.737268 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m22de06c167" x="225.737268" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 246.897635 342.857031 
+L 246.897635 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m22de06c167" x="246.897635" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 263.310892 342.857031 
+L 263.310892 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m22de06c167" x="263.310892" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 276.721498 342.857031 
+L 276.721498 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m22de06c167" x="276.721498" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 288.060005 342.857031 
+L 288.060005 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m22de06c167" x="288.060005" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 297.881866 342.857031 
+L 297.881866 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m22de06c167" x="297.881866" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 306.545362 342.857031 
+L 306.545362 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m22de06c167" x="306.545362" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 365.279353 342.857031 
+L 365.279353 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m22de06c167" x="365.279353" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 395.103216 342.857031 
+L 395.103216 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m22de06c167" x="395.103216" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 416.263584 342.857031 
+L 416.263584 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m22de06c167" x="416.263584" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 432.67684 342.857031 
+L 432.67684 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m22de06c167" x="432.67684" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 446.087447 342.857031 
+L 446.087447 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m22de06c167" x="446.087447" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 457.425953 342.857031 
+L 457.425953 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m22de06c167" x="457.425953" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 467.247815 342.857031 
+L 467.247815 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m22de06c167" x="467.247815" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 475.91131 342.857031 
+L 475.91131 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m22de06c167" x="475.91131" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 534.645302 342.857031 
+L 534.645302 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m22de06c167" x="534.645302" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 564.469165 342.857031 
+L 564.469165 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m22de06c167" x="564.469165" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 585.629532 342.857031 
+L 585.629532 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m22de06c167" x="585.629532" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 602.042789 342.857031 
+L 602.042789 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m22de06c167" x="602.042789" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- validator count  V  (≤ leanSpec VALIDATOR_REGISTRY_LIMIT = 4096) -->
+     <g transform="translate(154.244961 371.513516) scale(0.105 -0.105)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2264" d="M 4684 3175 
+L 1684 2309 
+L 4684 1453 
+L 4684 897 
+L 678 2047 
+L 678 2578 
+L 4684 3725 
+L 4684 3175 
+z
+M 678 531 
+L 4684 531 
+L 4684 0 
+L 678 0 
+L 678 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 628 4666 
+L 3578 4666 
+L 3578 4134 
+L 1259 4134 
+L 1259 2753 
+L 3481 2753 
+L 3481 2222 
+L 1259 2222 
+L 1259 531 
+L 3634 531 
+L 3634 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(148.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(176.025391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(239.501953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(300.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(339.990234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(401.171875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(442.285156 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(474.072266 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(529.052734 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(590.234375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(653.613281 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(716.992188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(756.201172 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(787.988281 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(819.775391 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(888.183594 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(919.970703 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(951.757812 0)"/>
+      <use xlink:href="#DejaVuSans-2264" transform="translate(990.771484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1074.560547 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.347656 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1134.130859 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1195.654297 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1256.933594 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1320.3125 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1383.789062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1447.265625 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1508.789062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1563.769531 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1595.556641 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1657.589844 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1725.998047 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(1781.710938 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1811.203125 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1886.455078 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(1947.113281 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(2008.197266 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2086.908203 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2156.390625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2206.390625 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(2275.873047 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(2339.056641 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2416.546875 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(2446.039062 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2509.515625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2570.599609 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(2633.707031 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2694.791016 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(2744.791016 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2800.503906 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(2829.996094 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2916.275391 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2945.767578 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3006.851562 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3038.638672 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3122.427734 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(3154.214844 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(3217.837891 0)"/>
+      <use xlink:href="#DejaVuSans-39" transform="translate(3281.460938 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(3345.083984 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(3408.707031 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_59">
+      <path d="M 65.577656 325.375999 
+L 604.927656 325.375999 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <defs>
+       <path id="m6fa2b785ab" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m6fa2b785ab" x="65.577656" y="325.375999" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 300 µs -->
+      <g transform="translate(24.740156 329.175218) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_61">
+      <path d="M 65.577656 273.468481 
+L 604.927656 273.468481 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m6fa2b785ab" x="65.577656" y="273.468481" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 1 ms -->
+      <g transform="translate(34.087031 277.2677) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_63">
+      <path d="M 65.577656 226.103426 
+L 604.927656 226.103426 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m6fa2b785ab" x="65.577656" y="226.103426" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 3 ms -->
+      <g transform="translate(34.087031 229.902645) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_65">
+      <path d="M 65.577656 174.195908 
+L 604.927656 174.195908 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m6fa2b785ab" x="65.577656" y="174.195908" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 10 ms -->
+      <g transform="translate(27.724531 177.995127) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_67">
+      <path d="M 65.577656 126.830854 
+L 604.927656 126.830854 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m6fa2b785ab" x="65.577656" y="126.830854" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 30 ms -->
+      <g transform="translate(27.724531 130.630073) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_69">
+      <path d="M 65.577656 74.923336 
+L 604.927656 74.923336 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m6fa2b785ab" x="65.577656" y="74.923336" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 100 ms -->
+      <g transform="translate(21.362031 78.722554) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_71">
+      <path d="M 65.577656 27.558281 
+L 604.927656 27.558281 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m6fa2b785ab" x="65.577656" y="27.558281" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 300 ms -->
+      <g transform="translate(21.362031 31.3575) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_73">
+      <path d="M 65.577656 342.857031 
+L 604.927656 342.857031 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_74">
+      <defs>
+       <path id="m6cafcd3fa4" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_75">
+      <path d="M 65.577656 312.973009 
+L 604.927656 312.973009 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="312.973009" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_77">
+      <path d="M 65.577656 303.352503 
+L 604.927656 303.352503 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="303.352503" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_79">
+      <path d="M 65.577656 295.491977 
+L 604.927656 295.491977 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="295.491977" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_81">
+      <path d="M 65.577656 288.845997 
+L 604.927656 288.845997 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="288.845997" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_83">
+      <path d="M 65.577656 283.088987 
+L 604.927656 283.088987 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="283.088987" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_85">
+      <path d="M 65.577656 278.010945 
+L 604.927656 278.010945 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="278.010945" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_87">
+      <path d="M 65.577656 243.584459 
+L 604.927656 243.584459 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="243.584459" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_89">
+      <path d="M 65.577656 213.700437 
+L 604.927656 213.700437 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="213.700437" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_91">
+      <path d="M 65.577656 204.07993 
+L 604.927656 204.07993 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="204.07993" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_93">
+      <path d="M 65.577656 196.219404 
+L 604.927656 196.219404 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="196.219404" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_95">
+      <path d="M 65.577656 189.573424 
+L 604.927656 189.573424 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="189.573424" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_97">
+      <path d="M 65.577656 183.816415 
+L 604.927656 183.816415 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="183.816415" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_99">
+      <path d="M 65.577656 178.738372 
+L 604.927656 178.738372 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="178.738372" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_101">
+      <path d="M 65.577656 144.311886 
+L 604.927656 144.311886 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="144.311886" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_103">
+      <path d="M 65.577656 114.427864 
+L 604.927656 114.427864 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="114.427864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_105">
+      <path d="M 65.577656 104.807358 
+L 604.927656 104.807358 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="104.807358" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_107">
+      <path d="M 65.577656 96.946832 
+L 604.927656 96.946832 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="96.946832" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_109">
+      <path d="M 65.577656 90.300852 
+L 604.927656 90.300852 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="90.300852" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_111">
+      <path d="M 65.577656 84.543842 
+L 604.927656 84.543842 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="84.543842" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_113">
+      <path d="M 65.577656 79.465799 
+L 604.927656 79.465799 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="79.465799" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_115">
+      <path d="M 65.577656 45.039314 
+L 604.927656 45.039314 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#m6cafcd3fa4" x="65.577656" y="45.039314" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- pipeline time per call (log scale) -->
+     <g transform="translate(15.178359 269.61125) rotate(-90) scale(0.105 -0.105)">
+      <defs>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(91.259766 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(154.736328 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(216.259766 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(244.042969 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(271.826172 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(335.205078 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(396.728516 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(428.515625 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(467.724609 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(495.507812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(592.919922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(654.443359 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(686.230469 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(749.707031 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(811.230469 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(852.34375 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(884.130859 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(939.111328 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1000.390625 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1028.173828 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1055.957031 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1087.744141 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1126.757812 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1154.541016 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1215.722656 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1279.199219 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1310.986328 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1363.085938 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1418.066406 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1479.345703 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1507.128906 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1568.652344 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_117">
+    <path d="M 65.577656 45.039314 
+L 604.927656 45.039314 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 65.577656 342.857031 
+L 65.577656 27.558281 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 604.927656 342.857031 
+L 604.927656 27.558281 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 65.577656 342.857031 
+L 604.927656 342.857031 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 65.577656 27.558281 
+L 604.927656 27.558281 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- SLO target 200 ms -->
+    <g style="fill: #555555" transform="translate(84.542198 39.77008) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(194.275391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(226.0625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(265.271484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(326.550781 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(365.914062 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(429.390625 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(490.914062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(530.123047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(561.910156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(625.533203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(689.15625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(752.779297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(784.566406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(881.978516 0)"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 484.050069 109.237386 
+Q 534.732964 119.66913 584.211273 129.852941 
+" style="fill: none; stroke: #0b3d6e; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 581.18865 127.474759 
+L 584.211273 129.852941 
+L 580.495153 130.84413 
+" style="fill: none; stroke: #0b3d6e; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_16">
+    <!-- V=4096 (spec max) -->
+    <g style="fill: #0b3d6e" transform="translate(327.705729 85.54712) scale(0.086 -0.086)">
+     <defs>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(215.820312 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(279.443359 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(343.066406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(406.689453 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(438.476562 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(477.490234 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(529.589844 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(593.066406 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(654.589844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(709.570312 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(741.357422 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(838.769531 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(900.048828 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(959.228516 0)"/>
+    </g>
+    <!-- stub 15.1 ms → real 27.6 ms -->
+    <g style="fill: #0b3d6e" transform="translate(327.705729 95.177239) scale(0.086 -0.086)">
+     <defs>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2192" d="M 5050 2147 
+L 5050 1866 
+L 3822 638 
+L 3447 1013 
+L 4175 1741 
+L 366 1741 
+L 366 2272 
+L 4175 2272 
+L 3447 3000 
+L 3822 3375 
+L 5050 2147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(91.308594 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(154.6875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(218.164062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(249.951172 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(313.574219 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(377.197266 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(408.984375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(472.607422 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(504.394531 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(601.806641 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(653.90625 0)"/>
+     <use xlink:href="#DejaVuSans-2192" transform="translate(685.693359 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(769.482422 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(801.269531 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(840.132812 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(901.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(962.935547 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(990.71875 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(1022.505859 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(1086.128906 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(1149.751953 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1181.539062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1245.162109 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1276.949219 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1374.361328 0)"/>
+    </g>
+    <!-- hash_tree_root ≈ +12.4 ms (+82%) -->
+    <g style="fill: #0b3d6e" transform="translate(327.705729 104.807358) scale(0.086 -0.086)">
+     <defs>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2248" d="M 4684 1947 
+L 4684 1388 
+Q 4356 1144 4076 1036 
+Q 3797 928 3494 928 
+Q 3150 928 2694 1113 
+Q 2663 1125 2641 1134 
+Q 2622 1141 2575 1159 
+Q 2091 1350 1797 1350 
+Q 1522 1350 1253 1231 
+Q 984 1113 678 850 
+L 678 1409 
+Q 1006 1653 1286 1761 
+Q 1566 1869 1869 1869 
+Q 2213 1869 2672 1684 
+Q 2706 1669 2722 1663 
+Q 2741 1656 2788 1638 
+Q 3272 1447 3566 1447 
+Q 3834 1447 4098 1564 
+Q 4363 1681 4684 1947 
+z
+M 4684 3163 
+L 4684 2606 
+Q 4356 2359 4076 2251 
+Q 3797 2144 3494 2144 
+Q 3150 2144 2694 2328 
+Q 2663 2341 2641 2350 
+Q 2622 2356 2575 2375 
+Q 2091 2566 1797 2566 
+Q 1522 2566 1253 2447 
+Q 984 2328 678 2069 
+L 678 2625 
+Q 1006 2869 1286 2976 
+Q 1566 3084 1869 3084 
+Q 2213 3084 2672 2900 
+Q 2703 2888 2719 2881 
+Q 2741 2872 2788 2853 
+Q 3272 2663 3566 2663 
+Q 3834 2663 4098 2780 
+Q 4363 2897 4684 3163 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-25" d="M 4653 2053 
+Q 4381 2053 4226 1822 
+Q 4072 1591 4072 1178 
+Q 4072 772 4226 539 
+Q 4381 306 4653 306 
+Q 4919 306 5073 539 
+Q 5228 772 5228 1178 
+Q 5228 1588 5073 1820 
+Q 4919 2053 4653 2053 
+z
+M 4653 2450 
+Q 5147 2450 5437 2106 
+Q 5728 1763 5728 1178 
+Q 5728 594 5436 251 
+Q 5144 -91 4653 -91 
+Q 4153 -91 3862 251 
+Q 3572 594 3572 1178 
+Q 3572 1766 3864 2108 
+Q 4156 2450 4653 2450 
+z
+M 1428 4353 
+Q 1159 4353 1004 4120 
+Q 850 3888 850 3481 
+Q 850 3069 1003 2837 
+Q 1156 2606 1428 2606 
+Q 1700 2606 1854 2837 
+Q 2009 3069 2009 3481 
+Q 2009 3884 1853 4118 
+Q 1697 4353 1428 4353 
+z
+M 4250 4750 
+L 4750 4750 
+L 1831 -91 
+L 1331 -91 
+L 4250 4750 
+z
+M 1428 4750 
+Q 1922 4750 2215 4408 
+Q 2509 4066 2509 3481 
+Q 2509 2891 2217 2550 
+Q 1925 2209 1428 2209 
+Q 931 2209 642 2551 
+Q 353 2894 353 3481 
+Q 353 4063 643 4406 
+Q 934 4750 1428 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-68"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(63.378906 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(124.658203 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(176.757812 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(240.136719 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(290.136719 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(329.345703 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(368.208984 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(429.732422 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(491.255859 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(541.255859 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(580.119141 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(641.300781 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(702.482422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(741.691406 0)"/>
+     <use xlink:href="#DejaVuSans-2248" transform="translate(773.478516 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(857.267578 0)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(889.054688 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(972.84375 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(1036.466797 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(1100.089844 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1131.876953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1195.5 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1227.287109 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1324.699219 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1376.798828 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1408.585938 0)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(1447.599609 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(1531.388672 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(1595.011719 0)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(1658.634766 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1753.654297 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- Real SSZ hash_tree_root cost vs the ZERO stub (state_transition, A=8 valid attestations) -->
+    <g transform="translate(91.848437 15.558281) scale(0.11 -0.11)">
+     <defs>
+      <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-52"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(64.982422 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(126.505859 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(187.785156 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(215.568359 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(247.355469 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(310.832031 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(374.308594 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(442.814453 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(474.601562 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(537.980469 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(599.259766 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(651.359375 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(714.738281 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(764.738281 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(803.947266 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(842.810547 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(904.333984 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(965.857422 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1015.857422 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1054.720703 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1115.902344 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1177.083984 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1216.292969 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1248.080078 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1303.060547 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1364.242188 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1416.341797 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1455.550781 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1487.337891 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1546.517578 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1598.617188 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1630.404297 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1669.613281 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1732.992188 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1794.515625 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(1826.302734 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1894.808594 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1957.992188 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2027.474609 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2106.185547 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2137.972656 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2190.072266 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(2229.28125 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2292.660156 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2356.136719 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2387.923828 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2426.9375 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2479.037109 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2518.246094 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2579.525391 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2618.734375 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(2680.257812 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2730.257812 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2769.466797 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2810.580078 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2871.859375 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2935.238281 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2987.337891 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3015.121094 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3054.330078 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3082.113281 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3143.294922 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(3206.673828 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3238.460938 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(3270.248047 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(3338.65625 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(3422.445312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3486.068359 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(3517.855469 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3577.035156 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3638.314453 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3666.097656 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(3693.880859 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3757.357422 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3789.144531 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3850.423828 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3889.632812 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3928.841797 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3990.365234 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4042.464844 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(4081.673828 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4142.953125 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(4182.162109 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4209.945312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4271.126953 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4334.505859 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(4386.605469 0)"/>
+    </g>
+   </g>
+   <g id="line2d_118">
+    <path d="M 77.531687 323.013214 
+L 128.515918 321.201567 
+L 281.46861 300.338905 
+L 434.421302 240.46646 
+L 587.373994 156.37134 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+    <defs>
+     <path id="mdc6000b36a" d="M -3 3 
+L 3 3 
+L 3 -3 
+L -3 -3 
+z
+" style="stroke: #9467bd; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#pad614e34c7)">
+     <use xlink:href="#mdc6000b36a" x="77.531687" y="323.013214" style="fill: #ffffff; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc6000b36a" x="128.515918" y="321.201567" style="fill: #ffffff; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc6000b36a" x="281.46861" y="300.338905" style="fill: #ffffff; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc6000b36a" x="434.421302" y="240.46646" style="fill: #ffffff; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc6000b36a" x="587.373994" y="156.37134" style="fill: #ffffff; stroke: #9467bd; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_119">
+    <path d="M 77.531687 323.204103 
+L 128.515918 316.380841 
+L 281.46861 285.192773 
+L 434.421302 218.845897 
+L 587.373994 130.503904 
+" clip-path="url(#pad614e34c7)" style="fill: none; stroke: #1f77b4; stroke-width: 2.2; stroke-linecap: square"/>
+    <defs>
+     <path id="m42e6b6e0f6" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#pad614e34c7)">
+     <use xlink:href="#m42e6b6e0f6" x="77.531687" y="323.204103" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m42e6b6e0f6" x="128.515918" y="316.380841" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m42e6b6e0f6" x="281.46861" y="285.192773" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m42e6b6e0f6" x="434.421302" y="218.845897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m42e6b6e0f6" x="587.373994" y="130.503904" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 71.877656 61.429219 
+L 326.213437 61.429219 
+Q 328.013438 61.429219 328.013438 59.629219 
+L 328.013438 33.858281 
+Q 328.013438 32.058281 326.213437 32.058281 
+L 71.877656 32.058281 
+Q 70.077656 32.058281 70.077656 33.858281 
+L 70.077656 59.629219 
+Q 70.077656 61.429219 71.877656 61.429219 
+z
+" style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_120">
+     <path d="M 73.677656 39.346875 
+L 82.677656 39.346875 
+L 91.677656 39.346875 
+" style="fill: none; stroke: #1f77b4; stroke-width: 2.2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m42e6b6e0f6" x="82.677656" y="39.346875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- STF pipeline — real SSZ hash_tree_root (SHA-256) -->
+     <g transform="translate(98.877656 42.496875) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 628 4666 
+L 1259 4666 
+L 1259 2753 
+L 3553 2753 
+L 3553 4666 
+L 4184 4666 
+L 4184 0 
+L 3553 0 
+L 3553 2222 
+L 1259 2222 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(124.560547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(182.080078 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.867188 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(277.34375 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(305.126953 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(368.603516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(430.126953 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(457.910156 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(485.693359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(549.072266 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(610.595703 0)"/>
+      <use xlink:href="#DejaVuSans-2014" transform="translate(642.382812 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(742.382812 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(774.169922 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(813.033203 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(874.556641 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(935.835938 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(963.619141 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(995.40625 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1058.882812 0)"/>
+      <use xlink:href="#DejaVuSans-5a" transform="translate(1122.359375 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1190.865234 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1222.652344 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1286.03125 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1347.310547 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1399.410156 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(1462.789062 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1512.789062 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1551.998047 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1590.861328 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1652.384766 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(1713.908203 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1763.908203 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1802.771484 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1863.953125 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1925.134766 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1964.34375 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1996.130859 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(2035.144531 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(2098.621094 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(2173.816406 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(2239.974609 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(2276.058594 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(2339.681641 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(2403.304688 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2466.927734 0)"/>
+     </g>
+    </g>
+    <g id="line2d_121">
+     <path d="M 73.677656 52.8075 
+L 82.677656 52.8075 
+L 91.677656 52.8075 
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+     <g>
+      <use xlink:href="#mdc6000b36a" x="82.677656" y="52.8075" style="fill: #ffffff; stroke: #9467bd; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_19">
+     <!-- STF pipeline — HTR = ZERO stub (pre-#5) -->
+     <g transform="translate(98.877656 55.9575) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-23" d="M 3272 2816 
+L 2363 2816 
+L 2100 1772 
+L 3016 1772 
+L 3272 2816 
+z
+M 2803 4594 
+L 2478 3297 
+L 3391 3297 
+L 3719 4594 
+L 4219 4594 
+L 3897 3297 
+L 4872 3297 
+L 4872 2816 
+L 3775 2816 
+L 3519 1772 
+L 4513 1772 
+L 4513 1294 
+L 3397 1294 
+L 3072 0 
+L 2572 0 
+L 2894 1294 
+L 1978 1294 
+L 1656 0 
+L 1153 0 
+L 1478 1294 
+L 494 1294 
+L 494 1772 
+L 1594 1772 
+L 1856 2816 
+L 850 2816 
+L 850 3297 
+L 1978 3297 
+L 2297 4594 
+L 2803 4594 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(124.560547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(182.080078 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.867188 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(277.34375 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(305.126953 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(368.603516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(430.126953 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(457.910156 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(485.693359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(549.072266 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(610.595703 0)"/>
+      <use xlink:href="#DejaVuSans-2014" transform="translate(642.382812 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(742.382812 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(774.169922 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(849.365234 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(910.449219 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(979.931641 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(1011.71875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1095.507812 0)"/>
+      <use xlink:href="#DejaVuSans-5a" transform="translate(1127.294922 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(1195.800781 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1258.984375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(1328.466797 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1407.177734 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1438.964844 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1491.064453 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1530.273438 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(1593.652344 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1657.128906 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1688.916016 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1727.929688 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1791.40625 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1830.269531 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1891.792969 0)"/>
+      <use xlink:href="#DejaVuSans-23" transform="translate(1927.876953 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(2011.666016 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2075.289062 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pad614e34c7">
+   <rect x="65.577656" y="27.558281" width="539.35" height="315.29875"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -1,6 +1,6 @@
 ---
 title: Rust ↔ Lean 4 FFI ベンチマーク 実測結果
-last_updated: 2026-06-25
+last_updated: 2026-06-26
 tags:
   - benchmark
   - ffi
@@ -34,7 +34,7 @@ tags:
 
 ## 重要な前提と限界
 
-1. **暗号コストは除外** (A3): `hash_tree_root_*` は ZERO スタブ (`Funs/Types.lean:138-156`)。本物の SSZ ハッシュ計算は加算されない。
+1. **`hash_tree_root` は実 SHA-256 で計算される** (issue #5, §1b): 旧 ZERO スタブを廃し、`ConsensusLean4.Merkle`(純 Lean SSZ merkleize)＋ Rust `@[extern]` の SHA-256(sha2 crate)で本物の root を計算する。step4 の state_root 照合と `process_block_header` の parent_root 照合は live。**ただし署名検証(XMSS)は依然 STF 外で未計測**(§4e)。
 2. **Bench fixture は spec 標準ワークロード**:
    - `state_transition`: V validators の State + **A = `MAX_ATTESTATIONS_DATA` = 8 個の有効 AggregatedAttestation** を載せた Block。`processAttestationsFast` の `O(A·V)` ホットループが実際に走る (§1)。8 票はすべて `voteIsValid` を通り、かつ 2/3 finalize 閾値未満を維持 (fast path 継続)。**旧版は A=0 の空ブロックで構築コストのみを測っていた**ため、本再測で STF 本体に置き換えた。
    - `compute_lmd_ghost_head`: 線形チェーン B blocks + A attestations が最終 block にすべて投票。`alloc.vec.Vec` が `List`-backed のため、内部の block index は `List.indexOf` ベースで O(B)。**V 軸を持たない** (B blocks / A attestations でスケール、B ≤ `HISTORICAL_ROOTS_LIMIT = 2^18`) ため V 上限の修正対象外で、本再測では §2 の旧値を据え置く。
@@ -97,6 +97,37 @@ fixture は `is_valid_vote` / `slot_is_justifiable_after` / `current_proposer` (
 ![state_transition scaling: leanSpec V ≤ 4096 vs mainnet 1M](./assets/bench-scaling.svg)
 
 log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spec (V > 4096)。spec 上限 V=4096 でも STF pipeline は 15 ms で SLO target 200 ms の下、marshal は更に 3 桁下。V=1M は両 budget を突破 (4.17 s) し、leanSpec モデルでは到達不能。データは本節 §1 / §4c の実測値 (2026-06-25, AMD Ryzen 9 PRO 8945HS)。
+
+> **注**: 上表・上図は `hash_tree_root` を ZERO スタブにした値。**実 SHA-256 HTR を有効にした再測は §1b**。
+
+## 1b. `state_transition` — 実 `hash_tree_root` (SHA-256) 込み (issue #5)
+
+§1 の値は HTR を ZERO スタブにしていた(照合が vacuous)。本節は **実 SSZ `hash_tree_root` を STF に組み込んだ**再測。実装:
+
+- **`ConsensusLean4.Merkle`**(純 Lean): leanSpec `spec/crypto/merkleization.py` 準拠の SSZ merkleize(32B chunk → `next_pow2` zero-padding → 二分木 → `mix_in_length`)。State/Block 全型の `hash_tree_root`。
+- **SHA-256**: Rust `@[extern "csf_sha256"]`(sha2 crate)を C shim 経由で呼ぶ。leanSpec の HTR は **SHA-256**(SHA-2、`merkleization.py` の `from hashlib import sha256`)であり Poseidon ではない。Poseidon2/KoalaBear は XMSS 署名専用。
+- **検証**: `csf_selftest_htr` が uint64 LE 詰め・2-leaf merkleize・正準 SSZ `zerohashes[1] = sha256(64 zeros) = f5a5fd42…fb4b` に一致(published vector)。
+- **fixture root-consistent 化**: HTR が live になると `parent_root`/`state_root` 照合が本物になるため、`mkConsistentBlock` で `parent_root = htr(advanced header)`・`state_root = htr(post-state)` を逆算(循環なし: post-state は `block.state_root` を読まない)。paired-delta は prep-cancellation(run と buildonly が同じ prep を踏み、Δ が実 HTR 込み STF を 1 回だけ抽出)。
+
+### 計測結果 (V = 4 … 4096、A=8 valid attestations、5 trials)
+
+| V | run median | buildonly | **pipeline (Δ, 実 HTR 込み)** | §1 stub Δ | HTR 増分 | sentinel |
+|---:|---:|---:|---:|---:|---:|:---:|
+| 4 | 707.3 µs | 391.8 µs | **315.5 µs** | 316.9 µs | ~0 | 0 |
+| 8 | 815.0 µs | 445.4 µs | **369.6 µs** | 330.5 µs | +12% | 0 |
+| 64 | 1.83 ms | 1.06 ms | **761.9 µs** | 536.2 µs | +42% | 0 |
+| 512 | 10.91 ms | 7.36 ms | **3.55 ms** | 2.15 ms | +65% | 0 |
+| 4096 (spec max) | 75.68 ms | 48.14 ms | **27.55 ms** | 15.12 ms | **+82%** | 0 |
+
+![real hash_tree_root cost vs ZERO stub](./assets/htr-cost.svg)
+
+### 判定・観察
+
+- **spec 上限 V=4096 でも 27.55 ms で 🟢 green**(SLO target 200 ms の 1/7)。実 HTR を入れても 1 スロット ~4 s の世界では余裕。
+- **HTR 増分は V とともに拡大**(+0% → +82%)。小 V は 8 票分の `voteIsValid` 固定費が支配で HTR の相対比が小さく、大 V では post-state の merkleize(O(V) validators + O(R·V) justification bits を SHA-256 で畳む)が効いて ~+12 ms。HTR コストは V に概ね線形。
+- **paired-delta の整合**: V=4096 で run 75.68 = build 16 + 2×STF(27.55)、buildonly 48.14 = build + 1×STF。Δ = 実 HTR 込み STF を 1 回分、正しく抽出。
+- **att_cells = 9 を維持**: 実 HTR 化後も 8 票はすべて有効処理(root 整合化は投票の有効性に影響しない)。
+- **依然 STF 外**: 署名検証(XMSS/Poseidon)は未計測(§4e ①)。本節は「実 HTR 込み・署名検証なし」の値。
 
 ## 2. `compute_lmd_ghost_head` (Aeneas direct, no fast path)
 
@@ -335,34 +366,36 @@ def state_transition(state, block, valid_signatures=True):
 |---|---|---|
 | 2. `process_slots` (L135) | `state_transition.process_slots` | ✅ 実装 |
 | 3. `process_block` (L332) | `processBlockFast` | ✅ 実装 |
-| ├ `process_block_header` (L195) | `state_transition.process_block_header` | ✅(内部 HTR は stub) |
-| └ `process_attestations` (L385) | `processAttestationsFast` + `try_finalize` | ✅ 実装 |
-| 4. `hash_tree_root` 照合 (L644) | `hash_tree_root_state`→`eq`→`StateRootMismatch` | ⚠️ 枠のみ。HTR は `ok H256.ZERO` stub |
+| ├ `process_block_header` (L195) | `state_transition.process_block_header` | ✅(内部 HTR も実 SHA-256、§1b) |
+| └ `process_attestations` (L385) | `processAttestationsFast` + `try_finalize` | ✅ 実装(§1 で A=8 有効投票を駆動) |
+| 4. `hash_tree_root` 照合 (L644) | `hash_tree_root_state`→`eq`→`StateRootMismatch` | ✅ 実装。HTR は実 SSZ SHA-256(§1b) |
 | 1. `valid_signatures` 前提 (L634) | — | ❌ 引数なし(常に valid 扱い) |
 | `verify_signatures` (L864, 別メソッド) | — | ❌ 完全欠如 |
 
-→ **`state_transition` 本体の step 2・3 は完全、step 4 は構造のみ実装済み。** 欠けているのは関数外の署名検証と、step 4 の実ハッシュ。
+→ **`state_transition` 本体の step 2・3・4 は実装済み**(step4 の HTR は実 SHA-256、§1b)。欠けているのは**関数外の署名検証のみ**。
+
+> **訂正 (issue #5)**: 本節の旧版は「leanSpec の HTR は Poseidon1/KoalaBear(SHA-256 ではない)」と記していたが**誤り**。leanSpec の `hash_tree_root`(`spec/crypto/merkleization.py`)は **SHA-256**(`from hashlib import sha256`)。Poseidon2/KoalaBear は **XMSS 署名**(`spec/crypto/xmss/`)専用で、state root の merkleize には使われない。したがって実 HTR は SHA-256 で実装可能・実装済み(§1b)で、コストも Poseidon ほど大きくない(V=4096 で +12 ms)。
 
 ### realistic STF への差分(実装先つき)
 
-| # | 欠けている処理 | 実装先 | 備考 |
+| # | 欠けている処理 | 実装先 | 状態 |
 |---|---|---|---|
-| ① | `verify_signatures` (L864): 提案者 + 集約署名 (XMSS) | **Rust/FFI**(leanSig/leanMultisig, Plonky3) + 段取りは Lean | leanSpec では STF の外。最大コスト |
-| ② | 実 `hash_tree_root` (step 4 / header 内) | merkleize 構造=**Lean**、**Poseidon1** 置換=Rust/FFI or Lean | leanSpec は **Poseidon1/KoalaBear**(SHA-256 ではない) |
-| ③ | 非空 attestation/justification 入力 | データ(leanSpec テストベクタ) | 現 fixture は空で 3SF 本体が未駆動 |
-| ④ | 正準 SSZ codec | **Lean**(decode) | 現状はフラット自前コーデック |
-| ⑤ | マルチスロット/エポック境界 | **Lean**(既存ロジック) | 入力次第で駆動 |
+| ① | `verify_signatures` (L864): 提案者 + 集約署名 (XMSS) | **Rust/FFI**(leanSig/leanMultisig, Plonky3) + 段取りは Lean | ❌ 未実装。leanSpec では STF の外。**最大コスト**(Poseidon/XMSS) |
+| ② | 実 `hash_tree_root` (step 4 / header 内) | merkleize 構造=**Lean**(`ConsensusLean4.Merkle`)、SHA-256=**Rust `@[extern]`** | ✅ **実装済み(§1b、issue #5)** |
+| ③ | 非空 attestation/justification 入力 | データ | ✅ §1 で A=`MAX_ATTESTATIONS_DATA`=8 有効投票を駆動。**2/3 finalization 遷移は未駆動**(票を 2/3 未満に抑制) |
+| ④ | 正準 SSZ codec | **Lean**(decode) | ⚠️ 現状はフラット自前コーデック(§4d) |
+| ⑤ | マルチスロット/エポック境界 | **Lean**(既存ロジック) | ⚠️ 入力次第で駆動(現 fixture は 1 スロット前進) |
 
-**信頼境界の原則**: 検証対象ロジック (STF / SSZ decode / merkleize 構造 / 署名検証の段取り) は Lean、重い暗号プリミティブ (Poseidon1 置換, XMSS/集約 ZK 検証) は Rust/FFI。`compute_block_weights` (L1370) は STF ではなく fork-choice(§2 `compute_lmd_ghost_head`)で別系統。
+**信頼境界の原則**: 検証対象ロジック (STF / SSZ decode / merkleize 構造 / 署名検証の段取り) は Lean、重い暗号プリミティブ (SHA-256 / XMSS・集約 ZK 検証) は Rust/FFI。§1b の実 HTR がこの境界の最初の実例(merkleize=Lean、SHA-256=Rust `@[extern]`)。`compute_block_weights` (L1370) は STF ではなく fork-choice(§2)で別系統。
 
-**ベンチ解釈への含意**: §1/§4 の数値は「署名検証なし・HTR=ZERO・attestation 空」での値。realistic STF では ① 署名検証(支配項)+ ② Poseidon HTR が加わり、桁が上がる。現数値は **FFI/decode/STF ロジックの下限**として読むこと。
+**ベンチ解釈への含意**: §1b の数値は「実 HTR(SHA-256)込み・**署名検証なし**・A=8・2/3 finalization 未駆動」での値。realistic STF への残差は主に ① 署名検証(支配項)。現数値は **署名検証を除く STF の実コスト**として読むこと。
 
 ## 5. Future work
 
 `docs/ffi-feasibility.md` に既出の項目を実数値で裏付け:
 
 - **issue #4** (Option III SSZ): bench fixture を SSZ バイト列マーシャルに切り替え、ToLean 構築コストを排除
-- **issue #5** (`hash_tree_root` real 実装): "crypto cost excluded" 注記が外れた状態で再測
+- ~~**issue #5** (`hash_tree_root` real 実装)~~: **完了(§1b)**。実 SSZ SHA-256 HTR を STF に組み込み再測。V=4096 で 27.55 ms。残課題は署名検証(①)
 - **issue #6** (block-chaining bench): 現 fixture は genesis→1 block のみ。N block chain で連続 state を計測
 - **新規候補** (本実測から): `compute_lmd_ghost_head_fast` (Array-backed) の handwritten 実装。B=10K で 1s 切りが目標
 - **新規候補**: state_transition の "realistic attestation" fixture (R≥1 + valid checkpoints + non-trivial agg_bits) で `processAttestationsFast` の N·A scaling を計測

--- a/rust-ffi/Cargo.lock
+++ b/rust-ffi/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,10 +22,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "libc"
@@ -30,6 +84,18 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "libc",
+ "sha2",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -37,3 +103,15 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"

--- a/rust-ffi/Cargo.toml
+++ b/rust-ffi/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 libc = "0.2"
+sha2 = "0.10"
 
 [build-dependencies]
 cc = "1"

--- a/rust-ffi/csf_marshal_shim.c
+++ b/rust-ffi/csf_marshal_shim.c
@@ -21,3 +21,21 @@ lean_object *csf_make_bytearray(const uint8_t *src, size_t n) {
   }
   return arr;
 }
+
+/* SHA-256 entry point for Lean's `@[extern "csf_sha256"]`.
+ *
+ * Signature matches Lean's compiled `ByteArray -> ByteArray`:
+ * `data` is an owned `lean_sarray` argument (consumed here); the return is a
+ * freshly-allocated owned 32-byte `lean_sarray`. The actual hashing is done in
+ * Rust (`csf_sha256_raw`, src/sha_extern.rs, sha2 crate); this wrapper only
+ * bridges the Lean object ABI that needs lean.h's static-inline accessors. */
+void csf_sha256_raw(const uint8_t *src, size_t n, uint8_t *out);
+
+lean_object *csf_sha256(lean_object *data) {
+  size_t n = lean_sarray_size(data);
+  const uint8_t *src = lean_sarray_cptr(data);
+  lean_object *out = lean_alloc_sarray(1, 32, 32);
+  csf_sha256_raw(src, n, lean_sarray_cptr(out));
+  lean_dec(data); /* owned argument */
+  return out;
+}

--- a/rust-ffi/src/bin/bench-ffi-marshal.rs
+++ b/rust-ffi/src/bin/bench-ffi-marshal.rs
@@ -25,6 +25,11 @@ use std::hint::black_box;
 use std::ptr;
 use std::time::{Duration, Instant};
 
+// Provides `csf_sha256_raw` for the `csf_sha256` shim that ConsensusLean4
+// references via `@[extern]`; every binary linking the Lean lib needs it.
+#[path = "../sha_extern.rs"]
+mod sha_extern;
+
 #[link(name = "Init_shared")]
 extern "C" {
     fn lean_initialize_runtime_module();

--- a/rust-ffi/src/bin/bench-ffi-overhead.rs
+++ b/rust-ffi/src/bin/bench-ffi-overhead.rs
@@ -21,6 +21,11 @@ use std::hint::black_box;
 use std::ptr;
 use std::time::{Duration, Instant};
 
+// Provides `csf_sha256_raw` for the `csf_sha256` shim that ConsensusLean4
+// references via `@[extern]`; every binary linking the Lean lib needs it.
+#[path = "../sha_extern.rs"]
+mod sha_extern;
+
 #[link(name = "Init_shared")]
 extern "C" {
     fn lean_initialize_runtime_module();

--- a/rust-ffi/src/bin/bench-ffi-ssz.rs
+++ b/rust-ffi/src/bin/bench-ffi-ssz.rs
@@ -27,6 +27,11 @@ use std::hint::black_box;
 use std::ptr;
 use std::time::{Duration, Instant};
 
+// Provides `csf_sha256_raw` for the `csf_sha256` shim that ConsensusLean4
+// references via `@[extern]`; every binary linking the Lean lib needs it.
+#[path = "../sha_extern.rs"]
+mod sha_extern;
+
 #[link(name = "Init_shared")]
 extern "C" {
     fn lean_initialize_runtime_module();

--- a/rust-ffi/src/bin/bench-ffi-ssz.rs
+++ b/rust-ffi/src/bin/bench-ffi-ssz.rs
@@ -155,9 +155,20 @@ struct Row {
 fn bench_cell(n: u64) -> Row {
     let buf = serialize_fixture(n);
 
-    // Correctness gate: the decoded fixture must transition cleanly (Ok = 0).
+    // Codec gate: the decoded fixture must reach a deterministic sentinel.
+    // Since hash_tree_root is now live (real SHA-256), this synthetic flat fixture
+    // carries ZERO parent_root/state_root, so the STF bails at the parent-root
+    // check with InvalidParent (sentinel 1) rather than Ok. That is expected and
+    // fine here: this bench's subject is the marshal/decode byte-boundary split,
+    // not STF completion — the STF column reflects decode + the process_slots
+    // hash_tree_root(state) up to the parent-root check. A 2 (Aeneas fail) or 3
+    // (div) would indicate a real codec break.
     let sentinel = unsafe { csf_bench_state_transition_ssz_run(csf_make_bytearray(buf.as_ptr(), buf.len())) };
-    assert_eq!(sentinel, 0, "N={n}: ssz_run sentinel must be 0 (Ok), got {sentinel} — codec mismatch");
+    assert!(
+        sentinel == 0 || sentinel == 1,
+        "N={n}: ssz_run sentinel must be 0 (Ok) or 1 (InvalidParent, expected under live HTR), \
+         got {sentinel} — codec break"
+    );
 
     let marshal = bench(&buf, csf_bench_marshal_noop);
     let decode_total = bench(&buf, csf_bench_state_transition_ssz_decode);
@@ -183,7 +194,9 @@ fn main() {
 
     println!("# End-to-end SSZ-bytes pipeline: marshal → decode → pure STF");
     println!();
-    println!("Fixture = §1 buildBenchState(n)/buildBenchBlock(n), serialized. Codec gate: sentinel 0 (Ok).");
+    println!("Fixture = empty-block buildBenchState(n)/buildBenchBlock(n), serialized (flat codec, not canonical SSZ).");
+    println!("hash_tree_root is now live (SHA-256): the ZERO-root flat fixture bails at the parent-root check");
+    println!("(sentinel 1, InvalidParent), so STF = decode + process_slots htr(state). marshal/decode are the subject.");
     println!();
     println!("| N | payload | marshal | decode | STF | total (e2e) |");
     println!("|---:|---:|---:|---:|---:|---:|");
@@ -205,7 +218,7 @@ fn main() {
     println!();
     println!(
         "> marshal = alloc+memcpy+dec_ref; decode = ssz_decode−marshal (bytes→typed State/Block); \
-         STF = ssz_run−ssz_decode (pure stateTransitionFast). Trials={TRIALS}. \
-         Flat codec, no canonical SSZ / hash_tree_root."
+         STF = ssz_run−ssz_decode (stateTransitionFast; bails at parent-root htr for this flat fixture). \
+         Trials={TRIALS}. Flat codec (not canonical SSZ); hash_tree_root itself is real SHA-256."
     );
 }

--- a/rust-ffi/src/bin/bench-fork-choice.rs
+++ b/rust-ffi/src/bin/bench-fork-choice.rs
@@ -20,6 +20,11 @@ use std::ffi::c_void;
 use std::ptr;
 use std::time::{Duration, Instant};
 
+// Provides `csf_sha256_raw` for the `csf_sha256` shim that ConsensusLean4
+// references via `@[extern]`; every binary linking the Lean lib needs it.
+#[path = "../sha_extern.rs"]
+mod sha_extern;
+
 #[link(name = "Init_shared")]
 extern "C" {
     fn lean_initialize_runtime_module();

--- a/rust-ffi/src/bin/bench-state-transition.rs
+++ b/rust-ffi/src/bin/bench-state-transition.rs
@@ -20,6 +20,11 @@ use std::ffi::c_void;
 use std::ptr;
 use std::time::{Duration, Instant};
 
+// Provides `csf_sha256_raw` for the `csf_sha256` shim that ConsensusLean4
+// references via `@[extern]`; every binary linking the Lean lib needs it.
+#[path = "../sha_extern.rs"]
+mod sha_extern;
+
 #[link(name = "Init_shared")]
 extern "C" {
     fn lean_initialize_runtime_module();

--- a/rust-ffi/src/main.rs
+++ b/rust-ffi/src/main.rs
@@ -11,6 +11,11 @@
 use std::ffi::c_void;
 use std::ptr;
 
+// Provides `csf_sha256_raw`, called by the `csf_sha256` C shim that Lean's
+// `@[extern "csf_sha256"]` binds to.
+#[path = "sha_extern.rs"]
+mod sha_extern;
+
 #[link(name = "Init_shared")]
 extern "C" {
     fn lean_initialize_runtime_module();
@@ -25,6 +30,7 @@ extern "C" {
     ) -> *mut c_void;
 
     fn csf_ping(n: u64) -> u64;
+    fn csf_selftest_sha256(seed: u64) -> u8;
     fn csf_smoke_state_transition_ok(seed: u64) -> u8;
     fn csf_smoke_state_transition_err(seed: u64) -> u8;
     fn csf_smoke_compute_lmd_ghost_head_empty(seed: u64) -> u8;
@@ -54,6 +60,11 @@ fn main() {
         // M1 carry-over.
         assert_eq!(csf_ping(41), 42);
         println!("[M1] csf_ping(41) = 42 ✓");
+
+        // SHA-256 @[extern] path: Lean → csf_sha256 (C shim) → csf_sha256_raw (Rust/sha2).
+        let sha = csf_selftest_sha256(0);
+        assert_eq!(sha, 0, "SHA-256(\"abc\") @[extern] self-test failed (got {sha})");
+        println!("[sha] csf_selftest_sha256 → 0 ✓ (Lean→C→Rust sha2, NIST \"abc\" vector)");
 
         // M4c stage 2: state_transition pipeline.
         let r_ok = csf_smoke_state_transition_ok(0);

--- a/rust-ffi/src/main.rs
+++ b/rust-ffi/src/main.rs
@@ -31,6 +31,7 @@ extern "C" {
 
     fn csf_ping(n: u64) -> u64;
     fn csf_selftest_sha256(seed: u64) -> u8;
+    fn csf_selftest_htr(seed: u64) -> u8;
     fn csf_smoke_state_transition_ok(seed: u64) -> u8;
     fn csf_smoke_state_transition_err(seed: u64) -> u8;
     fn csf_smoke_compute_lmd_ghost_head_empty(seed: u64) -> u8;
@@ -65,6 +66,12 @@ fn main() {
         let sha = csf_selftest_sha256(0);
         assert_eq!(sha, 0, "SHA-256(\"abc\") @[extern] self-test failed (got {sha})");
         println!("[sha] csf_selftest_sha256 → 0 ✓ (Lean→C→Rust sha2, NIST \"abc\" vector)");
+
+        // SSZ hash_tree_root self-test: uint64 LE packing + 2-leaf merkleize vs
+        // the canonical SSZ zerohashes[1] = sha256(64 zeros).
+        let htr = csf_selftest_htr(0);
+        assert_eq!(htr, 0, "SSZ hash_tree_root self-test failed (got {htr})");
+        println!("[htr] csf_selftest_htr → 0 ✓ (uint64 LE, merkleize, zerohashes[1])");
 
         // M4c stage 2: state_transition pipeline.
         let r_ok = csf_smoke_state_transition_ok(0);

--- a/rust-ffi/src/sha_extern.rs
+++ b/rust-ffi/src/sha_extern.rs
@@ -1,0 +1,35 @@
+// SHA-256 primitive exposed to Lean via @[extern].
+//
+// leanSpec's `hash_tree_root` (spec/crypto/merkleization.py) uses SHA-256.
+// The Lean side owns the SSZ merkleization structure (chunking, the binary
+// tree, mix_in_length) and calls down to this single compression-grade
+// primitive for the heavy work — matching the trust boundary in
+// docs/rust-ffi-benchmarks.md §4e ("merkleize structure = Lean, primitive =
+// Rust/FFI").
+//
+// The Lean ABI (reading the input `lean_sarray`, allocating the 32-byte output
+// `lean_sarray`, dec_ref of the owned argument) lives in `csf_marshal_shim.c`
+// because `lean_alloc_sarray`/`lean_sarray_cptr` are `static inline` in lean.h
+// and cannot be linked from Rust. That C shim calls this function.
+//
+// This module is `#[path]`-included into every binary that links the Lean
+// static lib (which references `csf_sha256`), so the `#[no_mangle]` symbol is
+// present in each final executable.
+
+/// Compute SHA-256 of `n` bytes at `src`, writing the 32-byte digest to `out`.
+///
+/// # Safety
+/// `src` must point to `n` readable bytes (or `n == 0`), and `out` must point
+/// to 32 writable bytes. Called only from the C shim with pointers obtained
+/// from a live Lean `lean_sarray`.
+#[no_mangle]
+pub unsafe extern "C" fn csf_sha256_raw(src: *const u8, n: usize, out: *mut u8) {
+    use sha2::{Digest, Sha256};
+    let data: &[u8] = if n == 0 {
+        &[]
+    } else {
+        std::slice::from_raw_parts(src, n)
+    };
+    let digest = Sha256::digest(data);
+    std::ptr::copy_nonoverlapping(digest.as_ptr(), out, 32);
+}


### PR DESCRIPTION
> **Stacked on #22** (spec-realistic A=8 benches). Base auto-retargets to `main` once #22 merges. Diff shown here is HTR-only.

## Why (issue #5)

The STF's `hash_tree_root` was a `ok H256.ZERO` stub, so the `state_root` and `parent_root` checks were **vacuous** — two different valid post-states hashed identically and the comparison always passed. This PR computes the real SSZ root, making those checks meaningful, and re-measures.

A side correction: the docs previously claimed leanSpec's HTR is Poseidon1/KoalaBear. That was **wrong** — `spec/crypto/merkleization.py` uses `from hashlib import sha256`. Poseidon2/KoalaBear is XMSS-signature only. So HTR is implementable with SHA-256 (and is far cheaper than Poseidon would have been).

## What

- **`Sha.lean`** — `csfSha256 : ByteArray → ByteArray` via Rust `@[extern "csf_sha256"]`. The Lean object ABI (read sarray / alloc 32-byte output / dec_ref) lives in the C shim `csf_marshal_shim.c`; the hashing is Rust (`src/sha_extern.rs`, `sha2` crate). Trust boundary per §4e: merkleize structure = Lean, primitive = Rust/FFI.
- **`Merkleization.lean`** — pure-Lean SSZ `hash_tree_root` faithful to `merkleization.py` (32-byte chunks, `next_pow2` zero-padding with cached zero-subtree roots, `mix_in_length`, basic-type packing, container field roots) for the whole State/Block type tree.
- **`Funs/Types.lean`** — the 3 generated `hash_tree_root_*` stubs hand-swapped from `ok H256.ZERO` to `Merkle.*`. ⚠️ generated file — re-running Aeneas reverts them (regen note in README/CLAUDE).
- **`Ffi.lean`** — `mkConsistentBlock` derives `parent_root = htr(advanced header)` and `state_root = htr(post-state)` (no circularity: the post-state never reads `block.state_root`). The A=8 bench uses prep-cancellation paired-delta so Δ isolates exactly one real-HTR transition.
- **`bench-ffi-ssz.rs`** — its synthetic flat ZERO-root fixture now bails at the live parent-root check (sentinel 1); gate relaxed to accept it (that bench's subject is the marshal/decode split).

## Verification (published vectors + self-tests, asserted at smoke startup)

- `csf_selftest_sha256 → 0` — SHA-256("abc") = `ba7816bf…20015ad` (NIST FIPS-180).
- `csf_selftest_htr → 0` — uint64 LE packing, 2-leaf merkleize, and `merkleize([0,0]) = sha256(64 zeros) = f5a5fd42…fb4b` (canonical SSZ `zerohashes[1]`).
- smoke `state_transition_ok → 0`, `att_cells(V=64) → 9`, all A=8 cells sentinel 0.

## Results — real SHA-256 HTR vs ZERO stub (A=8, AMD Ryzen 9 PRO 8945HS)

![real hash_tree_root cost vs ZERO stub](https://raw.githubusercontent.com/NyxFoundation/consensus-ffi-poc/feat/hash-tree-root/docs/assets/htr-cost.svg)

| V | pipeline Δ (real HTR) | stub Δ (#22) | HTR overhead | sentinel |
|---:|---:|---:|---:|:---:|
| 4 | 315.5 µs | 316.9 µs | ~0 | 0 |
| 8 | 369.6 µs | 330.5 µs | +12% | 0 |
| 64 | 761.9 µs | 536.2 µs | +42% | 0 |
| 512 | 3.55 ms | 2.15 ms | +65% | 0 |
| **4096 (spec max)** | **27.55 ms** | 15.12 ms | **+82%** | 0 |

Real HTR adds the post-state SSZ merkleize (O(V) validators + O(R·V) justification bits, SHA-256) — ~+12 ms at the spec ceiling. **Still 🟢 green** (27.55 ms ≪ 200 ms SLO). The remaining STF gap is signature verification (XMSS), which stays outside the STF in leanSpec.

## Verify

`lake build ConsensusLean4:static && (cd rust-ffi && cargo build --release)`; run `rust-ffi` (self-tests pass), `bench-state-transition` (att_cells=9, sentinel 0, V=4096 ≈ 27.5 ms).
