### PR TITLE
docs(ffi): SHA-256 hash_tree_root benchmark chart (incl. V=1M reference)

### DIFF
--- a/docs/assets/bench-htr-results-baseline-full.svg
+++ b/docs/assets/bench-htr-results-baseline-full.svg
@@ -1,0 +1,3501 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="681.955pt" height="397.00476pt" viewBox="0 0 681.955 397.00476" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7+dfsg1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 397.00476 
+L 681.955 397.00476 
+L 681.955 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 77.70152 341.75815 
+L 645.49152 341.75815 
+L 645.49152 35.04925 
+L 77.70152 35.04925 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 384.650572 341.75815 
+L 645.49152 341.75815 
+L 645.49152 35.04925 
+L 384.650572 35.04925 
+z
+" clip-path="url(#p19ac95b25d)" style="fill: #d62728; opacity: 0.06"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 84.733532 341.75815 
+L 84.733532 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m3fd96c78d8" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m3fd96c78d8" x="84.733532" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 4 -->
+      <g transform="translate(80.916032 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 114.725236 341.75815 
+L 114.725236 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m3fd96c78d8" x="114.725236" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 8 -->
+      <g transform="translate(110.907736 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 204.700348 341.75815 
+L 204.700348 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m3fd96c78d8" x="204.700348" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 64 -->
+      <g transform="translate(197.065348 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 294.67546 341.75815 
+L 294.67546 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m3fd96c78d8" x="294.67546" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 512 -->
+      <g transform="translate(283.22296 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 384.650572 341.75815 
+L 384.650572 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m3fd96c78d8" x="384.650572" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4096 -->
+      <g transform="translate(369.380572 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 622.531829 341.75815 
+L 622.531829 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m3fd96c78d8" x="622.531829" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1M -->
+      <g transform="translate(613.537454 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-4d" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 94.388705 341.75815 
+L 94.388705 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_14"/>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 102.277555 341.75815 
+L 102.277555 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_16"/>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 108.947482 341.75815 
+L 108.947482 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_18"/>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 119.821577 341.75815 
+L 119.821577 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_20"/>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 154.372113 341.75815 
+L 154.372113 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_22"/>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 171.916135 341.75815 
+L 171.916135 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_24"/>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 184.363816 341.75815 
+L 184.363816 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_26"/>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 194.018989 341.75815 
+L 194.018989 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_28"/>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 201.907839 341.75815 
+L 201.907839 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_30"/>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 208.577766 341.75815 
+L 208.577766 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_32"/>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 214.35552 341.75815 
+L 214.35552 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_34"/>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 219.451861 341.75815 
+L 219.451861 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_36"/>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 254.002397 341.75815 
+L 254.002397 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_38"/>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 271.546419 341.75815 
+L 271.546419 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_40"/>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 283.9941 341.75815 
+L 283.9941 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_42"/>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 293.649273 341.75815 
+L 293.649273 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_44"/>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 301.538123 341.75815 
+L 301.538123 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_46"/>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 308.20805 341.75815 
+L 308.20805 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_48"/>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 313.985804 341.75815 
+L 313.985804 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_50"/>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 319.082145 341.75815 
+L 319.082145 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_52"/>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 353.63268 341.75815 
+L 353.63268 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_54"/>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 371.176703 341.75815 
+L 371.176703 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_56"/>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 383.624384 341.75815 
+L 383.624384 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_58"/>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_59">
+      <path d="M 393.279557 341.75815 
+L 393.279557 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_60"/>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_61">
+      <path d="M 401.168407 341.75815 
+L 401.168407 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_62"/>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_63">
+      <path d="M 407.838334 341.75815 
+L 407.838334 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_64"/>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_65">
+      <path d="M 413.616088 341.75815 
+L 413.616088 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_66"/>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_67">
+      <path d="M 418.712429 341.75815 
+L 418.712429 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_68"/>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_69">
+      <path d="M 453.262964 341.75815 
+L 453.262964 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_70"/>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_71">
+      <path d="M 470.806987 341.75815 
+L 470.806987 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_72"/>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_73">
+      <path d="M 483.254668 341.75815 
+L 483.254668 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_74"/>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_75">
+      <path d="M 492.909841 341.75815 
+L 492.909841 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_76"/>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_77">
+      <path d="M 500.798691 341.75815 
+L 500.798691 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_78"/>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_79">
+      <path d="M 507.468618 341.75815 
+L 507.468618 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_80"/>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_81">
+      <path d="M 513.246372 341.75815 
+L 513.246372 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_82"/>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_83">
+      <path d="M 518.342713 341.75815 
+L 518.342713 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_84"/>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_85">
+      <path d="M 552.893248 341.75815 
+L 552.893248 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_86"/>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_87">
+      <path d="M 570.437271 341.75815 
+L 570.437271 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_88"/>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_89">
+      <path d="M 582.884952 341.75815 
+L 582.884952 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_90"/>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_91">
+      <path d="M 592.540125 341.75815 
+L 592.540125 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_92"/>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_93">
+      <path d="M 600.428975 341.75815 
+L 600.428975 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_94"/>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_95">
+      <path d="M 607.098902 341.75815 
+L 607.098902 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_96"/>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_97">
+      <path d="M 612.876656 341.75815 
+L 612.876656 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_98"/>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_99">
+      <path d="M 617.972997 341.75815 
+L 617.972997 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_100"/>
+    </g>
+    <g id="text_7">
+     <!-- validator count  V  (leanSpec VALIDATOR_REGISTRY_LIMIT = 2¹² = 4096) -->
+     <g transform="translate(135.136559 373.869947) scale(0.125 -0.125)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 628 4666 
+L 3578 4666 
+L 3578 4134 
+L 1259 4134 
+L 1259 2753 
+L 3481 2753 
+L 3481 2222 
+L 1259 2222 
+L 1259 531 
+L 3634 531 
+L 3634 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b9" d="M 488 2431 
+L 1125 2431 
+L 1125 4341 
+L 428 4213 
+L 428 4575 
+L 1147 4697 
+L 1575 4697 
+L 1575 2431 
+L 2216 2431 
+L 2216 2088 
+L 488 2088 
+L 488 2431 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b2" d="M 838 2444 
+L 2163 2444 
+L 2163 2088 
+L 294 2088 
+L 294 2431 
+Q 400 2528 597 2703 
+Q 1672 3656 1672 3950 
+Q 1672 4156 1509 4282 
+Q 1347 4409 1081 4409 
+Q 919 4409 728 4354 
+Q 538 4300 313 4191 
+L 313 4575 
+Q 553 4663 761 4706 
+Q 969 4750 1147 4750 
+Q 1600 4750 1872 4544 
+Q 2144 4338 2144 4000 
+Q 2144 3566 1109 2678 
+Q 934 2528 838 2444 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(148.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(176.025391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(239.501953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(300.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(339.990234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(401.171875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(442.285156 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(474.072266 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(529.052734 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(590.234375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(653.613281 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(716.992188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(756.201172 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(787.988281 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(819.775391 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(888.183594 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(919.970703 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(951.757812 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(990.771484 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1018.554688 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1080.078125 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1141.357422 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1204.736328 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1268.212891 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1331.689453 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1393.212891 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1448.193359 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1479.980469 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1542.013672 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1610.421875 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(1666.134766 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1695.626953 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1770.878906 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(1831.537109 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(1892.621094 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1971.332031 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2040.814453 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2090.814453 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(2160.296875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(2223.480469 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2300.970703 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(2330.462891 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2393.939453 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2455.023438 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(2518.130859 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2579.214844 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(2629.214844 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2684.927734 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(2714.419922 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2800.699219 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2830.191406 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2891.275391 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(2923.0625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3006.851562 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(3038.638672 0)"/>
+      <use xlink:href="#DejaVuSans-b9" transform="translate(3102.261719 0)"/>
+      <use xlink:href="#DejaVuSans-b2" transform="translate(3142.349609 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3182.4375 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3214.224609 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3298.013672 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(3329.800781 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(3393.423828 0)"/>
+      <use xlink:href="#DejaVuSans-39" transform="translate(3457.046875 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(3520.669922 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(3584.292969 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_101">
+      <path d="M 77.70152 324.742096 
+L 645.49152 324.742096 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_102">
+      <defs>
+       <path id="m80b72c8de0" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="324.742096" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 300 µs -->
+      <g transform="translate(30.09652 329.301158) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_103">
+      <path d="M 77.70152 295.185795 
+L 645.49152 295.185795 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="295.185795" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 1 ms -->
+      <g transform="translate(41.31277 299.744857) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_105">
+      <path d="M 77.70152 268.215987 
+L 645.49152 268.215987 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="268.215987" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 3 ms -->
+      <g transform="translate(41.31277 272.775049) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_107">
+      <path d="M 77.70152 238.659686 
+L 645.49152 238.659686 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="238.659686" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 10 ms -->
+      <g transform="translate(33.67777 243.218748) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_109">
+      <path d="M 77.70152 211.689878 
+L 645.49152 211.689878 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="211.689878" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 30 ms -->
+      <g transform="translate(33.67777 216.24894) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_111">
+      <path d="M 77.70152 182.133577 
+L 645.49152 182.133577 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="182.133577" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 100 ms -->
+      <g transform="translate(26.04277 186.692639) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_113">
+      <path d="M 77.70152 155.163769 
+L 645.49152 155.163769 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="155.163769" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 300 ms -->
+      <g transform="translate(26.04277 159.722831) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_115">
+      <path d="M 77.70152 125.607468 
+L 645.49152 125.607468 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="125.607468" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1 s -->
+      <g transform="translate(53.00152 130.16653) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_117">
+      <path d="M 77.70152 98.63766 
+L 645.49152 98.63766 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="98.63766" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 3 s -->
+      <g transform="translate(53.00152 103.196722) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_119">
+      <path d="M 77.70152 69.081359 
+L 645.49152 69.081359 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#m80b72c8de0" x="77.70152" y="69.081359" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 10 s -->
+      <g transform="translate(45.36652 73.640421) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_121">
+      <path d="M 77.70152 334.695849 
+L 645.49152 334.695849 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_122"/>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_123">
+      <path d="M 77.70152 317.679795 
+L 645.49152 317.679795 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_124"/>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_125">
+      <path d="M 77.70152 312.201849 
+L 645.49152 312.201849 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_126"/>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_127">
+      <path d="M 77.70152 307.726041 
+L 645.49152 307.726041 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_128"/>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_129">
+      <path d="M 77.70152 303.9418 
+L 645.49152 303.9418 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_130"/>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_131">
+      <path d="M 77.70152 300.663741 
+L 645.49152 300.663741 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_132"/>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_133">
+      <path d="M 77.70152 297.772288 
+L 645.49152 297.772288 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_134"/>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_135">
+      <path d="M 77.70152 278.16974 
+L 645.49152 278.16974 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_136"/>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_137">
+      <path d="M 77.70152 261.153686 
+L 645.49152 261.153686 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_138"/>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_139">
+      <path d="M 77.70152 255.67574 
+L 645.49152 255.67574 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_140"/>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_141">
+      <path d="M 77.70152 251.199932 
+L 645.49152 251.199932 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_142"/>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_143">
+      <path d="M 77.70152 247.415691 
+L 645.49152 247.415691 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_144"/>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_145">
+      <path d="M 77.70152 244.137632 
+L 645.49152 244.137632 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_146"/>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_147">
+      <path d="M 77.70152 241.246179 
+L 645.49152 241.246179 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_148"/>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_149">
+      <path d="M 77.70152 221.643631 
+L 645.49152 221.643631 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_150"/>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_151">
+      <path d="M 77.70152 204.627577 
+L 645.49152 204.627577 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_152"/>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_153">
+      <path d="M 77.70152 199.149631 
+L 645.49152 199.149631 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_154"/>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_155">
+      <path d="M 77.70152 194.673823 
+L 645.49152 194.673823 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_156"/>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_157">
+      <path d="M 77.70152 190.889582 
+L 645.49152 190.889582 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_158"/>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_159">
+      <path d="M 77.70152 187.611523 
+L 645.49152 187.611523 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_160"/>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_161">
+      <path d="M 77.70152 184.72007 
+L 645.49152 184.72007 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_162"/>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_163">
+      <path d="M 77.70152 165.117522 
+L 645.49152 165.117522 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_164"/>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_165">
+      <path d="M 77.70152 148.101468 
+L 645.49152 148.101468 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_166"/>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_167">
+      <path d="M 77.70152 142.623522 
+L 645.49152 142.623522 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_168"/>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_169">
+      <path d="M 77.70152 138.147714 
+L 645.49152 138.147714 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_170"/>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_171">
+      <path d="M 77.70152 134.363473 
+L 645.49152 134.363473 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_172"/>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_173">
+      <path d="M 77.70152 131.085414 
+L 645.49152 131.085414 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_174"/>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_175">
+      <path d="M 77.70152 128.193961 
+L 645.49152 128.193961 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_176"/>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_177">
+      <path d="M 77.70152 108.591413 
+L 645.49152 108.591413 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_178"/>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_179">
+      <path d="M 77.70152 91.575359 
+L 645.49152 91.575359 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_180"/>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_181">
+      <path d="M 77.70152 86.097413 
+L 645.49152 86.097413 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_182"/>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_183">
+      <path d="M 77.70152 81.621605 
+L 645.49152 81.621605 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_184"/>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_185">
+      <path d="M 77.70152 77.837364 
+L 645.49152 77.837364 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_186"/>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_187">
+      <path d="M 77.70152 74.559305 
+L 645.49152 74.559305 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_188"/>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_189">
+      <path d="M 77.70152 71.667852 
+L 645.49152 71.667852 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_190"/>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_191">
+      <path d="M 77.70152 52.065304 
+L 645.49152 52.065304 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_192"/>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_193">
+      <path d="M 77.70152 42.111551 
+L 645.49152 42.111551 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_194"/>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_195">
+      <path d="M 77.70152 35.04925 
+L 645.49152 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_196"/>
+    </g>
+    <g id="text_18">
+     <!-- time per call (log scale) -->
+     <g transform="translate(19.443161 262.100966) rotate(-90) scale(0.125 -0.125)">
+      <defs>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-74"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(39.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(66.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(164.404297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.927734 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(257.714844 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(321.191406 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(382.714844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(423.828125 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(455.615234 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(510.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(571.875 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(599.658203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(627.441406 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(659.228516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(698.242188 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(726.025391 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(787.207031 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(850.683594 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(882.470703 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(934.570312 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(989.550781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1050.830078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1078.613281 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1140.136719 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_197">
+    <path d="M 384.650572 341.75815 
+L 384.650572 35.04925 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_198">
+    <path d="M 77.70152 165.117522 
+L 645.49152 165.117522 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 1.82,2.34; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.3"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 77.70152 341.75815 
+L 77.70152 35.04925 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 645.49152 341.75815 
+L 645.49152 35.04925 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 77.70152 341.75815 
+L 645.49152 341.75815 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 77.70152 35.04925 
+L 645.49152 35.04925 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_199">
+    <path d="M 77.70152 324.742096 
+L 645.49152 324.742096 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 9.9,4.32; stroke-dashoffset: 0; stroke: #7d3c98; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_200">
+    <path d="M 77.70152 389.538075 
+L 645.49152 67.397476 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 9.9,4.32; stroke-dashoffset: 0; stroke: #d9730d; stroke-width: 1.8"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 622.531829 77.195287 
+Q 622.531829 70.076719 622.531829 62.958151 
+" style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 624.531829 73.195287 
+L 622.531829 77.195287 
+L 620.531829 73.195287 
+" style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 620.531829 66.958151 
+L 622.531829 62.958151 
+L 624.531829 66.958151 
+" style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_19">
+    <!-- ≈2.3× -->
+    <g style="fill: #b01010" transform="translate(587.502454 72.695317) scale(0.095 -0.095)">
+     <defs>
+      <path id="DejaVuSans-2248" d="M 4684 1947 
+L 4684 1388 
+Q 4356 1144 4076 1036 
+Q 3797 928 3494 928 
+Q 3150 928 2694 1113 
+Q 2663 1125 2641 1134 
+Q 2622 1141 2575 1159 
+Q 2091 1350 1797 1350 
+Q 1522 1350 1253 1231 
+Q 984 1113 678 850 
+L 678 1409 
+Q 1006 1653 1286 1761 
+Q 1566 1869 1869 1869 
+Q 2213 1869 2672 1684 
+Q 2706 1669 2722 1663 
+Q 2741 1656 2788 1638 
+Q 3272 1447 3566 1447 
+Q 3834 1447 4098 1564 
+Q 4363 1681 4684 1947 
+z
+M 4684 3163 
+L 4684 2606 
+Q 4356 2359 4076 2251 
+Q 3797 2144 3494 2144 
+Q 3150 2144 2694 2328 
+Q 2663 2341 2641 2350 
+Q 2622 2356 2575 2375 
+Q 2091 2566 1797 2566 
+Q 1522 2566 1253 2447 
+Q 984 2328 678 2069 
+L 678 2625 
+Q 1006 2869 1286 2976 
+Q 1566 3084 1869 3084 
+Q 2213 3084 2672 2900 
+Q 2703 2888 2719 2881 
+Q 2741 2872 2788 2853 
+Q 3272 2663 3566 2663 
+Q 3834 2663 4098 2780 
+Q 4363 2897 4684 3163 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-d7" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2248"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(179.199219 0)"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(242.822266 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 324 µs -->
+    <g style="fill: #0b3d6e" transform="translate(65.814782 311.773093) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 344 µs -->
+    <g style="fill: #0b3d6e" transform="translate(95.806486 310.302655) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 712 µs -->
+    <g style="fill: #0b3d6e" transform="translate(185.781598 292.444839) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 3.85 ms -->
+    <g style="fill: #0b3d6e" transform="translate(272.478585 251.01229) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(254.443359 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 26.40 ms -->
+    <g style="fill: #0b3d6e" transform="translate(359.272447 203.748369) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
+    </g>
+   </g>
+   <g id="patch_9">
+    <path d="M 223.800895 273.200101 
+Q 291.833425 216.204662 381.420299 214.869429 
+" style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 377.390937 212.929261 
+L 381.420299 214.869429 
+L 377.450548 216.928817 
+z
+" style="fill: #0b6e0b; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_25">
+    <!-- V=4096 (leanSpec max) -->
+    <g style="fill: #0b6e0b" transform="translate(147.396516 284.086214) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(215.820312 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(279.443359 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(343.066406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(406.689453 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(438.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(477.490234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(505.273438 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(566.796875 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(628.076172 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(691.455078 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(754.931641 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(818.408203 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(879.931641 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(934.912109 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(966.699219 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1064.111328 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(1125.390625 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1184.570312 0)"/>
+    </g>
+    <!-- 26.40 ms — green, 8× under 200 ms budget -->
+    <g style="fill: #0b6e0b" transform="translate(96.28636 295.284027) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(467.578125 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(499.365234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(599.365234 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(631.152344 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(694.628906 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(733.492188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(795.015625 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(856.539062 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(919.917969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(951.705078 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(983.492188 0)"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(1047.115234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1130.904297 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1162.691406 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1226.070312 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1289.449219 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1352.925781 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1414.449219 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1455.5625 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(1487.349609 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1550.972656 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1614.595703 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1678.21875 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1710.005859 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1807.417969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1859.517578 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1891.304688 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1954.78125 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2018.160156 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2081.636719 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2145.113281 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2206.636719 0)"/>
+    </g>
+   </g>
+   <g id="patch_10">
+    <path d="M 554.883999 83.640054 
+Q 588.26662 76.971805 619.65347 61.179792 
+" style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 615.181348 61.191015 
+L 619.65347 61.179792 
+L 616.979176 64.764223 
+z
+" style="fill: #b01010; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_26">
+    <!-- V=1M (out-of-spec): 14.64 s — over budget -->
+    <g style="fill: #b01010" transform="translate(325.560969 74.306266) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(215.820312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(302.099609 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(333.886719 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(372.900391 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(434.082031 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(497.460938 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(536.669922 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(574.628906 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(635.810547 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(665.515625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(701.599609 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(753.699219 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(817.175781 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(878.699219 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(933.679688 0)"/>
+     <use xlink:href="#DejaVuSans-3a" transform="translate(972.693359 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1006.384766 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1038.171875 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1101.794922 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(1165.417969 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1197.205078 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1260.828125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1324.451172 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1356.238281 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1408.337891 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1440.125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1540.125 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1571.912109 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1633.09375 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1692.273438 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1753.796875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1794.910156 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1826.697266 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1890.173828 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1953.552734 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2017.029297 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2080.505859 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2142.029297 0)"/>
+    </g>
+    <!-- ≈2.3× the 6.3 µs·V linear extrapolation (6.3 s) -->
+    <g style="fill: #b01010" transform="translate(318.323469 85.504079) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2248"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(179.199219 0)"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(242.822266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(326.611328 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(358.398438 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(397.607422 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(460.986328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(522.509766 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(554.296875 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(617.919922 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(649.707031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(713.330078 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(745.117188 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(808.740234 0)"/>
+     <use xlink:href="#DejaVuSans-b7" transform="translate(860.839844 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(892.626953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(961.035156 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(992.822266 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1020.605469 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1048.388672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1111.767578 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1173.291016 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1234.570312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1275.683594 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1307.470703 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(1367.244141 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1426.423828 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1465.632812 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1506.746094 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1568.025391 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1631.501953 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1692.683594 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1720.466797 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1781.746094 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1820.955078 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1848.738281 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1909.919922 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1973.298828 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2005.085938 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2044.099609 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(2107.722656 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(2139.509766 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2203.132812 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2234.919922 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2287.019531 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- VALIDATOR_REGISTRY_LIMIT = 4096 -->
+    <g style="fill: #b01010" transform="translate(198.77299 321.675221) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(62.033203 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(130.441406 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(186.154297 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(215.646484 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(290.898438 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(351.556641 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(412.640625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(491.351562 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(560.833984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(610.833984 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(680.316406 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(743.5 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(820.990234 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(850.482422 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(913.958984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(975.042969 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1038.150391 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(1099.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1149.234375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1204.947266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(1234.439453 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1320.71875 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1350.210938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1411.294922 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(1443.082031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1526.871094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1558.658203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1622.28125 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(1685.904297 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1749.527344 0)"/>
+    </g>
+    <!-- (leanSpec cap) -->
+    <g style="fill: #b01010" transform="translate(305.390178 333.151158) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-28"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(39.013672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(66.796875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(128.320312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(189.599609 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(252.978516 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(316.455078 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(379.931641 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(441.455078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(496.435547 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(528.222656 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(583.203125 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(644.482422 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(707.958984 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- SLO target 200 ms (1 interval) -->
+    <g style="fill: #555555" transform="translate(88.857497 158.974625) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(194.275391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(226.0625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(265.271484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(326.550781 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(365.914062 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(429.390625 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(490.914062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(530.123047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(561.910156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(625.533203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(689.15625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(752.779297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(784.566406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(881.978516 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(934.078125 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(965.865234 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1004.878906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1068.501953 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1100.289062 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1128.072266 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1191.451172 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1230.660156 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1292.183594 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1333.296875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1392.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1453.755859 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1481.539062 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- state_transition (full STF) benchmark — A=8 valid attestations, incl. SHA-256 hash_tree_root -->
+    <g transform="translate(83.198395 11.278125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-48" d="M 628 4666 
+L 1259 4666 
+L 1259 2753 
+L 3553 2753 
+L 3553 4666 
+L 4184 4666 
+L 4184 0 
+L 3553 0 
+L 3553 2222 
+L 1259 2222 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(811.523438 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(850.537109 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(885.742188 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(949.121094 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(976.904297 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1004.6875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1036.474609 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1099.951172 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1161.035156 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1218.554688 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1257.568359 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1289.355469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1352.832031 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1414.355469 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1477.734375 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1532.714844 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1596.09375 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1693.505859 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1754.785156 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(1795.898438 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1853.808594 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1885.595703 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1985.595703 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(2017.382812 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(2085.791016 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(2169.580078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2233.203125 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(2264.990234 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2324.169922 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2385.449219 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2413.232422 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2441.015625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2504.492188 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2536.279297 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2597.558594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2636.767578 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2675.976562 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2737.5 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2789.599609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2828.808594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2890.087891 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2929.296875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2957.080078 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3018.261719 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3081.640625 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(3133.740234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3165.527344 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3197.314453 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3225.097656 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3288.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3343.457031 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3371.240234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3403.027344 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(3434.814453 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(3498.291016 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(3573.486328 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(3639.644531 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(3675.728516 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(3739.351562 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(3802.974609 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3866.597656 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3898.384766 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3961.763672 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4023.042969 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(4075.142578 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(4138.521484 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4188.521484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(4227.730469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4266.59375 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4328.117188 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(4389.640625 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(4439.640625 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4478.503906 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4539.685547 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4600.867188 0)"/>
+    </g>
+    <!-- fixed baseline + linear-in-V model (spec V ≤ 4096) vs out-of-spec V=1M -->
+    <g transform="translate(145.534645 25.04925) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2264" d="M 4684 3175 
+L 1684 2309 
+L 4684 1453 
+L 4684 897 
+L 678 2047 
+L 678 2578 
+L 4684 3725 
+L 4684 3175 
+z
+M 678 531 
+L 4684 531 
+L 4684 0 
+L 678 0 
+L 678 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-66"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(35.205078 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(62.988281 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(119.042969 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(180.566406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(244.042969 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(275.830078 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(339.306641 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(400.585938 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(452.685547 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(514.208984 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(541.992188 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(569.775391 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(633.154297 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(694.677734 0)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(726.464844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(810.253906 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(842.041016 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(869.824219 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(897.607422 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(960.986328 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1022.509766 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1083.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1118.527344 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1154.611328 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1182.394531 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1245.773438 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1275.982422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1344.390625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1376.177734 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1473.589844 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1534.771484 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1598.248047 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1659.771484 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1687.554688 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1719.341797 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1758.355469 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1810.455078 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1873.931641 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1935.455078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1990.435547 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2022.222656 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2090.630859 0)"/>
+     <use xlink:href="#DejaVuSans-2264" transform="translate(2122.417969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2206.207031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(2237.994141 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(2301.617188 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(2365.240234 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2428.863281 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2492.486328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2531.5 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(2563.287109 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2622.466797 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2674.566406 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2706.353516 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(2767.535156 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2830.914062 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(2870.123047 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2908.082031 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2969.263672 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(2998.96875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3035.052734 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(3087.152344 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3150.628906 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3212.152344 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3267.132812 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(3298.919922 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(3367.328125 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(3451.117188 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(3514.740234 0)"/>
+    </g>
+   </g>
+   <g id="line2d_201">
+    <path d="M 384.650572 214.828056 
+L 622.531829 59.723966 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke-dasharray: 6.16,2.66; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.4"/>
+   </g>
+   <g id="line2d_202">
+    <path d="M 84.733532 322.852781 
+L 114.725236 321.382343 
+L 204.700348 303.524527 
+L 294.67546 262.091978 
+L 384.650572 214.828056 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+    <defs>
+     <path id="m540fab49de" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p19ac95b25d)">
+     <use xlink:href="#m540fab49de" x="84.733532" y="322.852781" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m540fab49de" x="114.725236" y="321.382343" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m540fab49de" x="204.700348" y="303.524527" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m540fab49de" x="294.67546" y="262.091978" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m540fab49de" x="384.650572" y="214.828056" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_11">
+     <path d="M 84.35152 104.390344 
+L 356.113864 104.390344 
+Q 358.013864 104.390344 358.013864 102.490344 
+L 358.013864 41.69925 
+Q 358.013864 39.79925 356.113864 39.79925 
+L 84.35152 39.79925 
+Q 82.45152 39.79925 82.45152 41.69925 
+L 82.45152 102.490344 
+Q 82.45152 104.390344 84.35152 104.390344 
+z
+" style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-width: 0.8; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_203">
+     <path d="M 89.10152 50.342766 
+L 98.60152 50.342766 
+L 108.10152 50.342766 
+" style="fill: none; stroke-dasharray: 9.9,4.32; stroke-dashoffset: 0; stroke: #7d3c98; stroke-width: 1.8"/>
+    </g>
+    <g id="text_30">
+     <!-- fixed baseline ≈ 0.30 ms  (V-independent floor) -->
+     <g transform="translate(115.70152 53.667766) scale(0.095 -0.095)">
+      <use xlink:href="#DejaVuSans-66"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(35.205078 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(62.988281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(119.042969 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(180.566406 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(244.042969 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(275.830078 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(339.306641 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(400.585938 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(452.685547 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(514.208984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(541.992188 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(569.775391 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(633.154297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(694.677734 0)"/>
+      <use xlink:href="#DejaVuSans-2248" transform="translate(726.464844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(810.253906 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(842.041016 0)"/>
+      <use xlink:href="#DejaVuSans-2e" transform="translate(905.664062 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(937.451172 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(1001.074219 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1064.697266 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1096.484375 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1193.896484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1245.996094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1277.783203 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1309.570312 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1348.583984 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1411.117188 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1447.201172 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1474.984375 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1538.363281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1601.839844 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1663.363281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1726.839844 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1788.363281 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1851.742188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1915.21875 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1976.742188 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2040.121094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2079.330078 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(2111.117188 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2146.322266 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2174.105469 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2235.287109 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2296.46875 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2337.582031 0)"/>
+     </g>
+    </g>
+    <g id="line2d_204">
+     <path d="M 89.10152 64.286984 
+L 98.60152 64.286984 
+L 108.10152 64.286984 
+" style="fill: none; stroke-dasharray: 9.9,4.32; stroke-dashoffset: 0; stroke: #d9730d; stroke-width: 1.8"/>
+    </g>
+    <g id="text_31">
+     <!-- linear term ≈ 6.3 µs × V  (spec-range fit) -->
+     <g transform="translate(115.70152 67.611984) scale(0.095 -0.095)">
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(27.783203 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(55.566406 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(118.945312 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(180.46875 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(241.748047 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(282.861328 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(314.648438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(353.857422 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(415.380859 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(454.744141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(552.15625 0)"/>
+      <use xlink:href="#DejaVuSans-2248" transform="translate(583.943359 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(667.732422 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(699.519531 0)"/>
+      <use xlink:href="#DejaVuSans-2e" transform="translate(763.142578 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(794.929688 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(858.552734 0)"/>
+      <use xlink:href="#DejaVuSans-b5" transform="translate(890.339844 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(953.962891 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1006.0625 0)"/>
+      <use xlink:href="#DejaVuSans-d7" transform="translate(1037.849609 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1121.638672 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1153.425781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1221.833984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1253.621094 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1285.408203 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1324.421875 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1376.521484 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1439.998047 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1501.521484 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1556.501953 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1592.585938 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1633.699219 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1694.978516 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1758.357422 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1821.833984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1883.357422 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(1915.144531 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1950.349609 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1978.132812 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2017.341797 0)"/>
+     </g>
+    </g>
+    <g id="line2d_205">
+     <path d="M 89.10152 78.231203 
+L 98.60152 78.231203 
+L 108.10152 78.231203 
+" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m540fab49de" x="98.60152" y="78.231203" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_32">
+     <!-- measured pipeline (incl. SHA-256 hash_tree_root) -->
+     <g transform="translate(115.70152 81.556203) scale(0.095 -0.095)">
+      <use xlink:href="#DejaVuSans-6d"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(97.412109 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(158.935547 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(220.214844 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(272.314453 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(335.693359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(374.556641 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(436.080078 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(499.556641 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(531.34375 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(594.820312 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(622.603516 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(686.080078 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(747.603516 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(775.386719 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(803.169922 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(866.548828 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(928.072266 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(959.859375 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(998.873047 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1026.65625 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1090.035156 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1145.015625 0)"/>
+      <use xlink:href="#DejaVuSans-2e" transform="translate(1172.798828 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1204.585938 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1236.373047 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1299.849609 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1375.044922 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1441.203125 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(1477.287109 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(1540.910156 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(1604.533203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1668.15625 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1699.943359 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1763.322266 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1824.601562 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1876.701172 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(1940.080078 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1990.080078 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2029.289062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2068.152344 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2129.675781 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2191.199219 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2241.199219 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2280.0625 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2341.244141 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2402.425781 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2441.634766 0)"/>
+     </g>
+    </g>
+    <g id="line2d_206">
+     <path d="M 89.10152 92.439641 
+L 98.60152 92.439641 
+L 108.10152 92.439641 
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+     <defs>
+      <path id="mcc91c9116f" d="M 0 4 
+C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
+C 3.578535 2.078319 4 1.060812 4 0 
+C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
+C 2.078319 -3.578535 1.060812 -4 0 -4 
+C -1.060812 -4 -2.078319 -3.578535 -2.828427 -2.828427 
+C -3.578535 -2.078319 -4 -1.060812 -4 0 
+C -4 1.060812 -3.578535 2.078319 -2.828427 2.828427 
+C -2.078319 3.578535 -1.060812 4 0 4 
+z
+" style="stroke: #d62728"/>
+     </defs>
+     <g>
+      <use xlink:href="#mcc91c9116f" x="98.60152" y="92.439641" style="fill: #d62728; stroke: #d62728"/>
+     </g>
+    </g>
+    <g id="text_33">
+     <!-- V=1M (mainnet, out-of-spec reference) -->
+     <g transform="translate(115.70152 95.764641) scale(0.095 -0.095)">
+      <use xlink:href="#DejaVuSans-56"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(152.197266 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(215.820312 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(302.099609 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(333.886719 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(372.900391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(470.3125 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(531.591797 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(559.375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(622.753906 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(686.132812 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(747.65625 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(786.865234 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(818.652344 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(850.439453 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(911.621094 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(975 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1014.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1052.167969 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(1113.349609 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1143.054688 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1179.138672 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1231.238281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1294.714844 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1356.238281 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1411.21875 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1443.005859 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1481.869141 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(1543.392578 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1578.597656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1640.121094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1678.984375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1740.507812 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1803.886719 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1858.867188 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1920.390625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_207">
+    <path d="M 622.531829 59.723966 
+" clip-path="url(#p19ac95b25d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+    <g clip-path="url(#p19ac95b25d)">
+     <use xlink:href="#mcc91c9116f" x="622.531829" y="59.723966" style="fill: #d62728; stroke: #d62728"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_34">
+   <!-- AMD Ryzen 9 PRO 8945HS (Zen 4 mobile, 8C/16T)  ·  Linux 6.18.12+kali-amd64 x86_64  ·  Lean v4.28.0-rc1  ·  Rust release + thin LTO + codegen-units=1  ·  2026-06-26 -->
+   <g style="fill: #666666" transform="translate(2.16 392.95851) scale(0.08 -0.08)">
+    <defs>
+     <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-41"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(68.408203 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(154.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(231.689453 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(263.476562 0)"/>
+    <use xlink:href="#DejaVuSans-79" transform="translate(327.458984 0)"/>
+    <use xlink:href="#DejaVuSans-7a" transform="translate(386.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(439.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(500.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(564.03125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(595.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(659.441406 0)"/>
+    <use xlink:href="#DejaVuSans-50" transform="translate(691.228516 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(751.53125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(821.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(899.724609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(931.511719 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(995.134766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1058.757812 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1122.380859 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(1186.003906 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(1261.199219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1324.675781 0)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(1356.462891 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1395.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1463.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1525.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1620.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1684.294922 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(1716.082031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1813.494141 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(1874.675781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1938.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1965.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1993.71875 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(2055.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2087.029297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2118.816406 0)"/>
+    <use xlink:href="#DejaVuSans-43" transform="translate(2182.439453 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(2252.263672 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(2285.955078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2349.578125 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(2413.201172 0)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(2474.285156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2513.298828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2545.085938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2576.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2608.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2640.447266 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(2672.234375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2727.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2755.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2819.109375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2882.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2941.667969 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2973.455078 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3037.078125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3068.865234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3132.488281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3196.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3227.898438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3291.521484 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(3355.144531 0)"/>
+    <use xlink:href="#DejaVuSans-6b" transform="translate(3438.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3495.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3556.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3584.15625 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(3611.939453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3648.023438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(3709.302734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3806.714844 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3870.191406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3933.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3997.4375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(4029.224609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(4088.404297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4152.027344 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(4215.650391 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4265.650391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4329.273438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4392.896484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4424.683594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(4456.470703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4488.257812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4520.044922 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(4551.832031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4605.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4667.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4728.597656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4791.976562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4823.763672 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4882.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4946.566406 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4978.353516 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(5041.976562 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(5105.599609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(5137.386719 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5201.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5237.09375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5275.957031 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5330.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5394.560547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5426.347656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5458.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5489.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5521.708984 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(5553.496094 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5618.478516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(5681.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5733.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5773.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5804.953125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5843.816406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5905.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5933.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5994.646484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6055.925781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6108.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6169.548828 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(6201.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6285.125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6316.912109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6356.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6419.5 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6447.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6510.662109 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(6542.449219 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(6584.412109 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(6645.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6724.207031 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(6755.994141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6839.783203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6871.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6926.550781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6987.732422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7051.208984 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(7112.732422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7176.208984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7237.732422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(7301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7337.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7400.574219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7463.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7491.736328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7530.945312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(7583.044922 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(7666.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7730.457031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7762.244141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(7794.03125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7825.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7857.605469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(7889.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(7953.015625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8016.638672 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8080.261719 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8143.884766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(8179.96875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8243.591797 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8307.214844 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8343.298828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8406.921875 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p19ac95b25d">
+   <rect x="77.70152" y="35.04925" width="567.79" height="306.7089"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/bench-htr-results-baseline.svg
+++ b/docs/assets/bench-htr-results-baseline.svg
@@ -1,0 +1,2944 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="681.955pt" height="394.745479pt" viewBox="0 0 681.955 394.745479" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7+dfsg1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 394.745479 
+L 681.955 394.745479 
+L 681.955 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 73.56152 339.498869 
+L 640.735349 339.498869 
+L 640.735349 36.002969 
+L 73.56152 36.002969 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 86.132232 339.498869 
+L 86.132232 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m26f137c322" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m26f137c322" x="86.132232" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 4 -->
+      <g transform="translate(82.314732 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 139.746622 339.498869 
+L 139.746622 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m26f137c322" x="139.746622" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 8 -->
+      <g transform="translate(135.929122 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 300.589792 339.498869 
+L 300.589792 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m26f137c322" x="300.589792" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 64 -->
+      <g transform="translate(292.954792 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 461.432963 339.498869 
+L 461.432963 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m26f137c322" x="461.432963" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 512 -->
+      <g transform="translate(449.980463 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 622.276134 339.498869 
+L 622.276134 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m26f137c322" x="622.276134" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4096 -->
+      <g transform="translate(607.006134 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 103.39221 339.498869 
+L 103.39221 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_12"/>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 117.494639 339.498869 
+L 117.494639 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_14"/>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 129.418073 339.498869 
+L 129.418073 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_16"/>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 148.857047 339.498869 
+L 148.857047 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_18"/>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 210.62099 339.498869 
+L 210.62099 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_20"/>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 241.983398 339.498869 
+L 241.983398 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_22"/>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 264.235381 339.498869 
+L 264.235381 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_24"/>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 281.495359 339.498869 
+L 281.495359 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_26"/>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 295.597788 339.498869 
+L 295.597788 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_28"/>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 307.521223 339.498869 
+L 307.521223 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_30"/>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 317.849771 339.498869 
+L 317.849771 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_32"/>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 326.960196 339.498869 
+L 326.960196 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_34"/>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 388.72414 339.498869 
+L 388.72414 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_36"/>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 420.086547 339.498869 
+L 420.086547 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_38"/>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 442.33853 339.498869 
+L 442.33853 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_40"/>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 459.598508 339.498869 
+L 459.598508 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_42"/>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 473.700938 339.498869 
+L 473.700938 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_44"/>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 485.624372 339.498869 
+L 485.624372 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_46"/>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 495.95292 339.498869 
+L 495.95292 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_48"/>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 505.063345 339.498869 
+L 505.063345 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_50"/>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 566.827289 339.498869 
+L 566.827289 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_52"/>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 598.189696 339.498869 
+L 598.189696 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_54"/>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 620.441679 339.498869 
+L 620.441679 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_56"/>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 637.701657 339.498869 
+L 637.701657 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_58"/>
+    </g>
+    <g id="text_6">
+     <!-- validator count  V  (≤ leanSpec VALIDATOR_REGISTRY_LIMIT = 2¹² = 4096) -->
+     <g transform="translate(123.464841 371.610666) scale(0.125 -0.125)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2264" d="M 4684 3175 
+L 1684 2309 
+L 4684 1453 
+L 4684 897 
+L 678 2047 
+L 678 2578 
+L 4684 3725 
+L 4684 3175 
+z
+M 678 531 
+L 4684 531 
+L 4684 0 
+L 678 0 
+L 678 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 628 4666 
+L 3578 4666 
+L 3578 4134 
+L 1259 4134 
+L 1259 2753 
+L 3481 2753 
+L 3481 2222 
+L 1259 2222 
+L 1259 531 
+L 3634 531 
+L 3634 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b9" d="M 488 2431 
+L 1125 2431 
+L 1125 4341 
+L 428 4213 
+L 428 4575 
+L 1147 4697 
+L 1575 4697 
+L 1575 2431 
+L 2216 2431 
+L 2216 2088 
+L 488 2088 
+L 488 2431 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b2" d="M 838 2444 
+L 2163 2444 
+L 2163 2088 
+L 294 2088 
+L 294 2431 
+Q 400 2528 597 2703 
+Q 1672 3656 1672 3950 
+Q 1672 4156 1509 4282 
+Q 1347 4409 1081 4409 
+Q 919 4409 728 4354 
+Q 538 4300 313 4191 
+L 313 4575 
+Q 553 4663 761 4706 
+Q 969 4750 1147 4750 
+Q 1600 4750 1872 4544 
+Q 2144 4338 2144 4000 
+Q 2144 3566 1109 2678 
+Q 934 2528 838 2444 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(148.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(176.025391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(239.501953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(300.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(339.990234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(401.171875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(442.285156 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(474.072266 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(529.052734 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(590.234375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(653.613281 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(716.992188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(756.201172 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(787.988281 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(819.775391 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(888.183594 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(919.970703 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(951.757812 0)"/>
+      <use xlink:href="#DejaVuSans-2264" transform="translate(990.771484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1074.560547 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.347656 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1134.130859 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1195.654297 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1256.933594 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1320.3125 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1383.789062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1447.265625 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1508.789062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1563.769531 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1595.556641 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1657.589844 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1725.998047 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(1781.710938 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1811.203125 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1886.455078 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(1947.113281 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(2008.197266 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2086.908203 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2156.390625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2206.390625 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(2275.873047 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(2339.056641 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2416.546875 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(2446.039062 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2509.515625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2570.599609 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(2633.707031 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2694.791016 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(2744.791016 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2800.503906 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(2829.996094 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2916.275391 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2945.767578 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3006.851562 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3038.638672 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3122.427734 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(3154.214844 0)"/>
+      <use xlink:href="#DejaVuSans-b9" transform="translate(3217.837891 0)"/>
+      <use xlink:href="#DejaVuSans-b2" transform="translate(3257.925781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3298.013672 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3329.800781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3413.589844 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(3445.376953 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(3509 0)"/>
+      <use xlink:href="#DejaVuSans-39" transform="translate(3572.623047 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(3636.246094 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(3699.869141 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_59">
+      <path d="M 73.56152 291.425523 
+L 640.735349 291.425523 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <defs>
+       <path id="m9b33c36039" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9b33c36039" x="73.56152" y="291.425523" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 100 µs -->
+      <g transform="translate(25.95652 295.984586) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_61">
+      <path d="M 73.56152 247.55911 
+L 640.735349 247.55911 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m9b33c36039" x="73.56152" y="247.55911" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 300 µs -->
+      <g transform="translate(25.95652 252.118173) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_63">
+      <path d="M 73.56152 199.485765 
+L 640.735349 199.485765 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m9b33c36039" x="73.56152" y="199.485765" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 1 ms -->
+      <g transform="translate(37.17277 204.044827) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_65">
+      <path d="M 73.56152 155.619352 
+L 640.735349 155.619352 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m9b33c36039" x="73.56152" y="155.619352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 3 ms -->
+      <g transform="translate(37.17277 160.178415) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_67">
+      <path d="M 73.56152 107.546007 
+L 640.735349 107.546007 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m9b33c36039" x="73.56152" y="107.546007" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 10 ms -->
+      <g transform="translate(29.53777 112.105069) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_69">
+      <path d="M 73.56152 63.679594 
+L 640.735349 63.679594 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m9b33c36039" x="73.56152" y="63.679594" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 30 ms -->
+      <g transform="translate(29.53777 68.238656) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_71">
+      <path d="M 73.56152 339.498869 
+L 640.735349 339.498869 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_72"/>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_73">
+      <path d="M 73.56152 328.012032 
+L 640.735349 328.012032 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_74"/>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_75">
+      <path d="M 73.56152 319.102148 
+L 640.735349 319.102148 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_76"/>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_77">
+      <path d="M 73.56152 311.822244 
+L 640.735349 311.822244 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_78"/>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_79">
+      <path d="M 73.56152 305.667172 
+L 640.735349 305.667172 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_80"/>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_81">
+      <path d="M 73.56152 300.335406 
+L 640.735349 300.335406 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_82"/>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_83">
+      <path d="M 73.56152 295.632456 
+L 640.735349 295.632456 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_84"/>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_85">
+      <path d="M 73.56152 263.748898 
+L 640.735349 263.748898 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_86"/>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_87">
+      <path d="M 73.56152 236.072273 
+L 640.735349 236.072273 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_88"/>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_89">
+      <path d="M 73.56152 227.16239 
+L 640.735349 227.16239 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_90"/>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_91">
+      <path d="M 73.56152 219.882485 
+L 640.735349 219.882485 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_92"/>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_93">
+      <path d="M 73.56152 213.727414 
+L 640.735349 213.727414 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_94"/>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_95">
+      <path d="M 73.56152 208.395648 
+L 640.735349 208.395648 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_96"/>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_97">
+      <path d="M 73.56152 203.692698 
+L 640.735349 203.692698 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_98"/>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_99">
+      <path d="M 73.56152 171.80914 
+L 640.735349 171.80914 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_100"/>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_101">
+      <path d="M 73.56152 144.132515 
+L 640.735349 144.132515 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_102"/>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_103">
+      <path d="M 73.56152 135.222632 
+L 640.735349 135.222632 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_104"/>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_105">
+      <path d="M 73.56152 127.942727 
+L 640.735349 127.942727 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_106"/>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_107">
+      <path d="M 73.56152 121.787655 
+L 640.735349 121.787655 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_108"/>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_109">
+      <path d="M 73.56152 116.45589 
+L 640.735349 116.45589 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_110"/>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_111">
+      <path d="M 73.56152 111.752939 
+L 640.735349 111.752939 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_112"/>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_113">
+      <path d="M 73.56152 79.869382 
+L 640.735349 79.869382 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_114"/>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_115">
+      <path d="M 73.56152 52.192757 
+L 640.735349 52.192757 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_116"/>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_117">
+      <path d="M 73.56152 43.282873 
+L 640.735349 43.282873 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_118"/>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_119">
+      <path d="M 73.56152 36.002969 
+L 640.735349 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_120"/>
+    </g>
+    <g id="text_13">
+     <!-- time per call (log scale) -->
+     <g transform="translate(19.356911 261.448184) rotate(-90) scale(0.125 -0.125)">
+      <defs>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-74"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(39.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(66.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(164.404297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.927734 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(257.714844 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(321.191406 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(382.714844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(423.828125 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(455.615234 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(510.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(571.875 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(599.658203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(627.441406 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(659.228516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(698.242188 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(726.025391 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(787.207031 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(850.683594 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(882.470703 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(934.570312 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(989.550781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1050.830078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1078.613281 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1140.136719 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_121">
+    <path d="M 622.276134 339.498869 
+L 622.276134 36.002969 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 73.56152 339.498869 
+L 73.56152 36.002969 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 640.735349 339.498869 
+L 640.735349 36.002969 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 73.56152 339.498869 
+L 640.735349 339.498869 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 73.56152 36.002969 
+L 640.735349 36.002969 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_122">
+    <path d="M 73.56152 247.55911 
+L 640.735349 247.55911 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 9.9,4.32; stroke-dashoffset: 0; stroke: #7d3c98; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_123">
+    <path d="M 73.56152 352.94982 
+L 640.735349 60.165414 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke-dasharray: 9.9,4.32; stroke-dashoffset: 0; stroke: #d9730d; stroke-width: 1.8"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 243.474448 175.760364 
+Q 247.940608 215.802954 275.578006 245.292375 
+" style="fill: none; stroke: #555555; stroke-linecap: round"/>
+    <path d="M 274.302007 241.006138 
+L 275.578006 245.292375 
+L 271.383417 243.741432 
+z
+" style="fill: #555555; stroke: #555555; stroke-linecap: round"/>
+   </g>
+   <g id="text_14">
+    <!-- floor = linear  @  V ≈ 48 -->
+    <g style="fill: #333333" transform="translate(164.378768 158.493684) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-40" d="M 2381 1678 
+Q 2381 1231 2603 976 
+Q 2825 722 3213 722 
+Q 3597 722 3817 978 
+Q 4038 1234 4038 1678 
+Q 4038 2116 3813 2373 
+Q 3588 2631 3206 2631 
+Q 2828 2631 2604 2375 
+Q 2381 2119 2381 1678 
+z
+M 4084 744 
+Q 3897 503 3655 389 
+Q 3413 275 3091 275 
+Q 2553 275 2217 664 
+Q 1881 1053 1881 1678 
+Q 1881 2303 2218 2693 
+Q 2556 3084 3091 3084 
+Q 3413 3084 3656 2967 
+Q 3900 2850 4084 2613 
+L 4084 3022 
+L 4531 3022 
+L 4531 722 
+Q 4988 791 5245 1139 
+Q 5503 1488 5503 2041 
+Q 5503 2375 5404 2669 
+Q 5306 2963 5106 3213 
+Q 4781 3622 4314 3839 
+Q 3847 4056 3297 4056 
+Q 2913 4056 2559 3954 
+Q 2206 3853 1906 3653 
+Q 1416 3334 1139 2817 
+Q 863 2300 863 1697 
+Q 863 1200 1042 765 
+Q 1222 331 1563 0 
+Q 1891 -325 2322 -495 
+Q 2753 -666 3244 -666 
+Q 3647 -666 4036 -530 
+Q 4425 -394 4750 -141 
+L 5031 -488 
+Q 4641 -791 4180 -952 
+Q 3719 -1113 3244 -1113 
+Q 2666 -1113 2153 -908 
+Q 1641 -703 1241 -313 
+Q 841 78 631 592 
+Q 422 1106 422 1697 
+Q 422 2266 634 2781 
+Q 847 3297 1241 3688 
+Q 1644 4084 2172 4295 
+Q 2700 4506 3291 4506 
+Q 3953 4506 4520 4234 
+Q 5088 3963 5472 3463 
+Q 5706 3156 5829 2797 
+Q 5953 2438 5953 2053 
+Q 5953 1231 5456 756 
+Q 4959 281 4084 263 
+L 4084 744 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2248" d="M 4684 1947 
+L 4684 1388 
+Q 4356 1144 4076 1036 
+Q 3797 928 3494 928 
+Q 3150 928 2694 1113 
+Q 2663 1125 2641 1134 
+Q 2622 1141 2575 1159 
+Q 2091 1350 1797 1350 
+Q 1522 1350 1253 1231 
+Q 984 1113 678 850 
+L 678 1409 
+Q 1006 1653 1286 1761 
+Q 1566 1869 1869 1869 
+Q 2213 1869 2672 1684 
+Q 2706 1669 2722 1663 
+Q 2741 1656 2788 1638 
+Q 3272 1447 3566 1447 
+Q 3834 1447 4098 1564 
+Q 4363 1681 4684 1947 
+z
+M 4684 3163 
+L 4684 2606 
+Q 4356 2359 4076 2251 
+Q 3797 2144 3494 2144 
+Q 3150 2144 2694 2328 
+Q 2663 2341 2641 2350 
+Q 2622 2356 2575 2375 
+Q 2091 2566 1797 2566 
+Q 1522 2566 1253 2447 
+Q 984 2328 678 2069 
+L 678 2625 
+Q 1006 2869 1286 2976 
+Q 1566 3084 1869 3084 
+Q 2213 3084 2672 2900 
+Q 2703 2888 2719 2881 
+Q 2741 2872 2788 2853 
+Q 3272 2663 3566 2663 
+Q 3834 2663 4098 2780 
+Q 4363 2897 4684 3163 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-66"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(35.205078 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(62.988281 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(124.169922 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(185.351562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(226.464844 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(258.251953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(342.041016 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(373.828125 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(401.611328 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(429.394531 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(492.773438 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(554.296875 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(615.576172 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(656.689453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(688.476562 0)"/>
+     <use xlink:href="#DejaVuSans-40" transform="translate(720.263672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(820.263672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(852.050781 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(883.837891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(952.246094 0)"/>
+     <use xlink:href="#DejaVuSans-2248" transform="translate(984.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1067.822266 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1099.609375 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(1163.232422 0)"/>
+    </g>
+    <!-- → linear term dominates above -->
+    <g style="fill: #333333" transform="translate(164.378768 169.691497) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-2192" d="M 5050 2147 
+L 5050 1866 
+L 3822 638 
+L 3447 1013 
+L 4175 1741 
+L 366 1741 
+L 366 2272 
+L 4175 2272 
+L 3447 3000 
+L 3822 3375 
+L 5050 2147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2192"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(115.576172 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(143.359375 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(171.142578 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(234.521484 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(296.044922 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(357.324219 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(398.4375 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(430.224609 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(469.433594 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(530.957031 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(570.320312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(667.732422 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(699.519531 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(762.996094 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(824.177734 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(921.589844 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(949.373047 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1012.751953 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1074.03125 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1113.240234 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1174.763672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1226.863281 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1258.650391 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1319.929688 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1383.40625 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1444.587891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1503.767578 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- 324 µs -->
+    <g style="fill: #0b3d6e" transform="translate(67.213482 233.406451) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 344 µs -->
+    <g style="fill: #0b3d6e" transform="translate(120.827872 231.014782) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 712 µs -->
+    <g style="fill: #0b3d6e" transform="translate(281.671042 201.969031) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 3.85 ms -->
+    <g style="fill: #0b3d6e" transform="translate(439.236088 134.578959) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(254.443359 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 26.40 ms -->
+    <g style="fill: #0b3d6e" transform="translate(596.898009 57.704156) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- VALIDATOR_REGISTRY_LIMIT = 4096 -->
+    <g style="fill: #b01010" transform="translate(435.344097 308.755369) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(62.033203 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(130.441406 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(186.154297 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(215.646484 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(290.898438 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(351.556641 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(412.640625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(491.351562 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(560.833984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(610.833984 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(680.316406 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(743.5 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(820.990234 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(850.482422 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(913.958984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(975.042969 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1038.150391 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(1099.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1149.234375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1204.947266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(1234.439453 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1320.71875 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1350.210938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1411.294922 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(1443.082031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1526.871094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1558.658203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1622.28125 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(1685.904297 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1749.527344 0)"/>
+    </g>
+    <!-- (leanSpec cap) -->
+    <g style="fill: #b01010" transform="translate(541.961285 320.231306) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-28"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(39.013672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(66.796875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(128.320312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(189.599609 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(252.978516 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(316.455078 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(379.931641 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(441.455078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(496.435547 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(528.222656 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(583.203125 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(644.482422 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(707.958984 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- state_transition (full STF) scaling — fixed baseline + linear-in-V (A=8 valid attestations) -->
+    <g transform="translate(83.761716 11.658047) scale(0.125 -0.125)">
+     <defs>
+      <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(811.523438 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(850.537109 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(885.742188 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(949.121094 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(976.904297 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1004.6875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1036.474609 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1099.951172 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1161.035156 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1218.554688 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1257.568359 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1289.355469 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1341.455078 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1396.435547 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1457.714844 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1485.498047 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1513.28125 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1576.660156 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1640.136719 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1671.923828 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1771.923828 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(1803.710938 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1838.916016 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(1866.699219 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1922.753906 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1984.277344 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2047.753906 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2079.541016 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2143.017578 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2204.296875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2256.396484 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2317.919922 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2345.703125 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2373.486328 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2436.865234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2498.388672 0)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(2530.175781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2613.964844 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2645.751953 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2673.535156 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2701.318359 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2764.697266 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2826.220703 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2887.5 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(2922.238281 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2958.322266 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2986.105469 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(3049.484375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(3079.693359 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3148.101562 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(3179.888672 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(3218.902344 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(3287.310547 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(3371.099609 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3434.722656 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(3466.509766 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3525.689453 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3586.96875 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3614.751953 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(3642.535156 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3706.011719 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3737.798828 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3799.078125 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3838.287109 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3877.496094 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3939.019531 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3991.119141 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(4030.328125 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4091.607422 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(4130.816406 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4158.599609 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4219.78125 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4283.160156 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(4335.259766 0)"/>
+    </g>
+    <!-- leanSpec range (V ≤ 4096), incl. SHA-256 hash_tree_root -->
+    <g transform="translate(177.998044 26.002969) scale(0.125 -0.125)">
+     <defs>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-48" d="M 628 4666 
+L 1259 4666 
+L 1259 2753 
+L 3553 2753 
+L 3553 4666 
+L 4184 4666 
+L 4184 0 
+L 3553 0 
+L 3553 2222 
+L 1259 2222 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6c"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(27.783203 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(89.306641 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(150.585938 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(213.964844 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(277.441406 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(340.917969 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(402.441406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(457.421875 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(489.208984 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(530.322266 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(591.601562 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(654.980469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(718.457031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(779.980469 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(811.767578 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(850.78125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(919.189453 0)"/>
+     <use xlink:href="#DejaVuSans-2264" transform="translate(950.976562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1034.765625 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1066.552734 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1130.175781 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(1193.798828 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1257.421875 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1321.044922 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(1360.058594 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1391.845703 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1423.632812 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1451.416016 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1514.794922 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1569.775391 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(1597.558594 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1629.345703 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1661.132812 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1724.609375 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(1799.804688 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1865.962891 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(1902.046875 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(1965.669922 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2029.292969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2092.916016 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2124.703125 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2188.082031 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2249.361328 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2301.460938 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(2364.839844 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2414.839844 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2454.048828 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2492.912109 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2554.435547 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(2615.958984 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2665.958984 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2704.822266 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2766.003906 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2827.185547 0)"/>
+    </g>
+   </g>
+   <g id="line2d_124">
+    <path d="M 86.132232 244.486138 
+L 139.746622 242.09447 
+L 300.589792 213.048719 
+L 461.432963 145.658647 
+L 622.276134 68.783844 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+    <defs>
+     <path id="mdffe4c83bd" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p068f66cc9a)">
+     <use xlink:href="#mdffe4c83bd" x="86.132232" y="244.486138" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdffe4c83bd" x="139.746622" y="242.09447" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdffe4c83bd" x="300.589792" y="213.048719" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdffe4c83bd" x="461.432963" y="145.658647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mdffe4c83bd" x="622.276134" y="68.783844" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 80.91152 97.231094 
+L 389.895348 97.231094 
+Q 391.995348 97.231094 391.995348 95.131094 
+L 391.995348 43.352969 
+Q 391.995348 41.252969 389.895348 41.252969 
+L 80.91152 41.252969 
+Q 78.81152 41.252969 78.81152 43.352969 
+L 78.81152 95.131094 
+Q 78.81152 97.231094 80.91152 97.231094 
+z
+" style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-width: 0.8; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_125">
+     <path d="M 86.16152 52.906328 
+L 96.66152 52.906328 
+L 107.16152 52.906328 
+" style="fill: none; stroke-dasharray: 9.9,4.32; stroke-dashoffset: 0; stroke: #7d3c98; stroke-width: 1.8"/>
+    </g>
+    <g id="text_22">
+     <!-- fixed baseline ≈ 0.30 ms  (V-independent floor) -->
+     <g transform="translate(115.56152 56.581328) scale(0.105 -0.105)">
+      <use xlink:href="#DejaVuSans-66"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(35.205078 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(62.988281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(119.042969 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(180.566406 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(244.042969 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(275.830078 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(339.306641 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(400.585938 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(452.685547 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(514.208984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(541.992188 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(569.775391 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(633.154297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(694.677734 0)"/>
+      <use xlink:href="#DejaVuSans-2248" transform="translate(726.464844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(810.253906 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(842.041016 0)"/>
+      <use xlink:href="#DejaVuSans-2e" transform="translate(905.664062 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(937.451172 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(1001.074219 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1064.697266 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1096.484375 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1193.896484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1245.996094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1277.783203 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1309.570312 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1348.583984 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1411.117188 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1447.201172 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1474.984375 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1538.363281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1601.839844 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1663.363281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1726.839844 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1788.363281 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1851.742188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1915.21875 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1976.742188 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2040.121094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2079.330078 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(2111.117188 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2146.322266 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2174.105469 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2235.287109 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2296.46875 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2337.582031 0)"/>
+     </g>
+    </g>
+    <g id="line2d_126">
+     <path d="M 86.16152 68.318359 
+L 96.66152 68.318359 
+L 107.16152 68.318359 
+" style="fill: none; stroke-dasharray: 9.9,4.32; stroke-dashoffset: 0; stroke: #d9730d; stroke-width: 1.8"/>
+    </g>
+    <g id="text_23">
+     <!-- linear term ≈ 6.3 µs × V  (O(A·V) + HTR merkleize) -->
+     <g transform="translate(115.56152 71.993359) scale(0.105 -0.105)">
+      <defs>
+       <path id="DejaVuSans-d7" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(27.783203 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(55.566406 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(118.945312 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(180.46875 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(241.748047 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(282.861328 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(314.648438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(353.857422 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(415.380859 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(454.744141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(552.15625 0)"/>
+      <use xlink:href="#DejaVuSans-2248" transform="translate(583.943359 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(667.732422 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(699.519531 0)"/>
+      <use xlink:href="#DejaVuSans-2e" transform="translate(763.142578 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(794.929688 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(858.552734 0)"/>
+      <use xlink:href="#DejaVuSans-b5" transform="translate(890.339844 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(953.962891 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1006.0625 0)"/>
+      <use xlink:href="#DejaVuSans-d7" transform="translate(1037.849609 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1121.638672 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1153.425781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1221.833984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1253.621094 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1285.408203 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(1324.421875 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1403.132812 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1442.146484 0)"/>
+      <use xlink:href="#DejaVuSans-b7" transform="translate(1510.554688 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1542.341797 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1610.75 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1649.763672 0)"/>
+      <use xlink:href="#DejaVuSans-2b" transform="translate(1681.550781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1765.339844 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1797.126953 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(1872.322266 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1933.40625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2002.888672 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(2034.675781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2132.087891 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2193.611328 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(2234.724609 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2292.634766 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2320.417969 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(2381.941406 0)"/>
+      <use xlink:href="#DejaVuSans-7a" transform="translate(2409.724609 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2462.214844 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2523.738281 0)"/>
+     </g>
+    </g>
+    <g id="line2d_127">
+     <path d="M 86.16152 83.730391 
+L 96.66152 83.730391 
+L 107.16152 83.730391 
+" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#mdffe4c83bd" x="96.66152" y="83.730391" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- measured pipeline (incl. SHA-256 hash_tree_root) -->
+     <g transform="translate(115.56152 87.405391) scale(0.105 -0.105)">
+      <use xlink:href="#DejaVuSans-6d"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(97.412109 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(158.935547 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(220.214844 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(272.314453 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(335.693359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(374.556641 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(436.080078 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(499.556641 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(531.34375 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(594.820312 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(622.603516 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(686.080078 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(747.603516 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(775.386719 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(803.169922 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(866.548828 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(928.072266 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(959.859375 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(998.873047 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1026.65625 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1090.035156 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1145.015625 0)"/>
+      <use xlink:href="#DejaVuSans-2e" transform="translate(1172.798828 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1204.585938 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1236.373047 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1299.849609 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1375.044922 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1441.203125 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(1477.287109 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(1540.910156 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(1604.533203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1668.15625 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1699.943359 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1763.322266 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1824.601562 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1876.701172 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(1940.080078 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1990.080078 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2029.289062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2068.152344 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2129.675781 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2191.199219 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2241.199219 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2280.0625 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2341.244141 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2402.425781 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2441.634766 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_128">
+    <path d="M 277.721478 247.55911 
+" clip-path="url(#p068f66cc9a)" style="fill: none; stroke: #333333; stroke-width: 1.5; stroke-linecap: square"/>
+    <defs>
+     <path id="m05087bf41a" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #333333"/>
+    </defs>
+    <g clip-path="url(#p068f66cc9a)">
+     <use xlink:href="#m05087bf41a" x="277.721478" y="247.55911" style="fill: #333333; stroke: #333333"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_25">
+   <!-- AMD Ryzen 9 PRO 8945HS (Zen 4 mobile, 8C/16T)  ·  Linux 6.18.12+kali-amd64 x86_64  ·  Lean v4.28.0-rc1  ·  Rust release + thin LTO + codegen-units=1  ·  2026-06-26 -->
+   <g style="fill: #666666" transform="translate(2.16 390.699229) scale(0.08 -0.08)">
+    <defs>
+     <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-41"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(68.408203 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(154.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(231.689453 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(263.476562 0)"/>
+    <use xlink:href="#DejaVuSans-79" transform="translate(327.458984 0)"/>
+    <use xlink:href="#DejaVuSans-7a" transform="translate(386.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(439.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(500.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(564.03125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(595.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(659.441406 0)"/>
+    <use xlink:href="#DejaVuSans-50" transform="translate(691.228516 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(751.53125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(821.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(899.724609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(931.511719 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(995.134766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1058.757812 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1122.380859 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(1186.003906 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(1261.199219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1324.675781 0)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(1356.462891 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1395.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1463.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1525.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1620.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1684.294922 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(1716.082031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1813.494141 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(1874.675781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1938.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1965.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1993.71875 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(2055.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2087.029297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2118.816406 0)"/>
+    <use xlink:href="#DejaVuSans-43" transform="translate(2182.439453 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(2252.263672 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(2285.955078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2349.578125 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(2413.201172 0)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(2474.285156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2513.298828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2545.085938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2576.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2608.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2640.447266 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(2672.234375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2727.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2755.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2819.109375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2882.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2941.667969 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2973.455078 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3037.078125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3068.865234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3132.488281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3196.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3227.898438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3291.521484 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(3355.144531 0)"/>
+    <use xlink:href="#DejaVuSans-6b" transform="translate(3438.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3495.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3556.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3584.15625 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(3611.939453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3648.023438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(3709.302734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3806.714844 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3870.191406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3933.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3997.4375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(4029.224609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(4088.404297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4152.027344 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(4215.650391 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4265.650391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4329.273438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4392.896484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4424.683594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(4456.470703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4488.257812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4520.044922 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(4551.832031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4605.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4667.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4728.597656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4791.976562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4823.763672 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4882.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4946.566406 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4978.353516 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(5041.976562 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(5105.599609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(5137.386719 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5201.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5237.09375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5275.957031 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5330.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5394.560547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5426.347656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5458.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5489.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5521.708984 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(5553.496094 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5618.478516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(5681.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5733.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5773.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5804.953125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5843.816406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5905.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5933.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5994.646484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6055.925781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6108.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6169.548828 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(6201.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6285.125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6316.912109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6356.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6419.5 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6447.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6510.662109 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(6542.449219 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(6584.412109 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(6645.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6724.207031 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(6755.994141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6839.783203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6871.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6926.550781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6987.732422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7051.208984 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(7112.732422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7176.208984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7237.732422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(7301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7337.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7400.574219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7463.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7491.736328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7530.945312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(7583.044922 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(7666.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7730.457031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7762.244141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(7794.03125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7825.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7857.605469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(7889.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(7953.015625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8016.638672 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8080.261719 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8143.884766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(8179.96875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8243.591797 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8307.214844 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8343.298828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8406.921875 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p068f66cc9a">
+   <rect x="73.56152" y="36.002969" width="567.173829" height="303.4959"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/bench-htr-results-spec-ethlambda.svg
+++ b/docs/assets/bench-htr-results-spec-ethlambda.svg
@@ -1,0 +1,3038 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="697.269pt" height="397.00476pt" viewBox="0 0 697.269 397.00476" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7+dfsg1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 397.00476 
+L 697.269 397.00476 
+L 697.269 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 77.70152 341.75815 
+L 641.905349 341.75815 
+L 641.905349 35.04925 
+L 77.70152 35.04925 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 90.206405 341.75815 
+L 90.206405 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="me4610ad3b7" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#me4610ad3b7" x="90.206405" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 4 -->
+      <g transform="translate(86.388905 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 143.540044 341.75815 
+L 143.540044 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#me4610ad3b7" x="143.540044" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 8 -->
+      <g transform="translate(139.722544 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 303.540961 341.75815 
+L 303.540961 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#me4610ad3b7" x="303.540961" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 64 -->
+      <g transform="translate(295.905961 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 463.541878 341.75815 
+L 463.541878 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#me4610ad3b7" x="463.541878" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 512 -->
+      <g transform="translate(452.089378 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 623.542795 341.75815 
+L 623.542795 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#me4610ad3b7" x="623.542795" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4096 -->
+      <g transform="translate(608.272795 357.876275) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 107.376002 341.75815 
+L 107.376002 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_12"/>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 121.404584 341.75815 
+L 121.404584 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_14"/>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 133.265581 341.75815 
+L 133.265581 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_16"/>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 152.602763 341.75815 
+L 152.602763 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_18"/>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 214.04328 341.75815 
+L 214.04328 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_20"/>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 245.241459 341.75815 
+L 245.241459 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_22"/>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 267.376919 341.75815 
+L 267.376919 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_24"/>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 284.546516 341.75815 
+L 284.546516 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_26"/>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 298.575098 341.75815 
+L 298.575098 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_28"/>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 310.436095 341.75815 
+L 310.436095 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_30"/>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 320.710558 341.75815 
+L 320.710558 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_32"/>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 329.773277 341.75815 
+L 329.773277 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_34"/>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 391.213794 341.75815 
+L 391.213794 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_36"/>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 422.411973 341.75815 
+L 422.411973 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_38"/>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 444.547433 341.75815 
+L 444.547433 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_40"/>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 461.717029 341.75815 
+L 461.717029 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_42"/>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 475.745612 341.75815 
+L 475.745612 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_44"/>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 487.606609 341.75815 
+L 487.606609 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_46"/>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 497.881072 341.75815 
+L 497.881072 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_48"/>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 506.94379 341.75815 
+L 506.94379 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_50"/>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 568.384307 341.75815 
+L 568.384307 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_52"/>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 599.582486 341.75815 
+L 599.582486 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_54"/>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 621.717946 341.75815 
+L 621.717946 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_56"/>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 638.887543 341.75815 
+L 638.887543 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_58"/>
+    </g>
+    <g id="text_6">
+     <!-- validator count  V  (≤ leanSpec VALIDATOR_REGISTRY_LIMIT = 2¹² = 4096) -->
+     <g transform="translate(126.119841 373.869947) scale(0.125 -0.125)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2264" d="M 4684 3175 
+L 1684 2309 
+L 4684 1453 
+L 4684 897 
+L 678 2047 
+L 678 2578 
+L 4684 3725 
+L 4684 3175 
+z
+M 678 531 
+L 4684 531 
+L 4684 0 
+L 678 0 
+L 678 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 628 4666 
+L 3578 4666 
+L 3578 4134 
+L 1259 4134 
+L 1259 2753 
+L 3481 2753 
+L 3481 2222 
+L 1259 2222 
+L 1259 531 
+L 3634 531 
+L 3634 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b9" d="M 488 2431 
+L 1125 2431 
+L 1125 4341 
+L 428 4213 
+L 428 4575 
+L 1147 4697 
+L 1575 4697 
+L 1575 2431 
+L 2216 2431 
+L 2216 2088 
+L 488 2088 
+L 488 2431 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b2" d="M 838 2444 
+L 2163 2444 
+L 2163 2088 
+L 294 2088 
+L 294 2431 
+Q 400 2528 597 2703 
+Q 1672 3656 1672 3950 
+Q 1672 4156 1509 4282 
+Q 1347 4409 1081 4409 
+Q 919 4409 728 4354 
+Q 538 4300 313 4191 
+L 313 4575 
+Q 553 4663 761 4706 
+Q 969 4750 1147 4750 
+Q 1600 4750 1872 4544 
+Q 2144 4338 2144 4000 
+Q 2144 3566 1109 2678 
+Q 934 2528 838 2444 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(148.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(176.025391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(239.501953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(300.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(339.990234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(401.171875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(442.285156 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(474.072266 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(529.052734 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(590.234375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(653.613281 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(716.992188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(756.201172 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(787.988281 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(819.775391 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(888.183594 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(919.970703 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(951.757812 0)"/>
+      <use xlink:href="#DejaVuSans-2264" transform="translate(990.771484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1074.560547 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.347656 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1134.130859 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1195.654297 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1256.933594 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1320.3125 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1383.789062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1447.265625 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1508.789062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1563.769531 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1595.556641 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1657.589844 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1725.998047 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(1781.710938 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1811.203125 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1886.455078 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(1947.113281 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(2008.197266 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2086.908203 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2156.390625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2206.390625 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(2275.873047 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(2339.056641 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2416.546875 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(2446.039062 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2509.515625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2570.599609 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(2633.707031 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2694.791016 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(2744.791016 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2800.503906 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(2829.996094 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2916.275391 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2945.767578 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3006.851562 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3038.638672 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3122.427734 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(3154.214844 0)"/>
+      <use xlink:href="#DejaVuSans-b9" transform="translate(3217.837891 0)"/>
+      <use xlink:href="#DejaVuSans-b2" transform="translate(3257.925781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3298.013672 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3329.800781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3413.589844 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(3445.376953 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(3509 0)"/>
+      <use xlink:href="#DejaVuSans-39" transform="translate(3572.623047 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(3636.246094 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(3699.869141 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_59">
+      <path d="M 77.70152 312.992973 
+L 641.905349 312.992973 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <defs>
+       <path id="md0cd9e7542" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md0cd9e7542" x="77.70152" y="312.992973" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 100 µs -->
+      <g transform="translate(30.09652 317.552035) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_61">
+      <path d="M 77.70152 278.504162 
+L 641.905349 278.504162 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#md0cd9e7542" x="77.70152" y="278.504162" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 300 µs -->
+      <g transform="translate(30.09652 283.063225) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_63">
+      <path d="M 77.70152 240.707762 
+L 641.905349 240.707762 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#md0cd9e7542" x="77.70152" y="240.707762" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 1 ms -->
+      <g transform="translate(41.31277 245.266824) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_65">
+      <path d="M 77.70152 206.218951 
+L 641.905349 206.218951 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#md0cd9e7542" x="77.70152" y="206.218951" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 3 ms -->
+      <g transform="translate(41.31277 210.778014) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_67">
+      <path d="M 77.70152 168.422551 
+L 641.905349 168.422551 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#md0cd9e7542" x="77.70152" y="168.422551" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 10 ms -->
+      <g transform="translate(33.67777 172.981613) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_69">
+      <path d="M 77.70152 133.93374 
+L 641.905349 133.93374 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#md0cd9e7542" x="77.70152" y="133.93374" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 30 ms -->
+      <g transform="translate(33.67777 138.492803) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_71">
+      <path d="M 77.70152 96.13734 
+L 641.905349 96.13734 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#md0cd9e7542" x="77.70152" y="96.13734" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 100 ms -->
+      <g transform="translate(26.04277 100.696403) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_73">
+      <path d="M 77.70152 61.64853 
+L 641.905349 61.64853 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#md0cd9e7542" x="77.70152" y="61.64853" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 300 ms -->
+      <g transform="translate(26.04277 66.207592) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_75">
+      <path d="M 77.70152 341.75815 
+L 641.905349 341.75815 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_76"/>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_77">
+      <path d="M 77.70152 334.752989 
+L 641.905349 334.752989 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_78"/>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_79">
+      <path d="M 77.70152 329.029356 
+L 641.905349 329.029356 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_80"/>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_81">
+      <path d="M 77.70152 324.190093 
+L 641.905349 324.190093 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_82"/>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_83">
+      <path d="M 77.70152 319.998133 
+L 641.905349 319.998133 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_84"/>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_85">
+      <path d="M 77.70152 316.300562 
+L 641.905349 316.300562 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_86"/>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_87">
+      <path d="M 77.70152 291.232956 
+L 641.905349 291.232956 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_88"/>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_89">
+      <path d="M 77.70152 269.472939 
+L 641.905349 269.472939 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_90"/>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_91">
+      <path d="M 77.70152 262.467778 
+L 641.905349 262.467778 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_92"/>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_93">
+      <path d="M 77.70152 256.744145 
+L 641.905349 256.744145 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_94"/>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_95">
+      <path d="M 77.70152 251.904883 
+L 641.905349 251.904883 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_96"/>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_97">
+      <path d="M 77.70152 247.712922 
+L 641.905349 247.712922 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_98"/>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_99">
+      <path d="M 77.70152 244.015352 
+L 641.905349 244.015352 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_100"/>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_101">
+      <path d="M 77.70152 218.947745 
+L 641.905349 218.947745 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_102"/>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_103">
+      <path d="M 77.70152 197.187728 
+L 641.905349 197.187728 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_104"/>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_105">
+      <path d="M 77.70152 190.182568 
+L 641.905349 190.182568 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_106"/>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_107">
+      <path d="M 77.70152 184.458935 
+L 641.905349 184.458935 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_108"/>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_109">
+      <path d="M 77.70152 179.619672 
+L 641.905349 179.619672 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_110"/>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_111">
+      <path d="M 77.70152 175.427712 
+L 641.905349 175.427712 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_112"/>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_113">
+      <path d="M 77.70152 171.730141 
+L 641.905349 171.730141 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_114"/>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_115">
+      <path d="M 77.70152 146.662534 
+L 641.905349 146.662534 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_116"/>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_117">
+      <path d="M 77.70152 124.902517 
+L 641.905349 124.902517 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_118"/>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_119">
+      <path d="M 77.70152 117.897357 
+L 641.905349 117.897357 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_120"/>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_121">
+      <path d="M 77.70152 112.173724 
+L 641.905349 112.173724 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_122"/>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_123">
+      <path d="M 77.70152 107.334461 
+L 641.905349 107.334461 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_124"/>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_125">
+      <path d="M 77.70152 103.142501 
+L 641.905349 103.142501 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_126"/>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_127">
+      <path d="M 77.70152 99.44493 
+L 641.905349 99.44493 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_128"/>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_129">
+      <path d="M 77.70152 74.377323 
+L 641.905349 74.377323 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_130"/>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_131">
+      <path d="M 77.70152 52.617307 
+L 641.905349 52.617307 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_132"/>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_133">
+      <path d="M 77.70152 45.612146 
+L 641.905349 45.612146 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_134"/>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_135">
+      <path d="M 77.70152 39.888513 
+L 641.905349 39.888513 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_136"/>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_137">
+      <path d="M 77.70152 35.04925 
+L 641.905349 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_138"/>
+    </g>
+    <g id="text_15">
+     <!-- time per call (log scale) -->
+     <g transform="translate(19.443161 262.100966) rotate(-90) scale(0.125 -0.125)">
+      <defs>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-74"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(39.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(66.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(164.404297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.927734 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(257.714844 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(321.191406 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(382.714844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(423.828125 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(455.615234 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(510.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(571.875 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(599.658203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(627.441406 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(659.228516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(698.242188 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(726.025391 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(787.207031 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(850.683594 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(882.470703 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(934.570312 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(989.550781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1050.830078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1078.613281 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1140.136719 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_139">
+    <path d="M 623.542795 341.75815 
+L 623.542795 35.04925 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_140">
+    <path d="M 77.70152 74.377323 
+L 641.905349 74.377323 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 1.82,2.34; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.3"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 77.70152 341.75815 
+L 77.70152 35.04925 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 641.905349 341.75815 
+L 641.905349 35.04925 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 77.70152 341.75815 
+L 641.905349 341.75815 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 77.70152 35.04925 
+L 641.905349 35.04925 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 623.542795 174.621945 
+Q 623.542795 157.901063 623.542795 141.180181 
+" style="fill: none; stroke: #333333; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 625.542795 170.621945 
+L 623.542795 174.621945 
+L 621.542795 170.621945 
+" style="fill: none; stroke: #333333; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 621.542795 145.180181 
+L 623.542795 141.180181 
+L 625.542795 145.180181 
+" style="fill: none; stroke: #333333; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_16">
+    <!-- ≈3.6× -->
+    <g style="fill: #333333" transform="translate(584.880295 160.659766) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-2248" d="M 4684 1947 
+L 4684 1388 
+Q 4356 1144 4076 1036 
+Q 3797 928 3494 928 
+Q 3150 928 2694 1113 
+Q 2663 1125 2641 1134 
+Q 2622 1141 2575 1159 
+Q 2091 1350 1797 1350 
+Q 1522 1350 1253 1231 
+Q 984 1113 678 850 
+L 678 1409 
+Q 1006 1653 1286 1761 
+Q 1566 1869 1869 1869 
+Q 2213 1869 2672 1684 
+Q 2706 1669 2722 1663 
+Q 2741 1656 2788 1638 
+Q 3272 1447 3566 1447 
+Q 3834 1447 4098 1564 
+Q 4363 1681 4684 1947 
+z
+M 4684 3163 
+L 4684 2606 
+Q 4356 2359 4076 2251 
+Q 3797 2144 3494 2144 
+Q 3150 2144 2694 2328 
+Q 2663 2341 2641 2350 
+Q 2622 2356 2575 2375 
+Q 2091 2566 1797 2566 
+Q 1522 2566 1253 2447 
+Q 984 2328 678 2069 
+L 678 2625 
+Q 1006 2869 1286 2976 
+Q 1566 3084 1869 3084 
+Q 2213 3084 2672 2900 
+Q 2703 2888 2719 2881 
+Q 2741 2872 2788 2853 
+Q 3272 2663 3566 2663 
+Q 3834 2663 4098 2780 
+Q 4363 2897 4684 3163 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-d7" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2248"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(179.199219 0)"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(242.822266 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 324 µs -->
+    <g style="fill: #0b3d6e" transform="translate(72.133593 265.112416) scale(0.095 -0.095)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 344 µs -->
+    <g style="fill: #0b3d6e" transform="translate(125.467232 263.232029) scale(0.095 -0.095)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 712 µs -->
+    <g style="fill: #0b3d6e" transform="translate(285.468149 240.395573) scale(0.095 -0.095)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 3.85 ms -->
+    <g style="fill: #0b3d6e" transform="translate(442.354847 187.411906) scale(0.095 -0.095)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(254.443359 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 26.40 ms -->
+    <g style="fill: #0b3d6e" transform="translate(599.333576 126.971119) scale(0.095 -0.095)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 61 µs -->
+    <g style="fill: #9a5400" transform="translate(75.15578 346.677544) scale(0.095 -0.095)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 68 µs -->
+    <g style="fill: #9a5400" transform="translate(128.489419 343.503827) scale(0.095 -0.095)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 166 µs -->
+    <g style="fill: #9a5400" transform="translate(285.468149 315.357714) scale(0.095 -0.095)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 940 µs -->
+    <g style="fill: #9a5400" transform="translate(445.469066 260.878757) scale(0.095 -0.095)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 7.41 ms -->
+    <g style="fill: #9a5400" transform="translate(602.355764 196.072475) scale(0.095 -0.095)">
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(254.443359 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- VALIDATOR_REGISTRY_LIMIT = 4096 -->
+    <g style="fill: #b01010" transform="translate(436.640153 318.95732) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(62.033203 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(130.441406 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(186.154297 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(215.646484 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(290.898438 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(351.556641 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(412.640625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(491.351562 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(560.833984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(610.833984 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(680.316406 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(743.5 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(820.990234 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(850.482422 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(913.958984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(975.042969 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1038.150391 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(1099.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1149.234375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1204.947266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(1234.439453 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1320.71875 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1350.210938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1411.294922 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(1443.082031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1526.871094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1558.658203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1622.28125 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(1685.904297 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1749.527344 0)"/>
+    </g>
+    <!-- (leanSpec cap) -->
+    <g style="fill: #b01010" transform="translate(543.25734 330.433258) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-28"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(39.013672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(66.796875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(128.320312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(189.599609 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(252.978516 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(316.455078 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(379.931641 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(441.455078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(496.435547 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(528.222656 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(583.203125 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(644.482422 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(707.958984 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- SLO target 200 ms (1 interval) -->
+    <g style="fill: #555555" transform="translate(320.710558 70.173623) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(194.275391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(226.0625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(265.271484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(326.550781 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(365.914062 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(429.390625 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(490.914062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(530.123047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(561.910156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(625.533203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(689.15625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(752.779297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(784.566406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(881.978516 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(934.078125 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(965.865234 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1004.878906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1068.501953 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1100.289062 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1128.072266 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1191.451172 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1230.660156 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1292.183594 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1333.296875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1392.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1453.755859 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1481.539062 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- state_transition (full STF) — consensus-ffi-poc (Lean/FFI) vs ethlambda (native Rust) -->
+    <g transform="translate(107.164059 11.278125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(811.523438 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(850.537109 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(885.742188 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(949.121094 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(976.904297 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1004.6875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1036.474609 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1099.951172 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1161.035156 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1218.554688 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1257.568359 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1289.355469 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1389.355469 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1421.142578 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1476.123047 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1537.304688 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1600.683594 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1652.783203 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1714.306641 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1777.685547 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1829.785156 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1893.164062 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1945.263672 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(1981.347656 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2016.552734 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2051.757812 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(2079.541016 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2115.625 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2179.101562 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(2240.283203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2295.263672 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2327.050781 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2366.064453 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2420.027344 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2481.550781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2542.830078 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(2606.208984 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(2639.900391 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(2697.419922 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(2754.939453 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2784.431641 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2823.445312 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(2855.232422 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2914.412109 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2966.511719 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2998.298828 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3059.822266 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3099.03125 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3162.410156 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3190.193359 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3251.472656 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(3348.884766 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(3412.361328 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3475.837891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3537.117188 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(3568.904297 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3607.917969 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3671.296875 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3732.576172 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3771.785156 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(3799.568359 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3858.748047 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3920.271484 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(3952.058594 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(4017.041016 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4080.419922 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4132.519531 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(4171.728516 0)"/>
+    </g>
+    <!-- A=8 valid attestations, incl. SHA-256 hash_tree_root · leanSpec range (V ≤ 4096) -->
+    <g transform="translate(115.117809 25.04925) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-48" d="M 628 4666 
+L 1259 4666 
+L 1259 2753 
+L 3553 2753 
+L 3553 4666 
+L 4184 4666 
+L 4184 0 
+L 3553 0 
+L 3553 2222 
+L 1259 2222 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-41"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(215.820312 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(247.607422 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(306.787109 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(368.066406 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(395.849609 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(423.632812 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(487.109375 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(518.896484 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(580.175781 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(619.384766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(658.59375 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(720.117188 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(772.216797 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(811.425781 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(872.705078 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(911.914062 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(939.697266 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1000.878906 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1064.257812 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(1116.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1148.144531 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1179.931641 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1207.714844 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1271.09375 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1326.074219 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(1353.857422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1385.644531 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1417.431641 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1480.908203 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(1556.103516 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1622.261719 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(1658.345703 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(1721.96875 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1785.591797 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1849.214844 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1881.001953 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1944.380859 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2005.660156 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2057.759766 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(2121.138672 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2171.138672 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2210.347656 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2249.210938 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2310.734375 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(2372.257812 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2422.257812 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2461.121094 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2522.302734 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2583.484375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2622.693359 0)"/>
+     <use xlink:href="#DejaVuSans-b7" transform="translate(2654.480469 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2686.267578 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2718.054688 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2745.837891 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2807.361328 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2868.640625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(2932.019531 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2995.496094 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3058.972656 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3120.496094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3175.476562 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3207.263672 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3248.376953 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3309.65625 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(3373.035156 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3436.511719 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3498.035156 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(3529.822266 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(3568.835938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3637.244141 0)"/>
+     <use xlink:href="#DejaVuSans-2264" transform="translate(3669.03125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3752.820312 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(3784.607422 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3848.230469 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(3911.853516 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(3975.476562 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(4039.099609 0)"/>
+    </g>
+   </g>
+   <g id="line2d_141">
+    <path d="M 90.206405 276.088119 
+L 143.540044 274.207732 
+L 303.540961 251.371276 
+L 463.541878 198.387609 
+L 623.542795 137.946822 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+    <defs>
+     <path id="mb182a99705" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p32629a90c9)">
+     <use xlink:href="#mb182a99705" x="90.206405" y="276.088119" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mb182a99705" x="143.540044" y="274.207732" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mb182a99705" x="303.540961" y="251.371276" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mb182a99705" x="463.541878" y="198.387609" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mb182a99705" x="623.542795" y="137.946822" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_142">
+    <path d="M 90.206405 328.459029 
+L 143.540044 325.285312 
+L 303.540961 297.139199 
+L 463.541878 242.660241 
+L 623.542795 177.853959 
+" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #e6810a; stroke-width: 2.4; stroke-linecap: round"/>
+    <defs>
+     <path id="m41fb67ada5" d="M -3.25 3.25 
+L 3.25 3.25 
+L 3.25 -3.25 
+L -3.25 -3.25 
+z
+" style="stroke: #e6810a; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p32629a90c9)">
+     <use xlink:href="#m41fb67ada5" x="90.206405" y="328.459029" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+     <use xlink:href="#m41fb67ada5" x="143.540044" y="325.285312" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+     <use xlink:href="#m41fb67ada5" x="303.540961" y="297.139199" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+     <use xlink:href="#m41fb67ada5" x="463.541878" y="242.660241" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+     <use xlink:href="#m41fb67ada5" x="623.542795" y="177.853959" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 85.05152 80.573313 
+L 372.950036 80.573313 
+Q 375.050036 80.573313 375.050036 78.473313 
+L 375.050036 42.39925 
+Q 375.050036 40.29925 372.950036 40.29925 
+L 85.05152 40.29925 
+Q 82.95152 40.29925 82.95152 42.39925 
+L 82.95152 78.473313 
+Q 82.95152 80.573313 85.05152 80.573313 
+z
+" style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-width: 0.8; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_143">
+     <path d="M 90.30152 51.952609 
+L 100.80152 51.952609 
+L 111.30152 51.952609 
+" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#mb182a99705" x="100.80152" y="51.952609" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_30">
+     <!-- consensus-ffi-poc — Lean (Aeneas) via Rust FFI -->
+     <g transform="translate(119.70152 55.627609) scale(0.105 -0.105)">
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(116.162109 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(179.541016 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(231.640625 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(293.164062 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(356.542969 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(408.642578 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(472.021484 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(524.121094 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(560.205078 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(595.410156 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(630.615234 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(658.398438 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(694.482422 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(757.958984 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(819.140625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(874.121094 0)"/>
+      <use xlink:href="#DejaVuSans-2014" transform="translate(905.908203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1005.908203 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1037.695312 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1091.658203 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1153.181641 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1214.460938 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1277.839844 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1309.626953 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1348.640625 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1415.298828 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1476.822266 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1540.201172 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1601.724609 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1663.003906 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1715.103516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1754.117188 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(1785.904297 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1845.083984 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1872.867188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1934.146484 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1965.933594 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(2030.916016 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2094.294922 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2146.394531 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2185.603516 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(2217.390625 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(2274.910156 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2332.429688 0)"/>
+     </g>
+    </g>
+    <g id="line2d_144">
+     <path d="M 90.30152 67.364641 
+L 100.80152 67.364641 
+L 111.30152 67.364641 
+" style="fill: none; stroke: #e6810a; stroke-width: 2.4; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#m41fb67ada5" x="100.80152" y="67.364641" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_31">
+     <!-- ethlambda — native Rust (lambdaclass) -->
+     <g transform="translate(119.70152 71.039641) scale(0.105 -0.105)">
+      <use xlink:href="#DejaVuSans-65"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(61.523438 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(100.732422 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(164.111328 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(191.894531 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(253.173828 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(350.585938 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(414.0625 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(477.539062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(538.818359 0)"/>
+      <use xlink:href="#DejaVuSans-2014" transform="translate(570.605469 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(670.605469 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(702.392578 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(765.771484 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(827.050781 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(866.259766 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(894.042969 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(953.222656 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1014.746094 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1046.533203 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1111.515625 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1174.894531 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1226.994141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1266.203125 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1297.990234 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1337.003906 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1364.787109 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1426.066406 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(1523.478516 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1586.955078 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1650.431641 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1711.710938 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1766.691406 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1794.474609 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1855.753906 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1907.853516 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1959.953125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_32">
+   <!-- AMD Ryzen 9 PRO 8945HS (Zen 4 mobile, 8C/16T)  ·  Linux 6.18.12+kali-amd64 x86_64  ·  both: Rust release  ·  ethlambda @ lambdaclass/ethlambda, libssz Sha2 HTR  ·  2026-06-26 -->
+   <g style="fill: #666666" transform="translate(2.16 393.052823) scale(0.076 -0.076)">
+    <defs>
+     <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-40" d="M 2381 1678 
+Q 2381 1231 2603 976 
+Q 2825 722 3213 722 
+Q 3597 722 3817 978 
+Q 4038 1234 4038 1678 
+Q 4038 2116 3813 2373 
+Q 3588 2631 3206 2631 
+Q 2828 2631 2604 2375 
+Q 2381 2119 2381 1678 
+z
+M 4084 744 
+Q 3897 503 3655 389 
+Q 3413 275 3091 275 
+Q 2553 275 2217 664 
+Q 1881 1053 1881 1678 
+Q 1881 2303 2218 2693 
+Q 2556 3084 3091 3084 
+Q 3413 3084 3656 2967 
+Q 3900 2850 4084 2613 
+L 4084 3022 
+L 4531 3022 
+L 4531 722 
+Q 4988 791 5245 1139 
+Q 5503 1488 5503 2041 
+Q 5503 2375 5404 2669 
+Q 5306 2963 5106 3213 
+Q 4781 3622 4314 3839 
+Q 3847 4056 3297 4056 
+Q 2913 4056 2559 3954 
+Q 2206 3853 1906 3653 
+Q 1416 3334 1139 2817 
+Q 863 2300 863 1697 
+Q 863 1200 1042 765 
+Q 1222 331 1563 0 
+Q 1891 -325 2322 -495 
+Q 2753 -666 3244 -666 
+Q 3647 -666 4036 -530 
+Q 4425 -394 4750 -141 
+L 5031 -488 
+Q 4641 -791 4180 -952 
+Q 3719 -1113 3244 -1113 
+Q 2666 -1113 2153 -908 
+Q 1641 -703 1241 -313 
+Q 841 78 631 592 
+Q 422 1106 422 1697 
+Q 422 2266 634 2781 
+Q 847 3297 1241 3688 
+Q 1644 4084 2172 4295 
+Q 2700 4506 3291 4506 
+Q 3953 4506 4520 4234 
+Q 5088 3963 5472 3463 
+Q 5706 3156 5829 2797 
+Q 5953 2438 5953 2053 
+Q 5953 1231 5456 756 
+Q 4959 281 4084 263 
+L 4084 744 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-41"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(68.408203 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(154.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(231.689453 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(263.476562 0)"/>
+    <use xlink:href="#DejaVuSans-79" transform="translate(327.458984 0)"/>
+    <use xlink:href="#DejaVuSans-7a" transform="translate(386.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(439.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(500.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(564.03125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(595.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(659.441406 0)"/>
+    <use xlink:href="#DejaVuSans-50" transform="translate(691.228516 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(751.53125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(821.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(899.724609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(931.511719 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(995.134766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1058.757812 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1122.380859 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(1186.003906 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(1261.199219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1324.675781 0)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(1356.462891 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1395.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1463.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1525.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1620.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1684.294922 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(1716.082031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1813.494141 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(1874.675781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1938.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1965.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1993.71875 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(2055.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2087.029297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2118.816406 0)"/>
+    <use xlink:href="#DejaVuSans-43" transform="translate(2182.439453 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(2252.263672 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(2285.955078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2349.578125 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(2413.201172 0)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(2474.285156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2513.298828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2545.085938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2576.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2608.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2640.447266 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(2672.234375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2727.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2755.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2819.109375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2882.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2941.667969 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2973.455078 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3037.078125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3068.865234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3132.488281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3196.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3227.898438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3291.521484 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(3355.144531 0)"/>
+    <use xlink:href="#DejaVuSans-6b" transform="translate(3438.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3495.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3556.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3584.15625 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(3611.939453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3648.023438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(3709.302734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3806.714844 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3870.191406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3933.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3997.4375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(4029.224609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(4088.404297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4152.027344 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(4215.650391 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4265.650391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4329.273438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4392.896484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4424.683594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(4456.470703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4488.257812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4520.044922 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4551.832031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4615.308594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4676.490234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(4715.699219 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4779.078125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4812.769531 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(4844.556641 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(4909.539062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4972.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5025.017578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5064.226562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5096.013672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5134.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5196.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5224.183594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5285.707031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(5346.986328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5399.085938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5460.609375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5492.396484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5524.183594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5555.970703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5587.757812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5619.544922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5681.068359 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5720.277344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5783.65625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5811.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5872.71875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(5970.130859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6033.607422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6097.083984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6158.363281 0)"/>
+    <use xlink:href="#DejaVuSans-40" transform="translate(6190.150391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6290.150391 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(6321.9375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6349.720703 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6411 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(6508.412109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6571.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6635.365234 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6696.644531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(6751.625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6779.408203 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6840.6875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6892.787109 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(6944.886719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6978.578125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7040.101562 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7079.310547 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(7142.689453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7170.472656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7231.751953 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(7329.164062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7392.640625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7456.117188 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(7517.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7549.183594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(7580.970703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7608.753906 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(7636.537109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7700.013672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7752.113281 0)"/>
+    <use xlink:href="#DejaVuSans-7a" transform="translate(7804.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7856.703125 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(7888.490234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7951.966797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8015.345703 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8076.625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8140.248047 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(8172.035156 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(8247.230469 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(8308.314453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8377.796875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8409.583984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(8441.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8473.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8504.945312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8536.732422 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(8600.355469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8663.978516 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8727.601562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8791.224609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(8827.308594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8890.931641 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8954.554688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8990.638672 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(9054.261719 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p32629a90c9">
+   <rect x="77.70152" y="35.04925" width="564.203829" height="306.7089"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/bench-htr-results-spec-vs-native-rust.svg
+++ b/docs/assets/bench-htr-results-spec-vs-native-rust.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="697.269pt" height="397.00476pt" viewBox="0 0 697.269 397.00476" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="735.8675pt" height="397.00476pt" viewBox="0 0 735.8675 397.00476" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -21,8 +21,8 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 397.00476 
-L 697.269 397.00476 
-L 697.269 0 
+L 735.8675 397.00476 
+L 735.8675 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
@@ -41,16 +41,16 @@ z
      <g id="line2d_1">
       <path d="M 90.206405 341.75815 
 L 90.206405 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="me4610ad3b7" d="M 0 0 
+       <path id="m811f6c7884" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me4610ad3b7" x="90.206405" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m811f6c7884" x="90.206405" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -85,11 +85,11 @@ z
      <g id="line2d_3">
       <path d="M 143.540044 341.75815 
 L 143.540044 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me4610ad3b7" x="143.540044" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m811f6c7884" x="143.540044" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -144,11 +144,11 @@ z
      <g id="line2d_5">
       <path d="M 303.540961 341.75815 
 L 303.540961 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me4610ad3b7" x="303.540961" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m811f6c7884" x="303.540961" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -195,11 +195,11 @@ z
      <g id="line2d_7">
       <path d="M 463.541878 341.75815 
 L 463.541878 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me4610ad3b7" x="463.541878" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m811f6c7884" x="463.541878" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -280,11 +280,11 @@ z
      <g id="line2d_9">
       <path d="M 623.542795 341.75815 
 L 623.542795 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me4610ad3b7" x="623.542795" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m811f6c7884" x="623.542795" y="341.75815" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -354,7 +354,7 @@ z
      <g id="line2d_11">
       <path d="M 107.376002 341.75815 
 L 107.376002 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_12"/>
     </g>
@@ -362,7 +362,7 @@ L 107.376002 35.04925
      <g id="line2d_13">
       <path d="M 121.404584 341.75815 
 L 121.404584 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_14"/>
     </g>
@@ -370,7 +370,7 @@ L 121.404584 35.04925
      <g id="line2d_15">
       <path d="M 133.265581 341.75815 
 L 133.265581 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_16"/>
     </g>
@@ -378,7 +378,7 @@ L 133.265581 35.04925
      <g id="line2d_17">
       <path d="M 152.602763 341.75815 
 L 152.602763 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_18"/>
     </g>
@@ -386,7 +386,7 @@ L 152.602763 35.04925
      <g id="line2d_19">
       <path d="M 214.04328 341.75815 
 L 214.04328 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_20"/>
     </g>
@@ -394,7 +394,7 @@ L 214.04328 35.04925
      <g id="line2d_21">
       <path d="M 245.241459 341.75815 
 L 245.241459 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_22"/>
     </g>
@@ -402,7 +402,7 @@ L 245.241459 35.04925
      <g id="line2d_23">
       <path d="M 267.376919 341.75815 
 L 267.376919 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_24"/>
     </g>
@@ -410,7 +410,7 @@ L 267.376919 35.04925
      <g id="line2d_25">
       <path d="M 284.546516 341.75815 
 L 284.546516 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_26"/>
     </g>
@@ -418,7 +418,7 @@ L 284.546516 35.04925
      <g id="line2d_27">
       <path d="M 298.575098 341.75815 
 L 298.575098 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_28"/>
     </g>
@@ -426,7 +426,7 @@ L 298.575098 35.04925
      <g id="line2d_29">
       <path d="M 310.436095 341.75815 
 L 310.436095 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_30"/>
     </g>
@@ -434,7 +434,7 @@ L 310.436095 35.04925
      <g id="line2d_31">
       <path d="M 320.710558 341.75815 
 L 320.710558 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_32"/>
     </g>
@@ -442,7 +442,7 @@ L 320.710558 35.04925
      <g id="line2d_33">
       <path d="M 329.773277 341.75815 
 L 329.773277 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_34"/>
     </g>
@@ -450,7 +450,7 @@ L 329.773277 35.04925
      <g id="line2d_35">
       <path d="M 391.213794 341.75815 
 L 391.213794 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_36"/>
     </g>
@@ -458,7 +458,7 @@ L 391.213794 35.04925
      <g id="line2d_37">
       <path d="M 422.411973 341.75815 
 L 422.411973 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_38"/>
     </g>
@@ -466,7 +466,7 @@ L 422.411973 35.04925
      <g id="line2d_39">
       <path d="M 444.547433 341.75815 
 L 444.547433 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_40"/>
     </g>
@@ -474,7 +474,7 @@ L 444.547433 35.04925
      <g id="line2d_41">
       <path d="M 461.717029 341.75815 
 L 461.717029 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_42"/>
     </g>
@@ -482,7 +482,7 @@ L 461.717029 35.04925
      <g id="line2d_43">
       <path d="M 475.745612 341.75815 
 L 475.745612 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_44"/>
     </g>
@@ -490,7 +490,7 @@ L 475.745612 35.04925
      <g id="line2d_45">
       <path d="M 487.606609 341.75815 
 L 487.606609 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_46"/>
     </g>
@@ -498,7 +498,7 @@ L 487.606609 35.04925
      <g id="line2d_47">
       <path d="M 497.881072 341.75815 
 L 497.881072 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_48"/>
     </g>
@@ -506,7 +506,7 @@ L 497.881072 35.04925
      <g id="line2d_49">
       <path d="M 506.94379 341.75815 
 L 506.94379 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_50"/>
     </g>
@@ -514,7 +514,7 @@ L 506.94379 35.04925
      <g id="line2d_51">
       <path d="M 568.384307 341.75815 
 L 568.384307 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_52"/>
     </g>
@@ -522,7 +522,7 @@ L 568.384307 35.04925
      <g id="line2d_53">
       <path d="M 599.582486 341.75815 
 L 599.582486 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_54"/>
     </g>
@@ -530,7 +530,7 @@ L 599.582486 35.04925
      <g id="line2d_55">
       <path d="M 621.717946 341.75815 
 L 621.717946 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_56"/>
     </g>
@@ -538,7 +538,7 @@ L 621.717946 35.04925
      <g id="line2d_57">
       <path d="M 638.887543 341.75815 
 L 638.887543 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_58"/>
     </g>
@@ -1203,16 +1203,16 @@ z
      <g id="line2d_59">
       <path d="M 77.70152 312.992973 
 L 641.905349 312.992973 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <defs>
-       <path id="md0cd9e7542" d="M 0 0 
+       <path id="m355072894e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md0cd9e7542" x="77.70152" y="312.992973" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m355072894e" x="77.70152" y="312.992973" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1292,11 +1292,11 @@ z
      <g id="line2d_61">
       <path d="M 77.70152 278.504162 
 L 641.905349 278.504162 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#md0cd9e7542" x="77.70152" y="278.504162" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m355072894e" x="77.70152" y="278.504162" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1349,11 +1349,11 @@ z
      <g id="line2d_63">
       <path d="M 77.70152 240.707762 
 L 641.905349 240.707762 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#md0cd9e7542" x="77.70152" y="240.707762" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m355072894e" x="77.70152" y="240.707762" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1402,11 +1402,11 @@ z
      <g id="line2d_65">
       <path d="M 77.70152 206.218951 
 L 641.905349 206.218951 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#md0cd9e7542" x="77.70152" y="206.218951" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m355072894e" x="77.70152" y="206.218951" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1423,11 +1423,11 @@ L 641.905349 206.218951
      <g id="line2d_67">
       <path d="M 77.70152 168.422551 
 L 641.905349 168.422551 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#md0cd9e7542" x="77.70152" y="168.422551" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m355072894e" x="77.70152" y="168.422551" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1445,11 +1445,11 @@ L 641.905349 168.422551
      <g id="line2d_69">
       <path d="M 77.70152 133.93374 
 L 641.905349 133.93374 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#md0cd9e7542" x="77.70152" y="133.93374" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m355072894e" x="77.70152" y="133.93374" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -1467,11 +1467,11 @@ L 641.905349 133.93374
      <g id="line2d_71">
       <path d="M 77.70152 96.13734 
 L 641.905349 96.13734 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#md0cd9e7542" x="77.70152" y="96.13734" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m355072894e" x="77.70152" y="96.13734" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1490,11 +1490,11 @@ L 641.905349 96.13734
      <g id="line2d_73">
       <path d="M 77.70152 61.64853 
 L 641.905349 61.64853 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#md0cd9e7542" x="77.70152" y="61.64853" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m355072894e" x="77.70152" y="61.64853" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1513,7 +1513,7 @@ L 641.905349 61.64853
      <g id="line2d_75">
       <path d="M 77.70152 341.75815 
 L 641.905349 341.75815 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_76"/>
     </g>
@@ -1521,7 +1521,7 @@ L 641.905349 341.75815
      <g id="line2d_77">
       <path d="M 77.70152 334.752989 
 L 641.905349 334.752989 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_78"/>
     </g>
@@ -1529,7 +1529,7 @@ L 641.905349 334.752989
      <g id="line2d_79">
       <path d="M 77.70152 329.029356 
 L 641.905349 329.029356 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_80"/>
     </g>
@@ -1537,7 +1537,7 @@ L 641.905349 329.029356
      <g id="line2d_81">
       <path d="M 77.70152 324.190093 
 L 641.905349 324.190093 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_82"/>
     </g>
@@ -1545,7 +1545,7 @@ L 641.905349 324.190093
      <g id="line2d_83">
       <path d="M 77.70152 319.998133 
 L 641.905349 319.998133 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_84"/>
     </g>
@@ -1553,7 +1553,7 @@ L 641.905349 319.998133
      <g id="line2d_85">
       <path d="M 77.70152 316.300562 
 L 641.905349 316.300562 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_86"/>
     </g>
@@ -1561,7 +1561,7 @@ L 641.905349 316.300562
      <g id="line2d_87">
       <path d="M 77.70152 291.232956 
 L 641.905349 291.232956 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_88"/>
     </g>
@@ -1569,7 +1569,7 @@ L 641.905349 291.232956
      <g id="line2d_89">
       <path d="M 77.70152 269.472939 
 L 641.905349 269.472939 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_90"/>
     </g>
@@ -1577,7 +1577,7 @@ L 641.905349 269.472939
      <g id="line2d_91">
       <path d="M 77.70152 262.467778 
 L 641.905349 262.467778 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_92"/>
     </g>
@@ -1585,7 +1585,7 @@ L 641.905349 262.467778
      <g id="line2d_93">
       <path d="M 77.70152 256.744145 
 L 641.905349 256.744145 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_94"/>
     </g>
@@ -1593,7 +1593,7 @@ L 641.905349 256.744145
      <g id="line2d_95">
       <path d="M 77.70152 251.904883 
 L 641.905349 251.904883 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_96"/>
     </g>
@@ -1601,7 +1601,7 @@ L 641.905349 251.904883
      <g id="line2d_97">
       <path d="M 77.70152 247.712922 
 L 641.905349 247.712922 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_98"/>
     </g>
@@ -1609,7 +1609,7 @@ L 641.905349 247.712922
      <g id="line2d_99">
       <path d="M 77.70152 244.015352 
 L 641.905349 244.015352 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_100"/>
     </g>
@@ -1617,7 +1617,7 @@ L 641.905349 244.015352
      <g id="line2d_101">
       <path d="M 77.70152 218.947745 
 L 641.905349 218.947745 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_102"/>
     </g>
@@ -1625,7 +1625,7 @@ L 641.905349 218.947745
      <g id="line2d_103">
       <path d="M 77.70152 197.187728 
 L 641.905349 197.187728 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_104"/>
     </g>
@@ -1633,7 +1633,7 @@ L 641.905349 197.187728
      <g id="line2d_105">
       <path d="M 77.70152 190.182568 
 L 641.905349 190.182568 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_106"/>
     </g>
@@ -1641,7 +1641,7 @@ L 641.905349 190.182568
      <g id="line2d_107">
       <path d="M 77.70152 184.458935 
 L 641.905349 184.458935 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_108"/>
     </g>
@@ -1649,7 +1649,7 @@ L 641.905349 184.458935
      <g id="line2d_109">
       <path d="M 77.70152 179.619672 
 L 641.905349 179.619672 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_110"/>
     </g>
@@ -1657,7 +1657,7 @@ L 641.905349 179.619672
      <g id="line2d_111">
       <path d="M 77.70152 175.427712 
 L 641.905349 175.427712 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_112"/>
     </g>
@@ -1665,7 +1665,7 @@ L 641.905349 175.427712
      <g id="line2d_113">
       <path d="M 77.70152 171.730141 
 L 641.905349 171.730141 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_114"/>
     </g>
@@ -1673,7 +1673,7 @@ L 641.905349 171.730141
      <g id="line2d_115">
       <path d="M 77.70152 146.662534 
 L 641.905349 146.662534 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_116"/>
     </g>
@@ -1681,7 +1681,7 @@ L 641.905349 146.662534
      <g id="line2d_117">
       <path d="M 77.70152 124.902517 
 L 641.905349 124.902517 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_118"/>
     </g>
@@ -1689,7 +1689,7 @@ L 641.905349 124.902517
      <g id="line2d_119">
       <path d="M 77.70152 117.897357 
 L 641.905349 117.897357 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_120"/>
     </g>
@@ -1697,7 +1697,7 @@ L 641.905349 117.897357
      <g id="line2d_121">
       <path d="M 77.70152 112.173724 
 L 641.905349 112.173724 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_122"/>
     </g>
@@ -1705,7 +1705,7 @@ L 641.905349 112.173724
      <g id="line2d_123">
       <path d="M 77.70152 107.334461 
 L 641.905349 107.334461 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_124"/>
     </g>
@@ -1713,7 +1713,7 @@ L 641.905349 107.334461
      <g id="line2d_125">
       <path d="M 77.70152 103.142501 
 L 641.905349 103.142501 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_126"/>
     </g>
@@ -1721,7 +1721,7 @@ L 641.905349 103.142501
      <g id="line2d_127">
       <path d="M 77.70152 99.44493 
 L 641.905349 99.44493 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_128"/>
     </g>
@@ -1729,7 +1729,7 @@ L 641.905349 99.44493
      <g id="line2d_129">
       <path d="M 77.70152 74.377323 
 L 641.905349 74.377323 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_130"/>
     </g>
@@ -1737,7 +1737,7 @@ L 641.905349 74.377323
      <g id="line2d_131">
       <path d="M 77.70152 52.617307 
 L 641.905349 52.617307 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_132"/>
     </g>
@@ -1745,7 +1745,7 @@ L 641.905349 52.617307
      <g id="line2d_133">
       <path d="M 77.70152 45.612146 
 L 641.905349 45.612146 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_134"/>
     </g>
@@ -1753,7 +1753,7 @@ L 641.905349 45.612146
      <g id="line2d_135">
       <path d="M 77.70152 39.888513 
 L 641.905349 39.888513 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_136"/>
     </g>
@@ -1761,7 +1761,7 @@ L 641.905349 39.888513
      <g id="line2d_137">
       <path d="M 77.70152 35.04925 
 L 641.905349 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_138"/>
     </g>
@@ -1835,12 +1835,12 @@ z
    <g id="line2d_139">
     <path d="M 623.542795 341.75815 
 L 623.542795 35.04925 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
    </g>
    <g id="line2d_140">
     <path d="M 77.70152 74.377323 
 L 641.905349 74.377323 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke-dasharray: 1.82,2.34; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.3"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke-dasharray: 1.82,2.34; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.3"/>
    </g>
    <g id="patch_3">
     <path d="M 77.70152 341.75815 
@@ -2163,8 +2163,8 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- state_transition (full STF) — consensus-ffi-poc (Lean/FFI) vs ethlambda (native Rust) -->
-    <g transform="translate(107.164059 11.278125) scale(0.12 -0.12)">
+    <!-- state_transition (full STF) — consensus-ffi-poc (Lean/FFI) vs native-Rust implementation -->
+    <g transform="translate(96.378122 11.278125) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -2219,51 +2219,6 @@ L 2156 4666
 L 531 -594 
 L 0 -594 
 L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-68" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-62" d="M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-M 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2969 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -2329,29 +2284,32 @@ z
      <use xlink:href="#DejaVuSans-76" transform="translate(2855.232422 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(2914.412109 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(2966.511719 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2998.298828 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3059.822266 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(3099.03125 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3162.410156 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3190.193359 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(3251.472656 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(3348.884766 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(3412.361328 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3475.837891 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3537.117188 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(3568.904297 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3607.917969 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3671.296875 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3732.576172 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3771.785156 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(3799.568359 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3858.748047 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3920.271484 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(3952.058594 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(4017.041016 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(4080.419922 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(4132.519531 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(4171.728516 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2998.298828 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3061.677734 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3122.957031 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3162.166016 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(3189.949219 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3249.128906 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(3310.652344 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(3346.736328 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(3411.71875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3475.097656 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3527.197266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3566.40625 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3598.193359 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3625.976562 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(3723.388672 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3786.865234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3814.648438 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3876.171875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3973.583984 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4035.107422 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4098.486328 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(4137.695312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4198.974609 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(4238.183594 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4265.966797 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4327.148438 0)"/>
     </g>
     <!-- A=8 valid attestations, incl. SHA-256 hash_tree_root · leanSpec range (V ≤ 4096) -->
     <g transform="translate(115.117809 25.04925) scale(0.12 -0.12)">
@@ -2378,6 +2336,25 @@ L 1259 2222
 L 1259 0 
 L 628 0 
 L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2476,9 +2453,9 @@ L 143.540044 274.207732
 L 303.540961 251.371276 
 L 463.541878 198.387609 
 L 623.542795 137.946822 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
     <defs>
-     <path id="mb182a99705" d="M 0 3.5 
+     <path id="maadfceeae7" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2490,12 +2467,12 @@ C -1.81853 3.131218 -0.928211 3.5 0 3.5
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p32629a90c9)">
-     <use xlink:href="#mb182a99705" x="90.206405" y="276.088119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb182a99705" x="143.540044" y="274.207732" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb182a99705" x="303.540961" y="251.371276" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb182a99705" x="463.541878" y="198.387609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb182a99705" x="623.542795" y="137.946822" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pdcdc12aac5)">
+     <use xlink:href="#maadfceeae7" x="90.206405" y="276.088119" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#maadfceeae7" x="143.540044" y="274.207732" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#maadfceeae7" x="303.540961" y="251.371276" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#maadfceeae7" x="463.541878" y="198.387609" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#maadfceeae7" x="623.542795" y="137.946822" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_142">
@@ -2504,21 +2481,21 @@ L 143.540044 325.285312
 L 303.540961 297.139199 
 L 463.541878 242.660241 
 L 623.542795 177.853959 
-" clip-path="url(#p32629a90c9)" style="fill: none; stroke: #e6810a; stroke-width: 2.4; stroke-linecap: round"/>
+" clip-path="url(#pdcdc12aac5)" style="fill: none; stroke: #e6810a; stroke-width: 2.4; stroke-linecap: round"/>
     <defs>
-     <path id="m41fb67ada5" d="M -3.25 3.25 
+     <path id="m3362204c98" d="M -3.25 3.25 
 L 3.25 3.25 
 L 3.25 -3.25 
 L -3.25 -3.25 
 z
 " style="stroke: #e6810a; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p32629a90c9)">
-     <use xlink:href="#m41fb67ada5" x="90.206405" y="328.459029" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
-     <use xlink:href="#m41fb67ada5" x="143.540044" y="325.285312" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
-     <use xlink:href="#m41fb67ada5" x="303.540961" y="297.139199" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
-     <use xlink:href="#m41fb67ada5" x="463.541878" y="242.660241" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
-     <use xlink:href="#m41fb67ada5" x="623.542795" y="177.853959" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+    <g clip-path="url(#pdcdc12aac5)">
+     <use xlink:href="#m3362204c98" x="90.206405" y="328.459029" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+     <use xlink:href="#m3362204c98" x="143.540044" y="325.285312" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+     <use xlink:href="#m3362204c98" x="303.540961" y="297.139199" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+     <use xlink:href="#m3362204c98" x="463.541878" y="242.660241" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+     <use xlink:href="#m3362204c98" x="623.542795" y="177.853959" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2541,7 +2518,7 @@ L 100.80152 51.952609
 L 111.30152 51.952609 
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#mb182a99705" x="100.80152" y="51.952609" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#maadfceeae7" x="100.80152" y="51.952609" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_30">
@@ -2601,55 +2578,56 @@ L 100.80152 67.364641
 L 111.30152 67.364641 
 " style="fill: none; stroke: #e6810a; stroke-width: 2.4; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#m41fb67ada5" x="100.80152" y="67.364641" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
+      <use xlink:href="#m3362204c98" x="100.80152" y="67.364641" style="fill: #e6810a; stroke: #e6810a; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_31">
-     <!-- ethlambda — native Rust (lambdaclass) -->
+     <!-- independent native-Rust implementation -->
      <g transform="translate(119.70152 71.039641) scale(0.105 -0.105)">
-      <use xlink:href="#DejaVuSans-65"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(61.523438 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(100.732422 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(164.111328 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(191.894531 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(253.173828 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(350.585938 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(414.0625 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(477.539062 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(538.818359 0)"/>
-      <use xlink:href="#DejaVuSans-2014" transform="translate(570.605469 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(670.605469 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(702.392578 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(765.771484 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(827.050781 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(866.259766 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(894.042969 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(953.222656 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1014.746094 0)"/>
-      <use xlink:href="#DejaVuSans-52" transform="translate(1046.533203 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(1111.515625 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1174.894531 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(1226.994141 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1266.203125 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(1297.990234 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1337.003906 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1364.787109 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(1426.066406 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(1523.478516 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(1586.955078 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1650.431641 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(1711.710938 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1766.691406 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1794.474609 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1855.753906 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1907.853516 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(1959.953125 0)"/>
+      <use xlink:href="#DejaVuSans-69"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(27.783203 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(91.162109 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(154.638672 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(216.162109 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(279.638672 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(341.162109 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(404.541016 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(468.017578 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(529.541016 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(592.919922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(632.128906 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(663.916016 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(727.294922 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(788.574219 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(827.783203 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(855.566406 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(914.746094 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(976.269531 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1012.353516 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1077.335938 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1140.714844 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1192.814453 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1232.023438 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1263.810547 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1291.59375 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1389.005859 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1452.482422 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1480.265625 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1541.789062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1639.201172 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1700.724609 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1764.103516 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1803.3125 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1864.591797 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1903.800781 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1931.583984 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1992.765625 0)"/>
      </g>
     </g>
    </g>
   </g>
   <g id="text_32">
-   <!-- AMD Ryzen 9 PRO 8945HS (Zen 4 mobile, 8C/16T)  ·  Linux 6.18.12+kali-amd64 x86_64  ·  both: Rust release  ·  ethlambda @ lambdaclass/ethlambda, libssz Sha2 HTR  ·  2026-06-26 -->
+   <!-- AMD Ryzen 9 PRO 8945HS (Zen 4 mobile, 8C/16T)  ·  Linux 6.18.12+kali-amd64 x86_64  ·  both: Rust release  ·  native-Rust impl: same protocol &amp; spec constants, SSZ Sha2 HTR  ·  2026-06-26 -->
    <g style="fill: #666666" transform="translate(2.16 393.052823) scale(0.076 -0.076)">
     <defs>
      <path id="DejaVuSans-79" d="M 2059 -325 
@@ -2714,6 +2692,32 @@ L 288 481
 L 3238 4134 
 L 359 4134 
 L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-43" d="M 4122 4306 
@@ -2794,62 +2798,44 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-40" d="M 2381 1678 
-Q 2381 1231 2603 976 
-Q 2825 722 3213 722 
-Q 3597 722 3817 978 
-Q 4038 1234 4038 1678 
-Q 4038 2116 3813 2373 
-Q 3588 2631 3206 2631 
-Q 2828 2631 2604 2375 
-Q 2381 2119 2381 1678 
+     <path id="DejaVuSans-26" d="M 1556 2509 
+Q 1272 2256 1139 2004 
+Q 1006 1753 1006 1478 
+Q 1006 1022 1337 719 
+Q 1669 416 2169 416 
+Q 2466 416 2725 514 
+Q 2984 613 3213 813 
+L 1556 2509 
 z
-M 4084 744 
-Q 3897 503 3655 389 
-Q 3413 275 3091 275 
-Q 2553 275 2217 664 
-Q 1881 1053 1881 1678 
-Q 1881 2303 2218 2693 
-Q 2556 3084 3091 3084 
-Q 3413 3084 3656 2967 
-Q 3900 2850 4084 2613 
-L 4084 3022 
-L 4531 3022 
-L 4531 722 
-Q 4988 791 5245 1139 
-Q 5503 1488 5503 2041 
-Q 5503 2375 5404 2669 
-Q 5306 2963 5106 3213 
-Q 4781 3622 4314 3839 
-Q 3847 4056 3297 4056 
-Q 2913 4056 2559 3954 
-Q 2206 3853 1906 3653 
-Q 1416 3334 1139 2817 
-Q 863 2300 863 1697 
-Q 863 1200 1042 765 
-Q 1222 331 1563 0 
-Q 1891 -325 2322 -495 
-Q 2753 -666 3244 -666 
-Q 3647 -666 4036 -530 
-Q 4425 -394 4750 -141 
-L 5031 -488 
-Q 4641 -791 4180 -952 
-Q 3719 -1113 3244 -1113 
-Q 2666 -1113 2153 -908 
-Q 1641 -703 1241 -313 
-Q 841 78 631 592 
-Q 422 1106 422 1697 
-Q 422 2266 634 2781 
-Q 847 3297 1241 3688 
-Q 1644 4084 2172 4295 
-Q 2700 4506 3291 4506 
-Q 3953 4506 4520 4234 
-Q 5088 3963 5472 3463 
-Q 5706 3156 5829 2797 
-Q 5953 2438 5953 2053 
-Q 5953 1231 5456 756 
-Q 4959 281 4084 263 
-L 4084 744 
+M 1997 2859 
+L 3584 1234 
+Q 3769 1513 3872 1830 
+Q 3975 2147 3994 2503 
+L 4575 2503 
+Q 4538 2091 4375 1687 
+Q 4213 1284 3922 891 
+L 4794 0 
+L 4006 0 
+L 3559 459 
+Q 3234 181 2878 45 
+Q 2522 -91 2113 -91 
+Q 1359 -91 881 339 
+Q 403 769 403 1441 
+Q 403 1841 612 2192 
+Q 822 2544 1241 2853 
+Q 1091 3050 1012 3245 
+Q 934 3441 934 3628 
+Q 934 4134 1281 4442 
+Q 1628 4750 2203 4750 
+Q 2463 4750 2720 4694 
+Q 2978 4638 3244 4525 
+L 3244 3956 
+Q 2972 4103 2725 4179 
+Q 2478 4256 2266 4256 
+Q 1938 4256 1733 4082 
+Q 1528 3909 1528 3634 
+Q 1528 3475 1620 3314 
+Q 1713 3153 1997 2859 
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2962,76 +2948,88 @@ z
     <use xlink:href="#DejaVuSans-b7" transform="translate(5524.183594 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(5555.970703 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(5587.757812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(5619.544922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5681.068359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5720.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(5783.65625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(5811.439453 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5872.71875 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(5970.130859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6033.607422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6097.083984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6158.363281 0)"/>
-    <use xlink:href="#DejaVuSans-40" transform="translate(6190.150391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6290.150391 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(6321.9375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6349.720703 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6411 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(6508.412109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6571.888672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6635.365234 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(6696.644531 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(6751.625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6779.408203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6840.6875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6892.787109 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(6944.886719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6978.578125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7040.101562 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(7079.310547 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(7142.689453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7170.472656 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7231.751953 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(7329.164062 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7392.640625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7456.117188 0)"/>
-    <use xlink:href="#DejaVuSans-2c" transform="translate(7517.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7549.183594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(7580.970703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7608.753906 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(7636.537109 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7700.013672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7752.113281 0)"/>
-    <use xlink:href="#DejaVuSans-7a" transform="translate(7804.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7856.703125 0)"/>
-    <use xlink:href="#DejaVuSans-53" transform="translate(7888.490234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(7951.966797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(8015.345703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(8076.625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(8140.248047 0)"/>
-    <use xlink:href="#DejaVuSans-48" transform="translate(8172.035156 0)"/>
-    <use xlink:href="#DejaVuSans-54" transform="translate(8247.230469 0)"/>
-    <use xlink:href="#DejaVuSans-52" transform="translate(8308.314453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(8377.796875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(8409.583984 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(8441.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(8473.158203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(8504.945312 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(8536.732422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(8600.355469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(8663.978516 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(8727.601562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(8791.224609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(8827.308594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(8890.931641 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(8954.554688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(8990.638672 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(9054.261719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(5619.544922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5682.923828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5744.203125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(5783.412109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(5811.195312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5870.375 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5931.898438 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(5967.982422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(6032.964844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6096.34375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6148.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6187.652344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6219.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6247.222656 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6344.634766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(6408.111328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(6435.894531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6469.585938 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6501.373047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.472656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6614.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6712.164062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6773.6875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6805.474609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6868.951172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6907.814453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6968.996094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7008.205078 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7069.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7124.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(7185.548828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7213.332031 0)"/>
+    <use xlink:href="#DejaVuSans-26" transform="translate(7245.119141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7323.097656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7354.884766 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(7406.984375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7470.460938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7531.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7586.964844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7618.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7673.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7734.914062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.292969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.392578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7889.601562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7950.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(8014.259766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(8053.46875 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(8105.568359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8137.355469 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(8169.142578 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(8232.619141 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(8296.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8364.601562 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(8396.388672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(8459.865234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8523.244141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8584.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8648.146484 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(8679.933594 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(8755.128906 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(8816.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8885.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8917.482422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(8949.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8981.056641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(9012.84375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(9044.630859 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(9108.253906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(9171.876953 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(9235.5 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(9299.123047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(9335.207031 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(9398.830078 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(9462.453125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(9498.537109 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(9562.160156 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p32629a90c9">
+  <clipPath id="pdcdc12aac5">
    <rect x="77.70152" y="35.04925" width="564.203829" height="306.7089"/>
   </clipPath>
  </defs>

--- a/docs/assets/bench-htr-results-spec.svg
+++ b/docs/assets/bench-htr-results-spec.svg
@@ -30,40 +30,32 @@ z
   <g id="axes_1">
    <g id="patch_2">
     <path d="M 77.70152 339.498869 
-L 645.49152 339.498869 
-L 645.49152 36.002969 
+L 639.565349 339.498869 
+L 639.565349 36.002969 
 L 77.70152 36.002969 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g id="patch_3">
-    <path d="M 605.611752 339.498869 
-L 645.49152 339.498869 
-L 645.49152 36.002969 
-L 605.611752 36.002969 
-z
-" clip-path="url(#p38a563192f)" style="fill: #d62728; opacity: 0.06"/>
-   </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 89.795616 339.498869 
-L 89.795616 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 90.154542 339.498869 
+L 90.154542 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m71dc9c33aa" d="M 0 0 
+       <path id="m27dda38649" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m71dc9c33aa" x="89.795616" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27dda38649" x="90.154542" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 4 -->
-      <g transform="translate(85.978116 355.616994) scale(0.12 -0.12)">
+      <g transform="translate(86.337042 355.616994) scale(0.12 -0.12)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -91,18 +83,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 141.37723 339.498869 
-L 141.37723 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 143.266983 339.498869 
+L 143.266983 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m71dc9c33aa" x="141.37723" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27dda38649" x="143.266983" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 8 -->
-      <g transform="translate(137.55973 355.616994) scale(0.12 -0.12)">
+      <g transform="translate(139.449483 355.616994) scale(0.12 -0.12)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -150,18 +142,18 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 296.122071 339.498869 
-L 296.122071 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 302.604306 339.498869 
+L 302.604306 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m71dc9c33aa" x="296.122071" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27dda38649" x="302.604306" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 64 -->
-      <g transform="translate(288.487071 355.616994) scale(0.12 -0.12)">
+      <g transform="translate(294.969306 355.616994) scale(0.12 -0.12)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -201,18 +193,18 @@ z
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 450.866911 339.498869 
-L 450.866911 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 461.941629 339.498869 
+L 461.941629 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m71dc9c33aa" x="450.866911" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27dda38649" x="461.941629" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 512 -->
-      <g transform="translate(439.414411 355.616994) scale(0.12 -0.12)">
+      <g transform="translate(450.489129 355.616994) scale(0.12 -0.12)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -286,18 +278,18 @@ z
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 605.611752 339.498869 
-L 605.611752 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 621.278953 339.498869 
+L 621.278953 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m71dc9c33aa" x="605.611752" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27dda38649" x="621.278953" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 4096 -->
-      <g transform="translate(590.341752 355.616994) scale(0.12 -0.12)">
+      <g transform="translate(606.008953 355.616994) scale(0.12 -0.12)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -360,215 +352,199 @@ z
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 106.401187 339.498869 
-L 106.401187 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 107.252929 339.498869 
+L 107.252929 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_12"/>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 119.968926 339.498869 
-L 119.968926 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 121.223328 339.498869 
+L 121.223328 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_14"/>
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 131.440286 339.498869 
-L 131.440286 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 133.035133 339.498869 
+L 133.035133 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_16"/>
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 150.142235 339.498869 
-L 150.142235 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 152.292115 339.498869 
+L 152.292115 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_18"/>
     </g>
     <g id="xtick_10">
      <g id="line2d_19">
-      <path d="M 209.564414 339.498869 
-L 209.564414 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 213.477811 339.498869 
+L 213.477811 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_20"/>
     </g>
     <g id="xtick_11">
      <g id="line2d_21">
-      <path d="M 239.737724 339.498869 
-L 239.737724 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 244.546597 339.498869 
+L 244.546597 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_22"/>
     </g>
     <g id="xtick_12">
      <g id="line2d_23">
-      <path d="M 261.146028 339.498869 
-L 261.146028 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 266.590252 339.498869 
+L 266.590252 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_24"/>
     </g>
     <g id="xtick_13">
      <g id="line2d_25">
-      <path d="M 277.751598 339.498869 
-L 277.751598 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 283.688639 339.498869 
+L 283.688639 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_26"/>
     </g>
     <g id="xtick_14">
      <g id="line2d_27">
-      <path d="M 291.319337 339.498869 
-L 291.319337 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 297.659038 339.498869 
+L 297.659038 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_28"/>
     </g>
     <g id="xtick_15">
      <g id="line2d_29">
-      <path d="M 302.790697 339.498869 
-L 302.790697 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 309.470843 339.498869 
+L 309.470843 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_30"/>
     </g>
     <g id="xtick_16">
      <g id="line2d_31">
-      <path d="M 312.727641 339.498869 
-L 312.727641 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 319.702693 339.498869 
+L 319.702693 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_32"/>
     </g>
     <g id="xtick_17">
      <g id="line2d_33">
-      <path d="M 321.492647 339.498869 
-L 321.492647 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 328.727825 339.498869 
+L 328.727825 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_34"/>
     </g>
     <g id="xtick_18">
      <g id="line2d_35">
-      <path d="M 380.914825 339.498869 
-L 380.914825 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 389.913521 339.498869 
+L 389.913521 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_36"/>
     </g>
     <g id="xtick_19">
      <g id="line2d_37">
-      <path d="M 411.088135 339.498869 
-L 411.088135 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 420.982308 339.498869 
+L 420.982308 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_38"/>
     </g>
     <g id="xtick_20">
      <g id="line2d_39">
-      <path d="M 432.496439 339.498869 
-L 432.496439 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 443.025962 339.498869 
+L 443.025962 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_40"/>
     </g>
     <g id="xtick_21">
      <g id="line2d_41">
-      <path d="M 449.10201 339.498869 
-L 449.10201 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 460.124349 339.498869 
+L 460.124349 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_42"/>
     </g>
     <g id="xtick_22">
      <g id="line2d_43">
-      <path d="M 462.669749 339.498869 
-L 462.669749 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 474.094749 339.498869 
+L 474.094749 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_44"/>
     </g>
     <g id="xtick_23">
      <g id="line2d_45">
-      <path d="M 474.141109 339.498869 
-L 474.141109 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 485.906553 339.498869 
+L 485.906553 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_46"/>
     </g>
     <g id="xtick_24">
      <g id="line2d_47">
-      <path d="M 484.078053 339.498869 
-L 484.078053 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 496.138403 339.498869 
+L 496.138403 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_48"/>
     </g>
     <g id="xtick_25">
      <g id="line2d_49">
-      <path d="M 492.843058 339.498869 
-L 492.843058 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 505.163535 339.498869 
+L 505.163535 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_50"/>
     </g>
     <g id="xtick_26">
      <g id="line2d_51">
-      <path d="M 552.265237 339.498869 
-L 552.265237 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 566.349231 339.498869 
+L 566.349231 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_52"/>
     </g>
     <g id="xtick_27">
      <g id="line2d_53">
-      <path d="M 582.438546 339.498869 
-L 582.438546 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 597.418018 339.498869 
+L 597.418018 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_54"/>
     </g>
     <g id="xtick_28">
      <g id="line2d_55">
-      <path d="M 603.84685 339.498869 
-L 603.84685 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 619.461672 339.498869 
+L 619.461672 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_56"/>
     </g>
     <g id="xtick_29">
      <g id="line2d_57">
-      <path d="M 620.452421 339.498869 
-L 620.452421 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 636.560059 339.498869 
+L 636.560059 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_58"/>
     </g>
-    <g id="xtick_30">
-     <g id="line2d_59">
-      <path d="M 634.02016 339.498869 
-L 634.02016 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_60"/>
-    </g>
-    <g id="xtick_31">
-     <g id="line2d_61">
-      <path d="M 645.49152 339.498869 
-L 645.49152 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_62"/>
-    </g>
     <g id="text_6">
      <!-- validator count  V  (≤ leanSpec VALIDATOR_REGISTRY_LIMIT = 2¹² = 4096) -->
-     <g transform="translate(127.912926 371.610666) scale(0.125 -0.125)">
+     <g transform="translate(124.949841 371.610666) scale(0.125 -0.125)">
       <defs>
        <path id="DejaVuSans-76" d="M 191 3500 
 L 800 3500 
@@ -1224,19 +1200,19 @@ z
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_63">
+     <g id="line2d_59">
       <path d="M 77.70152 329.444976 
-L 645.49152 329.444976 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+L 639.565349 329.444976 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_64">
+     <g id="line2d_60">
       <defs>
-       <path id="m545c94d863" d="M 0 0 
+       <path id="m6baace694f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m545c94d863" x="77.70152" y="329.444976" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6baace694f" x="77.70152" y="329.444976" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1345,14 +1321,14 @@ z
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_65">
+     <g id="line2d_61">
       <path d="M 77.70152 283.888074 
-L 645.49152 283.888074 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+L 639.565349 283.888074 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_66">
+     <g id="line2d_62">
       <g>
-       <use xlink:href="#m545c94d863" x="77.70152" y="283.888074" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6baace694f" x="77.70152" y="283.888074" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1398,14 +1374,14 @@ z
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_67">
+     <g id="line2d_63">
       <path d="M 77.70152 242.317889 
-L 645.49152 242.317889 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+L 639.565349 242.317889 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_68">
+     <g id="line2d_64">
       <g>
-       <use xlink:href="#m545c94d863" x="77.70152" y="242.317889" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6baace694f" x="77.70152" y="242.317889" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1419,14 +1395,14 @@ L 645.49152 242.317889
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_69">
+     <g id="line2d_65">
       <path d="M 77.70152 196.760987 
-L 645.49152 196.760987 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+L 639.565349 196.760987 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_70">
+     <g id="line2d_66">
       <g>
-       <use xlink:href="#m545c94d863" x="77.70152" y="196.760987" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6baace694f" x="77.70152" y="196.760987" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1441,14 +1417,14 @@ L 645.49152 196.760987
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_71">
+     <g id="line2d_67">
       <path d="M 77.70152 155.190802 
-L 645.49152 155.190802 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+L 639.565349 155.190802 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_72">
+     <g id="line2d_68">
       <g>
-       <use xlink:href="#m545c94d863" x="77.70152" y="155.190802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6baace694f" x="77.70152" y="155.190802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1463,14 +1439,14 @@ L 645.49152 155.190802
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_73">
+     <g id="line2d_69">
       <path d="M 77.70152 109.633899 
-L 645.49152 109.633899 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+L 639.565349 109.633899 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_74">
+     <g id="line2d_70">
       <g>
-       <use xlink:href="#m545c94d863" x="77.70152" y="109.633899" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6baace694f" x="77.70152" y="109.633899" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -1486,14 +1462,14 @@ L 645.49152 109.633899
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_75">
+     <g id="line2d_71">
       <path d="M 77.70152 68.063714 
-L 645.49152 68.063714 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+L 639.565349 68.063714 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_76">
+     <g id="line2d_72">
       <g>
-       <use xlink:href="#m545c94d863" x="77.70152" y="68.063714" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6baace694f" x="77.70152" y="68.063714" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1509,204 +1485,204 @@ L 645.49152 68.063714
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_77">
+     <g id="line2d_73">
       <path d="M 77.70152 318.559428 
-L 645.49152 318.559428 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+L 639.565349 318.559428 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_74"/>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_75">
+      <path d="M 77.70152 310.115941 
+L 639.565349 310.115941 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_76"/>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_77">
+      <path d="M 77.70152 303.21711 
+L 639.565349 303.21711 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_78"/>
     </g>
-    <g id="ytick_9">
+    <g id="ytick_11">
      <g id="line2d_79">
-      <path d="M 77.70152 310.115941 
-L 645.49152 310.115941 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 297.384231 
+L 639.565349 297.384231 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_80"/>
     </g>
-    <g id="ytick_10">
+    <g id="ytick_12">
      <g id="line2d_81">
-      <path d="M 77.70152 303.21711 
-L 645.49152 303.21711 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 292.331561 
+L 639.565349 292.331561 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_82"/>
     </g>
-    <g id="ytick_11">
+    <g id="ytick_13">
      <g id="line2d_83">
-      <path d="M 77.70152 297.384231 
-L 645.49152 297.384231 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 287.874791 
+L 639.565349 287.874791 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_84"/>
     </g>
-    <g id="ytick_12">
+    <g id="ytick_14">
      <g id="line2d_85">
-      <path d="M 77.70152 292.331561 
-L 645.49152 292.331561 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 257.660207 
+L 639.565349 257.660207 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_86"/>
     </g>
-    <g id="ytick_13">
+    <g id="ytick_15">
      <g id="line2d_87">
-      <path d="M 77.70152 287.874791 
-L 645.49152 287.874791 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 231.432341 
+L 639.565349 231.432341 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_88"/>
     </g>
-    <g id="ytick_14">
+    <g id="ytick_16">
      <g id="line2d_89">
-      <path d="M 77.70152 257.660207 
-L 645.49152 257.660207 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 222.988854 
+L 639.565349 222.988854 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_90"/>
     </g>
-    <g id="ytick_15">
+    <g id="ytick_17">
      <g id="line2d_91">
-      <path d="M 77.70152 231.432341 
-L 645.49152 231.432341 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 216.090022 
+L 639.565349 216.090022 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_92"/>
     </g>
-    <g id="ytick_16">
+    <g id="ytick_18">
      <g id="line2d_93">
-      <path d="M 77.70152 222.988854 
-L 645.49152 222.988854 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 210.257143 
+L 639.565349 210.257143 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_94"/>
     </g>
-    <g id="ytick_17">
+    <g id="ytick_19">
      <g id="line2d_95">
-      <path d="M 77.70152 216.090022 
-L 645.49152 216.090022 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 205.204474 
+L 639.565349 205.204474 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_96"/>
     </g>
-    <g id="ytick_18">
+    <g id="ytick_20">
      <g id="line2d_97">
-      <path d="M 77.70152 210.257143 
-L 645.49152 210.257143 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 200.747704 
+L 639.565349 200.747704 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_98"/>
     </g>
-    <g id="ytick_19">
+    <g id="ytick_21">
      <g id="line2d_99">
-      <path d="M 77.70152 205.204474 
-L 645.49152 205.204474 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 170.53312 
+L 639.565349 170.53312 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_100"/>
     </g>
-    <g id="ytick_20">
+    <g id="ytick_22">
      <g id="line2d_101">
-      <path d="M 77.70152 200.747704 
-L 645.49152 200.747704 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 144.305253 
+L 639.565349 144.305253 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_102"/>
     </g>
-    <g id="ytick_21">
+    <g id="ytick_23">
      <g id="line2d_103">
-      <path d="M 77.70152 170.53312 
-L 645.49152 170.53312 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 135.861766 
+L 639.565349 135.861766 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_104"/>
     </g>
-    <g id="ytick_22">
+    <g id="ytick_24">
      <g id="line2d_105">
-      <path d="M 77.70152 144.305253 
-L 645.49152 144.305253 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 128.962935 
+L 639.565349 128.962935 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_106"/>
     </g>
-    <g id="ytick_23">
+    <g id="ytick_25">
      <g id="line2d_107">
-      <path d="M 77.70152 135.861766 
-L 645.49152 135.861766 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 123.130056 
+L 639.565349 123.130056 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_108"/>
     </g>
-    <g id="ytick_24">
+    <g id="ytick_26">
      <g id="line2d_109">
-      <path d="M 77.70152 128.962935 
-L 645.49152 128.962935 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 118.077387 
+L 639.565349 118.077387 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_110"/>
     </g>
-    <g id="ytick_25">
+    <g id="ytick_27">
      <g id="line2d_111">
-      <path d="M 77.70152 123.130056 
-L 645.49152 123.130056 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 113.620616 
+L 639.565349 113.620616 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_112"/>
     </g>
-    <g id="ytick_26">
+    <g id="ytick_28">
      <g id="line2d_113">
-      <path d="M 77.70152 118.077387 
-L 645.49152 118.077387 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 83.406033 
+L 639.565349 83.406033 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_114"/>
     </g>
-    <g id="ytick_27">
+    <g id="ytick_29">
      <g id="line2d_115">
-      <path d="M 77.70152 113.620616 
-L 645.49152 113.620616 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 57.178166 
+L 639.565349 57.178166 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_116"/>
     </g>
-    <g id="ytick_28">
+    <g id="ytick_30">
      <g id="line2d_117">
-      <path d="M 77.70152 83.406033 
-L 645.49152 83.406033 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 48.734679 
+L 639.565349 48.734679 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_118"/>
     </g>
-    <g id="ytick_29">
+    <g id="ytick_31">
      <g id="line2d_119">
-      <path d="M 77.70152 57.178166 
-L 645.49152 57.178166 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 41.835848 
+L 639.565349 41.835848 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_120"/>
     </g>
-    <g id="ytick_30">
+    <g id="ytick_32">
      <g id="line2d_121">
-      <path d="M 77.70152 48.734679 
-L 645.49152 48.734679 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+      <path d="M 77.70152 36.002969 
+L 639.565349 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
      </g>
      <g id="line2d_122"/>
-    </g>
-    <g id="ytick_31">
-     <g id="line2d_123">
-      <path d="M 77.70152 41.835848 
-L 645.49152 41.835848 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_124"/>
-    </g>
-    <g id="ytick_32">
-     <g id="line2d_125">
-      <path d="M 77.70152 36.002969 
-L 645.49152 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_126"/>
     </g>
     <g id="text_14">
      <!-- time per call (log scale) -->
@@ -1775,39 +1751,39 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_127">
-    <path d="M 605.611752 339.498869 
-L 605.611752 36.002969 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
+   <g id="line2d_123">
+    <path d="M 621.278953 339.498869 
+L 621.278953 36.002969 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
    </g>
-   <g id="line2d_128">
+   <g id="line2d_124">
     <path d="M 77.70152 83.406033 
-L 645.49152 83.406033 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 1.82,2.34; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.3"/>
+L 639.565349 83.406033 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke-dasharray: 1.82,2.34; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.3"/>
    </g>
-   <g id="patch_4">
+   <g id="patch_3">
     <path d="M 77.70152 339.498869 
 L 77.70152 36.002969 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
+   <g id="patch_4">
+    <path d="M 639.565349 339.498869 
+L 639.565349 36.002969 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
    <g id="patch_5">
-    <path d="M 645.49152 339.498869 
-L 645.49152 36.002969 
+    <path d="M 77.70152 339.498869 
+L 639.565349 339.498869 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 77.70152 339.498869 
-L 645.49152 339.498869 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_7">
     <path d="M 77.70152 36.002969 
-L 645.49152 36.002969 
+L 639.565349 36.002969 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_15">
     <!-- 324 µs -->
-    <g style="fill: #0b3d6e" transform="translate(70.030929 315.34919) scale(0.105 -0.105)">
+    <g style="fill: #0b3d6e" transform="translate(70.389854 315.34919) scale(0.105 -0.105)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
@@ -1818,7 +1794,7 @@ L 645.49152 36.002969
    </g>
    <g id="text_16">
     <!-- 344 µs -->
-    <g style="fill: #0b3d6e" transform="translate(121.612542 313.082715) scale(0.105 -0.105)">
+    <g style="fill: #0b3d6e" transform="translate(123.502296 313.082715) scale(0.105 -0.105)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
@@ -1829,7 +1805,7 @@ L 645.49152 36.002969
    </g>
    <g id="text_17">
     <!-- 712 µs -->
-    <g style="fill: #0b3d6e" transform="translate(276.357383 285.557391) scale(0.105 -0.105)">
+    <g style="fill: #0b3d6e" transform="translate(282.839619 285.557391) scale(0.105 -0.105)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1852,7 +1828,7 @@ z
    </g>
    <g id="text_18">
     <!-- 3.85 ms -->
-    <g style="fill: #0b3d6e" transform="translate(427.660193 221.694914) scale(0.105 -0.105)">
+    <g style="fill: #0b3d6e" transform="translate(438.734911 221.694914) scale(0.105 -0.105)">
      <defs>
       <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -1873,7 +1849,7 @@ z
    </g>
    <g id="text_19">
     <!-- 26.40 ms -->
-    <g style="fill: #0b3d6e" transform="translate(579.064721 148.844193) scale(0.105 -0.105)">
+    <g style="fill: #0b3d6e" transform="translate(594.731921 148.844193) scale(0.105 -0.105)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
@@ -1884,19 +1860,19 @@ z
      <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
     </g>
    </g>
-   <g id="patch_8">
-    <path d="M 384.150405 227.693171 
-Q 480.350271 155.856805 602.382364 159.915526 
+   <g id="patch_7">
+    <path d="M 392.924625 227.709373 
+Q 492.509688 154.543208 618.056021 159.88593 
 " style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
-    <path d="M 598.254492 157.677074 
-L 602.382364 159.915526 
-L 598.114879 161.874753 
+    <path d="M 613.949105 157.609256 
+L 618.056021 159.88593 
+L 613.770532 161.805458 
 z
 " style="fill: #0b6e0b; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
    </g>
    <g id="text_20">
     <!-- V=4096 (leanSpec max) -->
-    <g style="fill: #0b6e0b" transform="translate(295.266209 238.872296) scale(0.105 -0.105)">
+    <g style="fill: #0b6e0b" transform="translate(303.629554 238.872296) scale(0.105 -0.105)">
      <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -1937,7 +1913,7 @@ z
      <use xlink:href="#DejaVuSans-29" transform="translate(1184.570312 0)"/>
     </g>
     <!-- 26.40 ms — green, -->
-    <g style="fill: #0b6e0b" transform="translate(309.542928 250.629999) scale(0.105 -0.105)">
+    <g style="fill: #0b6e0b" transform="translate(317.906273 250.629999) scale(0.105 -0.105)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -1975,7 +1951,7 @@ z
      <use xlink:href="#DejaVuSans-2c" transform="translate(919.917969 0)"/>
     </g>
     <!-- 8× under the 200 ms budget -->
-    <g style="fill: #0b6e0b" transform="translate(282.948396 262.387702) scale(0.105 -0.105)">
+    <g style="fill: #0b6e0b" transform="translate(291.311741 262.387702) scale(0.105 -0.105)">
      <defs>
       <path id="DejaVuSans-d7" d="M 4488 3438 
 L 3059 2003 
@@ -2068,7 +2044,7 @@ z
    </g>
    <g id="text_21">
     <!-- VALIDATOR_REGISTRY_LIMIT = 4096 -->
-    <g style="fill: #b01010" transform="translate(409.826605 302.607499) scale(0.105 -0.105)">
+    <g style="fill: #b01010" transform="translate(425.333532 302.607499) scale(0.105 -0.105)">
      <use xlink:href="#DejaVuSans-56"/>
      <use xlink:href="#DejaVuSans-41" transform="translate(62.033203 0)"/>
      <use xlink:href="#DejaVuSans-4c" transform="translate(130.441406 0)"/>
@@ -2102,7 +2078,7 @@ z
      <use xlink:href="#DejaVuSans-36" transform="translate(1749.527344 0)"/>
     </g>
     <!-- (leanSpec cap) -->
-    <g style="fill: #b01010" transform="translate(521.774652 314.657234) scale(0.105 -0.105)">
+    <g style="fill: #b01010" transform="translate(537.281579 314.657234) scale(0.105 -0.105)">
      <use xlink:href="#DejaVuSans-28"/>
      <use xlink:href="#DejaVuSans-6c" transform="translate(39.013672 0)"/>
      <use xlink:href="#DejaVuSans-65" transform="translate(66.796875 0)"/>
@@ -2121,7 +2097,7 @@ z
    </g>
    <g id="text_22">
     <!-- SLO target 200 ms (1 interval) -->
-    <g style="fill: #555555" transform="translate(302.790697 78.662238) scale(0.105 -0.105)">
+    <g style="fill: #555555" transform="translate(309.470843 78.662238) scale(0.105 -0.105)">
      <use xlink:href="#DejaVuSans-53"/>
      <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
      <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
@@ -2156,7 +2132,7 @@ z
    </g>
    <g id="text_23">
     <!-- state_transition (full STF) benchmark — A=8 valid attestations, incl. SHA-256 hash_tree_root -->
-    <g transform="translate(71.598473 11.658047) scale(0.125 -0.125)">
+    <g transform="translate(68.635387 11.658047) scale(0.125 -0.125)">
      <defs>
       <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -2323,7 +2299,7 @@ z
      <use xlink:href="#DejaVuSans-74" transform="translate(4600.867188 0)"/>
     </g>
     <!-- leanSpec range (V ≤ 4096) -->
-    <g transform="translate(276.590661 26.002969) scale(0.125 -0.125)">
+    <g transform="translate(273.627575 26.002969) scale(0.125 -0.125)">
      <use xlink:href="#DejaVuSans-6c"/>
      <use xlink:href="#DejaVuSans-65" transform="translate(27.783203 0)"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(89.306641 0)"/>
@@ -2351,15 +2327,15 @@ z
      <use xlink:href="#DejaVuSans-29" transform="translate(1321.044922 0)"/>
     </g>
    </g>
-   <g id="line2d_129">
-    <path d="M 89.795616 326.532862 
-L 141.37723 324.266387 
-L 296.122071 296.741063 
-L 450.866911 232.878586 
-L 605.611752 160.027865 
-" clip-path="url(#p38a563192f)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+   <g id="line2d_125">
+    <path d="M 90.154542 326.532862 
+L 143.266983 324.266387 
+L 302.604306 296.741063 
+L 461.941629 232.878586 
+L 621.278953 160.027865 
+" clip-path="url(#pe5a02e8ed3)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
     <defs>
-     <path id="maedd3e2e71" d="M 0 3.5 
+     <path id="m2d4bbde7df" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2371,16 +2347,16 @@ C -1.81853 3.131218 -0.928211 3.5 0 3.5
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p38a563192f)">
-     <use xlink:href="#maedd3e2e71" x="89.795616" y="326.532862" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#maedd3e2e71" x="141.37723" y="324.266387" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#maedd3e2e71" x="296.122071" y="296.741063" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#maedd3e2e71" x="450.866911" y="232.878586" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#maedd3e2e71" x="605.611752" y="160.027865" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pe5a02e8ed3)">
+     <use xlink:href="#m2d4bbde7df" x="90.154542" y="326.532862" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2d4bbde7df" x="143.266983" y="324.266387" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2d4bbde7df" x="302.604306" y="296.741063" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2d4bbde7df" x="461.941629" y="232.878586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2d4bbde7df" x="621.278953" y="160.027865" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="legend_1">
-    <g id="patch_9">
+    <g id="patch_8">
      <path d="M 85.40152 67.854844 
 L 430.889176 67.854844 
 Q 433.089176 67.854844 433.089176 65.654844 
@@ -2393,13 +2369,13 @@ Q 83.20152 67.854844 85.40152 67.854844
 z
 " style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-width: 0.8; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_130">
+    <g id="line2d_126">
      <path d="M 90.90152 53.71125 
 L 101.90152 53.71125 
 L 112.90152 53.71125 
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
      <g>
-      <use xlink:href="#maedd3e2e71" x="101.90152" y="53.71125" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#m2d4bbde7df" x="101.90152" y="53.71125" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_24">
@@ -2751,8 +2727,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p38a563192f">
-   <rect x="77.70152" y="36.002969" width="567.79" height="303.4959"/>
+  <clipPath id="pe5a02e8ed3">
+   <rect x="77.70152" y="36.002969" width="561.863829" height="303.4959"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/bench-htr-results-spec.svg
+++ b/docs/assets/bench-htr-results-spec.svg
@@ -1,0 +1,2758 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="681.955pt" height="394.745479pt" viewBox="0 0 681.955 394.745479" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7+dfsg1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 394.745479 
+L 681.955 394.745479 
+L 681.955 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 77.70152 339.498869 
+L 645.49152 339.498869 
+L 645.49152 36.002969 
+L 77.70152 36.002969 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 605.611752 339.498869 
+L 645.49152 339.498869 
+L 645.49152 36.002969 
+L 605.611752 36.002969 
+z
+" clip-path="url(#p38a563192f)" style="fill: #d62728; opacity: 0.06"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 89.795616 339.498869 
+L 89.795616 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m71dc9c33aa" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m71dc9c33aa" x="89.795616" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 4 -->
+      <g transform="translate(85.978116 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 141.37723 339.498869 
+L 141.37723 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m71dc9c33aa" x="141.37723" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 8 -->
+      <g transform="translate(137.55973 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 296.122071 339.498869 
+L 296.122071 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m71dc9c33aa" x="296.122071" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 64 -->
+      <g transform="translate(288.487071 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 450.866911 339.498869 
+L 450.866911 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m71dc9c33aa" x="450.866911" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 512 -->
+      <g transform="translate(439.414411 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 605.611752 339.498869 
+L 605.611752 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m71dc9c33aa" x="605.611752" y="339.498869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4096 -->
+      <g transform="translate(590.341752 355.616994) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 106.401187 339.498869 
+L 106.401187 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_12"/>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 119.968926 339.498869 
+L 119.968926 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_14"/>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 131.440286 339.498869 
+L 131.440286 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_16"/>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 150.142235 339.498869 
+L 150.142235 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_18"/>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 209.564414 339.498869 
+L 209.564414 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_20"/>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 239.737724 339.498869 
+L 239.737724 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_22"/>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 261.146028 339.498869 
+L 261.146028 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_24"/>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 277.751598 339.498869 
+L 277.751598 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_26"/>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 291.319337 339.498869 
+L 291.319337 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_28"/>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 302.790697 339.498869 
+L 302.790697 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_30"/>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 312.727641 339.498869 
+L 312.727641 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_32"/>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 321.492647 339.498869 
+L 321.492647 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_34"/>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 380.914825 339.498869 
+L 380.914825 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_36"/>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 411.088135 339.498869 
+L 411.088135 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_38"/>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 432.496439 339.498869 
+L 432.496439 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_40"/>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 449.10201 339.498869 
+L 449.10201 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_42"/>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 462.669749 339.498869 
+L 462.669749 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_44"/>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 474.141109 339.498869 
+L 474.141109 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_46"/>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 484.078053 339.498869 
+L 484.078053 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_48"/>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 492.843058 339.498869 
+L 492.843058 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_50"/>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 552.265237 339.498869 
+L 552.265237 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_52"/>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 582.438546 339.498869 
+L 582.438546 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_54"/>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 603.84685 339.498869 
+L 603.84685 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_56"/>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 620.452421 339.498869 
+L 620.452421 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_58"/>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_59">
+      <path d="M 634.02016 339.498869 
+L 634.02016 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_60"/>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_61">
+      <path d="M 645.49152 339.498869 
+L 645.49152 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_62"/>
+    </g>
+    <g id="text_6">
+     <!-- validator count  V  (≤ leanSpec VALIDATOR_REGISTRY_LIMIT = 2¹² = 4096) -->
+     <g transform="translate(127.912926 371.610666) scale(0.125 -0.125)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2264" d="M 4684 3175 
+L 1684 2309 
+L 4684 1453 
+L 4684 897 
+L 678 2047 
+L 678 2578 
+L 4684 3725 
+L 4684 3175 
+z
+M 678 531 
+L 4684 531 
+L 4684 0 
+L 678 0 
+L 678 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 628 4666 
+L 3578 4666 
+L 3578 4134 
+L 1259 4134 
+L 1259 2753 
+L 3481 2753 
+L 3481 2222 
+L 1259 2222 
+L 1259 531 
+L 3634 531 
+L 3634 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b9" d="M 488 2431 
+L 1125 2431 
+L 1125 4341 
+L 428 4213 
+L 428 4575 
+L 1147 4697 
+L 1575 4697 
+L 1575 2431 
+L 2216 2431 
+L 2216 2088 
+L 488 2088 
+L 488 2431 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b2" d="M 838 2444 
+L 2163 2444 
+L 2163 2088 
+L 294 2088 
+L 294 2431 
+Q 400 2528 597 2703 
+Q 1672 3656 1672 3950 
+Q 1672 4156 1509 4282 
+Q 1347 4409 1081 4409 
+Q 919 4409 728 4354 
+Q 538 4300 313 4191 
+L 313 4575 
+Q 553 4663 761 4706 
+Q 969 4750 1147 4750 
+Q 1600 4750 1872 4544 
+Q 2144 4338 2144 4000 
+Q 2144 3566 1109 2678 
+Q 934 2528 838 2444 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(148.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(176.025391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(239.501953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(300.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(339.990234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(401.171875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(442.285156 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(474.072266 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(529.052734 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(590.234375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(653.613281 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(716.992188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(756.201172 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(787.988281 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(819.775391 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(888.183594 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(919.970703 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(951.757812 0)"/>
+      <use xlink:href="#DejaVuSans-2264" transform="translate(990.771484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1074.560547 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.347656 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1134.130859 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1195.654297 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1256.933594 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1320.3125 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1383.789062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1447.265625 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1508.789062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1563.769531 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1595.556641 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1657.589844 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1725.998047 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(1781.710938 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1811.203125 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1886.455078 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(1947.113281 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(2008.197266 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2086.908203 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2156.390625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2206.390625 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(2275.873047 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(2339.056641 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2416.546875 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(2446.039062 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2509.515625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2570.599609 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(2633.707031 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2694.791016 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(2744.791016 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2800.503906 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(2829.996094 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2916.275391 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2945.767578 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3006.851562 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3038.638672 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3122.427734 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(3154.214844 0)"/>
+      <use xlink:href="#DejaVuSans-b9" transform="translate(3217.837891 0)"/>
+      <use xlink:href="#DejaVuSans-b2" transform="translate(3257.925781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3298.013672 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3329.800781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3413.589844 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(3445.376953 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(3509 0)"/>
+      <use xlink:href="#DejaVuSans-39" transform="translate(3572.623047 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(3636.246094 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(3699.869141 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_63">
+      <path d="M 77.70152 329.444976 
+L 645.49152 329.444976 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <defs>
+       <path id="m545c94d863" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m545c94d863" x="77.70152" y="329.444976" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 300 µs -->
+      <g transform="translate(30.09652 334.004039) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_65">
+      <path d="M 77.70152 283.888074 
+L 645.49152 283.888074 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m545c94d863" x="77.70152" y="283.888074" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 1 ms -->
+      <g transform="translate(41.31277 288.447137) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_67">
+      <path d="M 77.70152 242.317889 
+L 645.49152 242.317889 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m545c94d863" x="77.70152" y="242.317889" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 3 ms -->
+      <g transform="translate(41.31277 246.876951) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_69">
+      <path d="M 77.70152 196.760987 
+L 645.49152 196.760987 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m545c94d863" x="77.70152" y="196.760987" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 10 ms -->
+      <g transform="translate(33.67777 201.320049) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_71">
+      <path d="M 77.70152 155.190802 
+L 645.49152 155.190802 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m545c94d863" x="77.70152" y="155.190802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 30 ms -->
+      <g transform="translate(33.67777 159.749864) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_73">
+      <path d="M 77.70152 109.633899 
+L 645.49152 109.633899 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m545c94d863" x="77.70152" y="109.633899" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 100 ms -->
+      <g transform="translate(26.04277 114.192962) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_75">
+      <path d="M 77.70152 68.063714 
+L 645.49152 68.063714 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#m545c94d863" x="77.70152" y="68.063714" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 300 ms -->
+      <g transform="translate(26.04277 72.622777) scale(0.12 -0.12)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_77">
+      <path d="M 77.70152 318.559428 
+L 645.49152 318.559428 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_78"/>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_79">
+      <path d="M 77.70152 310.115941 
+L 645.49152 310.115941 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_80"/>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_81">
+      <path d="M 77.70152 303.21711 
+L 645.49152 303.21711 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_82"/>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_83">
+      <path d="M 77.70152 297.384231 
+L 645.49152 297.384231 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_84"/>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_85">
+      <path d="M 77.70152 292.331561 
+L 645.49152 292.331561 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_86"/>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_87">
+      <path d="M 77.70152 287.874791 
+L 645.49152 287.874791 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_88"/>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_89">
+      <path d="M 77.70152 257.660207 
+L 645.49152 257.660207 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_90"/>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_91">
+      <path d="M 77.70152 231.432341 
+L 645.49152 231.432341 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_92"/>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_93">
+      <path d="M 77.70152 222.988854 
+L 645.49152 222.988854 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_94"/>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_95">
+      <path d="M 77.70152 216.090022 
+L 645.49152 216.090022 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_96"/>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_97">
+      <path d="M 77.70152 210.257143 
+L 645.49152 210.257143 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_98"/>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_99">
+      <path d="M 77.70152 205.204474 
+L 645.49152 205.204474 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_100"/>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_101">
+      <path d="M 77.70152 200.747704 
+L 645.49152 200.747704 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_102"/>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_103">
+      <path d="M 77.70152 170.53312 
+L 645.49152 170.53312 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_104"/>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_105">
+      <path d="M 77.70152 144.305253 
+L 645.49152 144.305253 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_106"/>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_107">
+      <path d="M 77.70152 135.861766 
+L 645.49152 135.861766 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_108"/>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_109">
+      <path d="M 77.70152 128.962935 
+L 645.49152 128.962935 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_110"/>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_111">
+      <path d="M 77.70152 123.130056 
+L 645.49152 123.130056 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_112"/>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_113">
+      <path d="M 77.70152 118.077387 
+L 645.49152 118.077387 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_114"/>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_115">
+      <path d="M 77.70152 113.620616 
+L 645.49152 113.620616 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_116"/>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_117">
+      <path d="M 77.70152 83.406033 
+L 645.49152 83.406033 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_118"/>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_119">
+      <path d="M 77.70152 57.178166 
+L 645.49152 57.178166 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_120"/>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_121">
+      <path d="M 77.70152 48.734679 
+L 645.49152 48.734679 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_122"/>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_123">
+      <path d="M 77.70152 41.835848 
+L 645.49152 41.835848 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_124"/>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_125">
+      <path d="M 77.70152 36.002969 
+L 645.49152 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.18; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_126"/>
+    </g>
+    <g id="text_14">
+     <!-- time per call (log scale) -->
+     <g transform="translate(19.443161 261.448184) rotate(-90) scale(0.125 -0.125)">
+      <defs>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-74"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(39.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(66.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(164.404297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.927734 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(257.714844 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(321.191406 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(382.714844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(423.828125 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(455.615234 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(510.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(571.875 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(599.658203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(627.441406 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(659.228516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(698.242188 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(726.025391 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(787.207031 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(850.683594 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(882.470703 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(934.570312 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(989.550781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1050.830078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1078.613281 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1140.136719 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_127">
+    <path d="M 605.611752 339.498869 
+L 605.611752 36.002969 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_128">
+    <path d="M 77.70152 83.406033 
+L 645.49152 83.406033 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke-dasharray: 1.82,2.34; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.3"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 77.70152 339.498869 
+L 77.70152 36.002969 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 645.49152 339.498869 
+L 645.49152 36.002969 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 77.70152 339.498869 
+L 645.49152 339.498869 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 77.70152 36.002969 
+L 645.49152 36.002969 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- 324 µs -->
+    <g style="fill: #0b3d6e" transform="translate(70.030929 315.34919) scale(0.105 -0.105)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 344 µs -->
+    <g style="fill: #0b3d6e" transform="translate(121.612542 313.082715) scale(0.105 -0.105)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 712 µs -->
+    <g style="fill: #0b3d6e" transform="translate(276.357383 285.557391) scale(0.105 -0.105)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 3.85 ms -->
+    <g style="fill: #0b3d6e" transform="translate(427.660193 221.694914) scale(0.105 -0.105)">
+     <defs>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(254.443359 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 26.40 ms -->
+    <g style="fill: #0b3d6e" transform="translate(579.064721 148.844193) scale(0.105 -0.105)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 384.150405 227.693171 
+Q 480.350271 155.856805 602.382364 159.915526 
+" style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 598.254492 157.677074 
+L 602.382364 159.915526 
+L 598.114879 161.874753 
+z
+" style="fill: #0b6e0b; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_20">
+    <!-- V=4096 (leanSpec max) -->
+    <g style="fill: #0b6e0b" transform="translate(295.266209 238.872296) scale(0.105 -0.105)">
+     <defs>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(215.820312 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(279.443359 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(343.066406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(406.689453 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(438.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(477.490234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(505.273438 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(566.796875 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(628.076172 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(691.455078 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(754.931641 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(818.408203 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(879.931641 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(934.912109 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(966.699219 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1064.111328 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(1125.390625 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1184.570312 0)"/>
+    </g>
+    <!-- 26.40 ms — green, -->
+    <g style="fill: #0b6e0b" transform="translate(309.542928 250.629999) scale(0.105 -0.105)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(467.578125 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(499.365234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(599.365234 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(631.152344 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(694.628906 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(733.492188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(795.015625 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(856.539062 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(919.917969 0)"/>
+    </g>
+    <!-- 8× under the 200 ms budget -->
+    <g style="fill: #0b6e0b" transform="translate(282.948396 262.387702) scale(0.105 -0.105)">
+     <defs>
+      <path id="DejaVuSans-d7" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(179.199219 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(242.578125 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(305.957031 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(369.433594 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(430.957031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(472.070312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(503.857422 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(543.066406 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(606.445312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(667.96875 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(699.755859 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(763.378906 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(827.001953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(890.625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(922.412109 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1019.824219 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1071.923828 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1103.710938 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1167.1875 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1230.566406 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1294.042969 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1357.519531 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1419.042969 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- VALIDATOR_REGISTRY_LIMIT = 4096 -->
+    <g style="fill: #b01010" transform="translate(409.826605 302.607499) scale(0.105 -0.105)">
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(62.033203 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(130.441406 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(186.154297 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(215.646484 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(290.898438 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(351.556641 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(412.640625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(491.351562 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(560.833984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(610.833984 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(680.316406 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(743.5 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(820.990234 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(850.482422 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(913.958984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(975.042969 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1038.150391 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(1099.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1149.234375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1204.947266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(1234.439453 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1320.71875 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1350.210938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1411.294922 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(1443.082031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1526.871094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1558.658203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1622.28125 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(1685.904297 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1749.527344 0)"/>
+    </g>
+    <!-- (leanSpec cap) -->
+    <g style="fill: #b01010" transform="translate(521.774652 314.657234) scale(0.105 -0.105)">
+     <use xlink:href="#DejaVuSans-28"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(39.013672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(66.796875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(128.320312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(189.599609 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(252.978516 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(316.455078 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(379.931641 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(441.455078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(496.435547 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(528.222656 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(583.203125 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(644.482422 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(707.958984 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- SLO target 200 ms (1 interval) -->
+    <g style="fill: #555555" transform="translate(302.790697 78.662238) scale(0.105 -0.105)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(194.275391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(226.0625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(265.271484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(326.550781 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(365.914062 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(429.390625 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(490.914062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(530.123047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(561.910156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(625.533203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(689.15625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(752.779297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(784.566406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(881.978516 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(934.078125 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(965.865234 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1004.878906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1068.501953 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1100.289062 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1128.072266 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1191.451172 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1230.660156 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1292.183594 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1333.296875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1392.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1453.755859 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1481.539062 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- state_transition (full STF) benchmark — A=8 valid attestations, incl. SHA-256 hash_tree_root -->
+    <g transform="translate(71.598473 11.658047) scale(0.125 -0.125)">
+     <defs>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-48" d="M 628 4666 
+L 1259 4666 
+L 1259 2753 
+L 3553 2753 
+L 3553 4666 
+L 4184 4666 
+L 4184 0 
+L 3553 0 
+L 3553 2222 
+L 1259 2222 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(811.523438 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(850.537109 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(885.742188 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(949.121094 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(976.904297 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1004.6875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1036.474609 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1099.951172 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1161.035156 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1218.554688 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1257.568359 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1289.355469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1352.832031 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1414.355469 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1477.734375 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1532.714844 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1596.09375 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1693.505859 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1754.785156 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(1795.898438 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1853.808594 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1885.595703 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1985.595703 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(2017.382812 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(2085.791016 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(2169.580078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2233.203125 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(2264.990234 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2324.169922 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2385.449219 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2413.232422 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2441.015625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2504.492188 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2536.279297 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2597.558594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2636.767578 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2675.976562 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2737.5 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2789.599609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2828.808594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2890.087891 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2929.296875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2957.080078 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3018.261719 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3081.640625 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(3133.740234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3165.527344 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3197.314453 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3225.097656 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3288.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3343.457031 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3371.240234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3403.027344 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(3434.814453 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(3498.291016 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(3573.486328 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(3639.644531 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(3675.728516 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(3739.351562 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(3802.974609 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3866.597656 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3898.384766 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3961.763672 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4023.042969 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(4075.142578 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(4138.521484 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4188.521484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(4227.730469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4266.59375 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4328.117188 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(4389.640625 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(4439.640625 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4478.503906 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4539.685547 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4600.867188 0)"/>
+    </g>
+    <!-- leanSpec range (V ≤ 4096) -->
+    <g transform="translate(276.590661 26.002969) scale(0.125 -0.125)">
+     <use xlink:href="#DejaVuSans-6c"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(27.783203 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(89.306641 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(150.585938 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(213.964844 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(277.441406 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(340.917969 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(402.441406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(457.421875 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(489.208984 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(530.322266 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(591.601562 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(654.980469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(718.457031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(779.980469 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(811.767578 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(850.78125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(919.189453 0)"/>
+     <use xlink:href="#DejaVuSans-2264" transform="translate(950.976562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1034.765625 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1066.552734 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1130.175781 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(1193.798828 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1257.421875 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1321.044922 0)"/>
+    </g>
+   </g>
+   <g id="line2d_129">
+    <path d="M 89.795616 326.532862 
+L 141.37723 324.266387 
+L 296.122071 296.741063 
+L 450.866911 232.878586 
+L 605.611752 160.027865 
+" clip-path="url(#p38a563192f)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+    <defs>
+     <path id="maedd3e2e71" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p38a563192f)">
+     <use xlink:href="#maedd3e2e71" x="89.795616" y="326.532862" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#maedd3e2e71" x="141.37723" y="324.266387" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#maedd3e2e71" x="296.122071" y="296.741063" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#maedd3e2e71" x="450.866911" y="232.878586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#maedd3e2e71" x="605.611752" y="160.027865" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_9">
+     <path d="M 85.40152 67.854844 
+L 430.889176 67.854844 
+Q 433.089176 67.854844 433.089176 65.654844 
+L 433.089176 43.702969 
+Q 433.089176 41.502969 430.889176 41.502969 
+L 85.40152 41.502969 
+Q 83.20152 41.502969 83.20152 43.702969 
+L 83.20152 65.654844 
+Q 83.20152 67.854844 85.40152 67.854844 
+z
+" style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-width: 0.8; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_130">
+     <path d="M 90.90152 53.71125 
+L 101.90152 53.71125 
+L 112.90152 53.71125 
+" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: round"/>
+     <g>
+      <use xlink:href="#maedd3e2e71" x="101.90152" y="53.71125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- state_transition pipeline (incl. SHA-256 hash_tree_root) -->
+     <g transform="translate(121.70152 57.56125) scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(811.523438 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(875 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(902.783203 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(966.259766 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1027.783203 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1055.566406 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1083.349609 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1146.728516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1208.251953 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1240.039062 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1279.052734 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1306.835938 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1370.214844 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1425.195312 0)"/>
+      <use xlink:href="#DejaVuSans-2e" transform="translate(1452.978516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1484.765625 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1516.552734 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1580.029297 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1655.224609 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1721.382812 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(1757.466797 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(1821.089844 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(1884.712891 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1948.335938 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1980.123047 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2043.501953 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2104.78125 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(2156.880859 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2220.259766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2270.259766 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2309.46875 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2348.332031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2409.855469 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2471.378906 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2521.378906 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2560.242188 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2621.423828 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2682.605469 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2721.814453 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_25">
+   <!-- AMD Ryzen 9 PRO 8945HS (Zen 4 mobile, 8C/16T)  ·  Linux 6.18.12+kali-amd64 x86_64  ·  Lean v4.28.0-rc1  ·  Rust release + thin LTO + codegen-units=1  ·  2026-06-26 -->
+   <g style="fill: #666666" transform="translate(2.16 390.699229) scale(0.08 -0.08)">
+    <defs>
+     <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-41"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(68.408203 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(154.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(231.689453 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(263.476562 0)"/>
+    <use xlink:href="#DejaVuSans-79" transform="translate(327.458984 0)"/>
+    <use xlink:href="#DejaVuSans-7a" transform="translate(386.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(439.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(500.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(564.03125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(595.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(659.441406 0)"/>
+    <use xlink:href="#DejaVuSans-50" transform="translate(691.228516 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(751.53125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(821.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(899.724609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(931.511719 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(995.134766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1058.757812 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1122.380859 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(1186.003906 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(1261.199219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1324.675781 0)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(1356.462891 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1395.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1463.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1525.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1620.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1684.294922 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(1716.082031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1813.494141 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(1874.675781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1938.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1965.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1993.71875 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(2055.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2087.029297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2118.816406 0)"/>
+    <use xlink:href="#DejaVuSans-43" transform="translate(2182.439453 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(2252.263672 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(2285.955078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2349.578125 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(2413.201172 0)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(2474.285156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2513.298828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2545.085938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2576.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2608.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2640.447266 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(2672.234375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2727.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2755.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2819.109375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2882.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2941.667969 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2973.455078 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3037.078125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3068.865234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3132.488281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3196.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3227.898438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3291.521484 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(3355.144531 0)"/>
+    <use xlink:href="#DejaVuSans-6b" transform="translate(3438.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3495.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3556.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3584.15625 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(3611.939453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3648.023438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(3709.302734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3806.714844 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3870.191406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3933.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3997.4375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(4029.224609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(4088.404297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4152.027344 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(4215.650391 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4265.650391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4329.273438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4392.896484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4424.683594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(4456.470703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4488.257812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4520.044922 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(4551.832031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4605.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4667.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4728.597656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4791.976562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4823.763672 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4882.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4946.566406 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4978.353516 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(5041.976562 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(5105.599609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(5137.386719 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5201.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5237.09375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5275.957031 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5330.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5394.560547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5426.347656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5458.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5489.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5521.708984 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(5553.496094 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5618.478516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(5681.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5733.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5773.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5804.953125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5843.816406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5905.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5933.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5994.646484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6055.925781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6108.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6169.548828 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(6201.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6285.125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6316.912109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6356.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6419.5 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6447.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6510.662109 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(6542.449219 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(6584.412109 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(6645.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6724.207031 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(6755.994141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6839.783203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6871.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6926.550781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6987.732422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7051.208984 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(7112.732422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7176.208984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7237.732422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(7301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7337.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7400.574219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7463.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7491.736328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7530.945312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(7583.044922 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(7666.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7730.457031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7762.244141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(7794.03125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7825.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7857.605469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(7889.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(7953.015625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8016.638672 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8080.261719 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8143.884766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(8179.96875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8243.591797 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8307.214844 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8343.298828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8406.921875 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p38a563192f">
+   <rect x="77.70152" y="36.002969" width="567.79" height="303.4959"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/bench-htr-results.svg
+++ b/docs/assets/bench-htr-results.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="624.563108pt" height="381.189219pt" viewBox="0 0 624.563108 381.189219" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="655.327656pt" height="381.189219pt" viewBox="0 0 655.327656 381.189219" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-26T00:58:45.155613</dc:date>
+    <dc:date>2026-06-26T01:06:13.908992</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -22,8 +22,8 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 381.189219 
-L 624.563108 381.189219 
-L 624.563108 0 
+L 655.327656 381.189219 
+L 655.327656 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
@@ -31,32 +31,45 @@ z
   <g id="axes_1">
    <g id="patch_2">
     <path d="M 65.577656 342.857031 
-L 615.869023 342.857031 
-L 615.869023 27.558281 
+L 648.127656 342.857031 
+L 648.127656 27.558281 
 L 65.577656 27.558281 
 z
 " style="fill: #ffffff"/>
    </g>
+   <g id="patch_3">
+    <path d="M 380.506011 342.857031 
+L 645.436306 342.857031 
+L 645.436306 27.558281 
+L 380.506011 27.558281 
+z
+" clip-path="url(#p289f9afc26)" style="fill: #d62728; opacity: 0.06; stroke: #d62728; stroke-linejoin: miter"/>
+   </g>
+   <g id="line2d_1">
+    <path d="M 380.506011 342.857031 
+L 380.506011 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
+   </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
-     <g id="line2d_1">
-      <path d="M 77.774189 342.857031 
-L 77.774189 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
      <g id="line2d_2">
+      <path d="M 72.79247 342.857031 
+L 72.79247 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_3">
       <defs>
-       <path id="m61b459e77d" d="M 0 0 
+       <path id="m53e1c9a5e6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m61b459e77d" x="77.774189" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m53e1c9a5e6" x="72.79247" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 4 -->
-      <g transform="translate(74.592939 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(69.61122 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -83,19 +96,19 @@ z
      </g>
     </g>
     <g id="xtick_2">
-     <g id="line2d_3">
-      <path d="M 129.792696 342.857031 
-L 129.792696 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
      <g id="line2d_4">
+      <path d="M 103.563824 342.857031 
+L 103.563824 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_5">
       <g>
-       <use xlink:href="#m61b459e77d" x="129.792696" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m53e1c9a5e6" x="103.563824" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 8 -->
-      <g transform="translate(126.611446 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(100.382574 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -142,19 +155,19 @@ z
      </g>
     </g>
     <g id="xtick_3">
-     <g id="line2d_5">
-      <path d="M 285.848219 342.857031 
-L 285.848219 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
      <g id="line2d_6">
+      <path d="M 195.877886 342.857031 
+L 195.877886 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7">
       <g>
-       <use xlink:href="#m61b459e77d" x="285.848219" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m53e1c9a5e6" x="195.877886" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 64 -->
-      <g transform="translate(279.485719 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(189.515386 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -193,19 +206,19 @@ z
      </g>
     </g>
     <g id="xtick_4">
-     <g id="line2d_7">
-      <path d="M 441.903741 342.857031 
-L 441.903741 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
      <g id="line2d_8">
+      <path d="M 288.191948 342.857031 
+L 288.191948 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
       <g>
-       <use xlink:href="#m61b459e77d" x="441.903741" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m53e1c9a5e6" x="288.191948" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 512 -->
-      <g transform="translate(432.359991 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(278.648198 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -278,19 +291,19 @@ z
      </g>
     </g>
     <g id="xtick_5">
-     <g id="line2d_9">
-      <path d="M 597.959264 342.857031 
-L 597.959264 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
      <g id="line2d_10">
+      <path d="M 380.506011 342.857031 
+L 380.506011 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
       <g>
-       <use xlink:href="#m61b459e77d" x="597.959264" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m53e1c9a5e6" x="380.506011" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 4096 -->
-      <g transform="translate(585.234264 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(367.781011 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -352,301 +365,578 @@ z
      </g>
     </g>
     <g id="xtick_6">
-     <g id="line2d_11">
-      <path d="M 94.520408 342.857031 
-L 94.520408 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_12">
-      <defs>
-       <path id="mda7365c716" d="M 0 0 
-L 0 2 
-" style="stroke: #000000; stroke-width: 0.6"/>
-      </defs>
+      <path d="M 624.571115 342.857031 
+L 624.571115 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
       <g>
-       <use xlink:href="#mda7365c716" x="94.520408" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m53e1c9a5e6" x="624.571115" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1M -->
+      <g transform="translate(617.075803 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-4d" transform="translate(63.623047 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
-     <g id="line2d_13">
-      <path d="M 108.203065 342.857031 
-L 108.203065 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_14">
+      <path d="M 82.698633 342.857031 
+L 82.698633 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_15">
+      <defs>
+       <path id="m056fec7c1d" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
       <g>
-       <use xlink:href="#mda7365c716" x="108.203065" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="82.698633" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
-     <g id="line2d_15">
-      <path d="M 119.771587 342.857031 
-L 119.771587 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_16">
+      <path d="M 90.792558 342.857031 
+L 90.792558 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_17">
       <g>
-       <use xlink:href="#mda7365c716" x="119.771587" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="90.792558" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
-     <g id="line2d_17">
-      <path d="M 138.631941 342.857031 
-L 138.631941 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_18">
+      <path d="M 97.635874 342.857031 
+L 97.635874 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_19">
       <g>
-       <use xlink:href="#mda7365c716" x="138.631941" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="97.635874" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
-     <g id="line2d_19">
-      <path d="M 198.557423 342.857031 
-L 198.557423 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_20">
+      <path d="M 108.792646 342.857031 
+L 108.792646 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_21">
       <g>
-       <use xlink:href="#mda7365c716" x="198.557423" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="108.792646" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
-     <g id="line2d_21">
-      <path d="M 228.986299 342.857031 
-L 228.986299 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_22">
+      <path d="M 144.241341 342.857031 
+L 144.241341 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_23">
       <g>
-       <use xlink:href="#mda7365c716" x="228.986299" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="144.241341" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
-     <g id="line2d_23">
-      <path d="M 250.57593 342.857031 
-L 250.57593 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_24">
+      <path d="M 162.241429 342.857031 
+L 162.241429 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_25">
       <g>
-       <use xlink:href="#mda7365c716" x="250.57593" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="162.241429" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
-     <g id="line2d_25">
-      <path d="M 267.322149 342.857031 
-L 267.322149 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_26">
+      <path d="M 175.012695 342.857031 
+L 175.012695 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_27">
       <g>
-       <use xlink:href="#mda7365c716" x="267.322149" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="175.012695" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
-     <g id="line2d_27">
-      <path d="M 281.004807 342.857031 
-L 281.004807 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_28">
+      <path d="M 184.918859 342.857031 
+L 184.918859 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_29">
       <g>
-       <use xlink:href="#mda7365c716" x="281.004807" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="184.918859" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
-     <g id="line2d_29">
-      <path d="M 292.573328 342.857031 
-L 292.573328 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_30">
+      <path d="M 193.012784 342.857031 
+L 193.012784 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_31">
       <g>
-       <use xlink:href="#mda7365c716" x="292.573328" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="193.012784" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
-     <g id="line2d_31">
-      <path d="M 302.594438 342.857031 
-L 302.594438 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_32">
+      <path d="M 199.856099 342.857031 
+L 199.856099 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_33">
       <g>
-       <use xlink:href="#mda7365c716" x="302.594438" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="199.856099" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
-     <g id="line2d_33">
-      <path d="M 311.433683 342.857031 
-L 311.433683 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_34">
+      <path d="M 205.784049 342.857031 
+L 205.784049 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_35">
       <g>
-       <use xlink:href="#mda7365c716" x="311.433683" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="205.784049" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
-     <g id="line2d_35">
-      <path d="M 371.359164 342.857031 
-L 371.359164 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_36">
+      <path d="M 211.012872 342.857031 
+L 211.012872 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_37">
       <g>
-       <use xlink:href="#mda7365c716" x="371.359164" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="211.012872" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
-     <g id="line2d_37">
-      <path d="M 401.788041 342.857031 
-L 401.788041 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_38">
+      <path d="M 246.461567 342.857031 
+L 246.461567 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_39">
       <g>
-       <use xlink:href="#mda7365c716" x="401.788041" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="246.461567" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
-     <g id="line2d_39">
-      <path d="M 423.377672 342.857031 
-L 423.377672 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_40">
+      <path d="M 264.461655 342.857031 
+L 264.461655 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_41">
       <g>
-       <use xlink:href="#mda7365c716" x="423.377672" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="264.461655" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
-     <g id="line2d_41">
-      <path d="M 440.123891 342.857031 
-L 440.123891 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_42">
+      <path d="M 277.232921 342.857031 
+L 277.232921 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_43">
       <g>
-       <use xlink:href="#mda7365c716" x="440.123891" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="277.232921" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
-     <g id="line2d_43">
-      <path d="M 453.806548 342.857031 
-L 453.806548 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_44">
+      <path d="M 287.139084 342.857031 
+L 287.139084 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_45">
       <g>
-       <use xlink:href="#mda7365c716" x="453.806548" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="287.139084" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
-     <g id="line2d_45">
-      <path d="M 465.37507 342.857031 
-L 465.37507 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_46">
+      <path d="M 295.233009 342.857031 
+L 295.233009 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_47">
       <g>
-       <use xlink:href="#mda7365c716" x="465.37507" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="295.233009" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
-     <g id="line2d_47">
-      <path d="M 475.396179 342.857031 
-L 475.396179 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_48">
+      <path d="M 302.076325 342.857031 
+L 302.076325 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_49">
       <g>
-       <use xlink:href="#mda7365c716" x="475.396179" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="302.076325" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_25">
-     <g id="line2d_49">
-      <path d="M 484.235424 342.857031 
-L 484.235424 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_50">
+      <path d="M 308.004275 342.857031 
+L 308.004275 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_51">
       <g>
-       <use xlink:href="#mda7365c716" x="484.235424" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="308.004275" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_26">
-     <g id="line2d_51">
-      <path d="M 544.160906 342.857031 
-L 544.160906 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_52">
+      <path d="M 313.233097 342.857031 
+L 313.233097 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_53">
       <g>
-       <use xlink:href="#mda7365c716" x="544.160906" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="313.233097" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_27">
-     <g id="line2d_53">
-      <path d="M 574.589782 342.857031 
-L 574.589782 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_54">
+      <path d="M 348.681793 342.857031 
+L 348.681793 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_55">
       <g>
-       <use xlink:href="#mda7365c716" x="574.589782" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="348.681793" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_28">
-     <g id="line2d_55">
-      <path d="M 596.179413 342.857031 
-L 596.179413 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_56">
+      <path d="M 366.681881 342.857031 
+L 366.681881 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_57">
       <g>
-       <use xlink:href="#mda7365c716" x="596.179413" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="366.681881" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_29">
-     <g id="line2d_57">
-      <path d="M 612.925632 342.857031 
-L 612.925632 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
      <g id="line2d_58">
+      <path d="M 379.453147 342.857031 
+L 379.453147 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_59">
       <g>
-       <use xlink:href="#mda7365c716" x="612.925632" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m056fec7c1d" x="379.453147" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="text_6">
+    <g id="xtick_30">
+     <g id="line2d_60">
+      <path d="M 389.35931 342.857031 
+L 389.35931 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="389.35931" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_62">
+      <path d="M 397.453235 342.857031 
+L 397.453235 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="397.453235" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_64">
+      <path d="M 404.296551 342.857031 
+L 404.296551 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="404.296551" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_66">
+      <path d="M 410.224501 342.857031 
+L 410.224501 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_67">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="410.224501" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_68">
+      <path d="M 415.453323 342.857031 
+L 415.453323 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_69">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="415.453323" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_70">
+      <path d="M 450.902018 342.857031 
+L 450.902018 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_71">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="450.902018" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_72">
+      <path d="M 468.902106 342.857031 
+L 468.902106 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="468.902106" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_74">
+      <path d="M 481.673372 342.857031 
+L 481.673372 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_75">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="481.673372" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_76">
+      <path d="M 491.579536 342.857031 
+L 491.579536 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_77">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="491.579536" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_78">
+      <path d="M 499.673461 342.857031 
+L 499.673461 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_79">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="499.673461" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_80">
+      <path d="M 506.516777 342.857031 
+L 506.516777 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_81">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="506.516777" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_82">
+      <path d="M 512.444726 342.857031 
+L 512.444726 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_83">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="512.444726" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_84">
+      <path d="M 517.673549 342.857031 
+L 517.673549 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_85">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="517.673549" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_86">
+      <path d="M 553.122244 342.857031 
+L 553.122244 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="553.122244" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_88">
+      <path d="M 571.122332 342.857031 
+L 571.122332 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="571.122332" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_90">
+      <path d="M 583.893598 342.857031 
+L 583.893598 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="583.893598" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_92">
+      <path d="M 593.799761 342.857031 
+L 593.799761 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_93">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="593.799761" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_94">
+      <path d="M 601.893686 342.857031 
+L 601.893686 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_95">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="601.893686" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_96">
+      <path d="M 608.737002 342.857031 
+L 608.737002 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_97">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="608.737002" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_98">
+      <path d="M 614.664952 342.857031 
+L 614.664952 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_99">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="614.664952" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_100">
+      <path d="M 619.893774 342.857031 
+L 619.893774 27.558281 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_101">
+      <g>
+       <use xlink:href="#m056fec7c1d" x="619.893774" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
      <!-- validator count  V  (≤ leanSpec VALIDATOR_REGISTRY_LIMIT = 2¹² = 4096) -->
-     <g transform="translate(144.429121 371.513516) scale(0.105 -0.105)">
+     <g transform="translate(160.558437 371.513516) scale(0.105 -0.105)">
       <defs>
        <path id="DejaVuSans-76" d="M 191 3500 
 L 800 3500 
@@ -1150,22 +1440,6 @@ L 1638 2222
 L -13 4666 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-4d" d="M 628 4666 
-L 1569 4666 
-L 2759 1491 
-L 3956 4666 
-L 4897 4666 
-L 4897 0 
-L 4281 0 
-L 4281 4097 
-L 3078 897 
-L 2444 897 
-L 1241 4097 
-L 1241 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
        <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -1302,24 +1576,24 @@ z
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_59">
-      <path d="M 65.577656 315.152639 
-L 615.869023 315.152639 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_102">
+      <path d="M 65.577656 325.494341 
+L 648.127656 325.494341 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_60">
+     <g id="line2d_103">
       <defs>
-       <path id="mb25f9954e2" d="M 0 0 
+       <path id="m005af03624" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb25f9954e2" x="65.577656" y="315.152639" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="325.494341" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_7">
+     <g id="text_8">
       <!-- 300 µs -->
-      <g transform="translate(24.740156 318.951858) scale(0.1 -0.1)">
+      <g transform="translate(24.740156 329.29356) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1423,19 +1697,19 @@ z
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_61">
-      <path d="M 65.577656 267.031063 
-L 615.869023 267.031063 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_104">
+      <path d="M 65.577656 295.335945 
+L 648.127656 295.335945 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_62">
+     <g id="line2d_105">
       <g>
-       <use xlink:href="#mb25f9954e2" x="65.577656" y="267.031063" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="295.335945" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_8">
+     <g id="text_9">
       <!-- 1 ms -->
-      <g transform="translate(34.087031 270.830282) scale(0.1 -0.1)">
+      <g transform="translate(34.087031 299.135164) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1476,19 +1750,19 @@ z
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_63">
-      <path d="M 65.577656 223.12064 
-L 615.869023 223.12064 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_106">
+      <path d="M 65.577656 267.816732 
+L 648.127656 267.816732 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_64">
+     <g id="line2d_107">
       <g>
-       <use xlink:href="#mb25f9954e2" x="65.577656" y="223.12064" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="267.816732" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_9">
+     <g id="text_10">
       <!-- 3 ms -->
-      <g transform="translate(34.087031 226.919859) scale(0.1 -0.1)">
+      <g transform="translate(34.087031 271.61595) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
@@ -1497,19 +1771,19 @@ L 615.869023 223.12064
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_65">
-      <path d="M 65.577656 174.999064 
-L 615.869023 174.999064 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_108">
+      <path d="M 65.577656 237.658336 
+L 648.127656 237.658336 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_66">
+     <g id="line2d_109">
       <g>
-       <use xlink:href="#mb25f9954e2" x="65.577656" y="174.999064" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="237.658336" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_10">
+     <g id="text_11">
       <!-- 10 ms -->
-      <g transform="translate(27.724531 178.798283) scale(0.1 -0.1)">
+      <g transform="translate(27.724531 241.457554) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -1519,19 +1793,19 @@ L 615.869023 174.999064
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_67">
-      <path d="M 65.577656 131.088642 
-L 615.869023 131.088642 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_110">
+      <path d="M 65.577656 210.139122 
+L 648.127656 210.139122 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_68">
+     <g id="line2d_111">
       <g>
-       <use xlink:href="#mb25f9954e2" x="65.577656" y="131.088642" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="210.139122" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_11">
+     <g id="text_12">
       <!-- 30 ms -->
-      <g transform="translate(27.724531 134.88786) scale(0.1 -0.1)">
+      <g transform="translate(27.724531 213.938341) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -1541,19 +1815,19 @@ L 615.869023 131.088642
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_69">
-      <path d="M 65.577656 82.967066 
-L 615.869023 82.967066 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_112">
+      <path d="M 65.577656 179.980726 
+L 648.127656 179.980726 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_70">
+     <g id="line2d_113">
       <g>
-       <use xlink:href="#mb25f9954e2" x="65.577656" y="82.967066" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="179.980726" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_12">
+     <g id="text_13">
       <!-- 100 ms -->
-      <g transform="translate(21.362031 86.766284) scale(0.1 -0.1)">
+      <g transform="translate(21.362031 183.779945) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1564,19 +1838,19 @@ L 615.869023 82.967066
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_71">
-      <path d="M 65.577656 39.056643 
-L 615.869023 39.056643 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_114">
+      <path d="M 65.577656 152.461513 
+L 648.127656 152.461513 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_72">
+     <g id="line2d_115">
       <g>
-       <use xlink:href="#mb25f9954e2" x="65.577656" y="39.056643" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="152.461513" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_13">
+     <g id="text_14">
       <!-- 300 ms -->
-      <g transform="translate(21.362031 42.855862) scale(0.1 -0.1)">
+      <g transform="translate(21.362031 156.260732) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1587,287 +1861,528 @@ L 615.869023 39.056643
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_73">
-      <path d="M 65.577656 331.35867 
-L 615.869023 331.35867 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_116">
+      <path d="M 65.577656 122.303117 
+L 648.127656 122.303117 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_74">
-      <defs>
-       <path id="medb7f47c58" d="M 0 0 
-L -2 0 
-" style="stroke: #000000; stroke-width: 0.6"/>
-      </defs>
+     <g id="line2d_117">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="331.35867" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="122.303117" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1 s -->
+      <g transform="translate(43.827656 126.102336) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
-     <g id="line2d_75">
-      <path d="M 65.577656 303.654277 
-L 615.869023 303.654277 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_118">
+      <path d="M 65.577656 94.783904 
+L 648.127656 94.783904 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_76">
+     <g id="line2d_119">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="303.654277" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="94.783904" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 3 s -->
+      <g transform="translate(43.827656 98.583123) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
-     <g id="line2d_77">
-      <path d="M 65.577656 294.735455 
-L 615.869023 294.735455 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_120">
+      <path d="M 65.577656 64.625508 
+L 648.127656 64.625508 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_78">
+     <g id="line2d_121">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="294.735455" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m005af03624" x="65.577656" y="64.625508" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 10 s -->
+      <g transform="translate(37.465156 68.424727) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(159.033203 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
-     <g id="line2d_79">
-      <path d="M 65.577656 287.448247 
-L 615.869023 287.448247 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_122">
+      <path d="M 65.577656 335.650864 
+L 648.127656 335.650864 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_80">
+     <g id="line2d_123">
+      <defs>
+       <path id="mccfc9c15e0" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="287.448247" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="335.650864" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
-     <g id="line2d_81">
-      <path d="M 65.577656 281.287 
-L 615.869023 281.287 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_124">
+      <path d="M 65.577656 318.288173 
+L 648.127656 318.288173 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_82">
+     <g id="line2d_125">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="281.287" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="318.288173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
-     <g id="line2d_83">
-      <path d="M 65.577656 275.949885 
-L 615.869023 275.949885 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_126">
+      <path d="M 65.577656 312.698635 
+L 648.127656 312.698635 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_84">
+     <g id="line2d_127">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="275.949885" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="312.698635" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
-     <g id="line2d_85">
-      <path d="M 65.577656 271.242216 
-L 615.869023 271.242216 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_128">
+      <path d="M 65.577656 308.13165 
+L 648.127656 308.13165 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_86">
+     <g id="line2d_129">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="271.242216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="308.13165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
-     <g id="line2d_87">
-      <path d="M 65.577656 239.326671 
-L 615.869023 239.326671 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_130">
+      <path d="M 65.577656 304.27032 
+L 648.127656 304.27032 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_88">
+     <g id="line2d_131">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="239.326671" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="304.27032" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
-     <g id="line2d_89">
-      <path d="M 65.577656 211.622279 
-L 615.869023 211.622279 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_132">
+      <path d="M 65.577656 300.925483 
+L 648.127656 300.925483 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_90">
+     <g id="line2d_133">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="211.622279" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="300.925483" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
-     <g id="line2d_91">
-      <path d="M 65.577656 202.703457 
-L 615.869023 202.703457 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_134">
+      <path d="M 65.577656 297.975128 
+L 648.127656 297.975128 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_92">
+     <g id="line2d_135">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="202.703457" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="297.975128" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
-     <g id="line2d_93">
-      <path d="M 65.577656 195.416248 
-L 615.869023 195.416248 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_136">
+      <path d="M 65.577656 277.973254 
+L 648.127656 277.973254 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_94">
+     <g id="line2d_137">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="195.416248" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="277.973254" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
-     <g id="line2d_95">
-      <path d="M 65.577656 189.255001 
-L 615.869023 189.255001 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_138">
+      <path d="M 65.577656 260.610564 
+L 648.127656 260.610564 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_96">
+     <g id="line2d_139">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="189.255001" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="260.610564" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
-     <g id="line2d_97">
-      <path d="M 65.577656 183.917887 
-L 615.869023 183.917887 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_140">
+      <path d="M 65.577656 255.021026 
+L 648.127656 255.021026 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_98">
+     <g id="line2d_141">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="183.917887" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="255.021026" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
-     <g id="line2d_99">
-      <path d="M 65.577656 179.210218 
-L 615.869023 179.210218 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_142">
+      <path d="M 65.577656 250.454041 
+L 648.127656 250.454041 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_100">
+     <g id="line2d_143">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="179.210218" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="250.454041" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
-     <g id="line2d_101">
-      <path d="M 65.577656 147.294672 
-L 615.869023 147.294672 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_144">
+      <path d="M 65.577656 246.59271 
+L 648.127656 246.59271 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_102">
+     <g id="line2d_145">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="147.294672" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="246.59271" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
-     <g id="line2d_103">
-      <path d="M 65.577656 119.59028 
-L 615.869023 119.59028 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_146">
+      <path d="M 65.577656 243.247874 
+L 648.127656 243.247874 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_104">
+     <g id="line2d_147">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="119.59028" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="243.247874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
-     <g id="line2d_105">
-      <path d="M 65.577656 110.671458 
-L 615.869023 110.671458 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_148">
+      <path d="M 65.577656 240.297518 
+L 648.127656 240.297518 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_106">
+     <g id="line2d_149">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="110.671458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="240.297518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
-     <g id="line2d_107">
-      <path d="M 65.577656 103.384249 
-L 615.869023 103.384249 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_150">
+      <path d="M 65.577656 220.295645 
+L 648.127656 220.295645 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_108">
+     <g id="line2d_151">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="103.384249" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="220.295645" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
-     <g id="line2d_109">
-      <path d="M 65.577656 97.223003 
-L 615.869023 97.223003 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_152">
+      <path d="M 65.577656 202.932955 
+L 648.127656 202.932955 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_110">
+     <g id="line2d_153">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="97.223003" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="202.932955" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
-     <g id="line2d_111">
-      <path d="M 65.577656 91.885888 
-L 615.869023 91.885888 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_154">
+      <path d="M 65.577656 197.343417 
+L 648.127656 197.343417 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_112">
+     <g id="line2d_155">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="91.885888" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="197.343417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
-     <g id="line2d_113">
-      <path d="M 65.577656 87.178219 
-L 615.869023 87.178219 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_156">
+      <path d="M 65.577656 192.776432 
+L 648.127656 192.776432 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_114">
+     <g id="line2d_157">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="87.178219" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="192.776432" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
-     <g id="line2d_115">
-      <path d="M 65.577656 55.262673 
-L 615.869023 55.262673 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_158">
+      <path d="M 65.577656 188.915101 
+L 648.127656 188.915101 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_116">
+     <g id="line2d_159">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="55.262673" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="188.915101" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
-     <g id="line2d_117">
-      <path d="M 65.577656 27.558281 
-L 615.869023 27.558281 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     <g id="line2d_160">
+      <path d="M 65.577656 185.570264 
+L 648.127656 185.570264 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
-     <g id="line2d_118">
+     <g id="line2d_161">
       <g>
-       <use xlink:href="#medb7f47c58" x="65.577656" y="27.558281" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="185.570264" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="text_14">
+    <g id="ytick_31">
+     <g id="line2d_162">
+      <path d="M 65.577656 182.619909 
+L 648.127656 182.619909 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_163">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="182.619909" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_164">
+      <path d="M 65.577656 162.618036 
+L 648.127656 162.618036 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_165">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="162.618036" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_166">
+      <path d="M 65.577656 145.255346 
+L 648.127656 145.255346 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_167">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="145.255346" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_168">
+      <path d="M 65.577656 139.665808 
+L 648.127656 139.665808 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_169">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="139.665808" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_170">
+      <path d="M 65.577656 135.098823 
+L 648.127656 135.098823 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_171">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="135.098823" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_172">
+      <path d="M 65.577656 131.237492 
+L 648.127656 131.237492 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_173">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="131.237492" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_174">
+      <path d="M 65.577656 127.892655 
+L 648.127656 127.892655 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_175">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="127.892655" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_176">
+      <path d="M 65.577656 124.9423 
+L 648.127656 124.9423 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_177">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="124.9423" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_178">
+      <path d="M 65.577656 104.940427 
+L 648.127656 104.940427 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_179">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="104.940427" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_180">
+      <path d="M 65.577656 87.577736 
+L 648.127656 87.577736 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_181">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="87.577736" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_182">
+      <path d="M 65.577656 81.988199 
+L 648.127656 81.988199 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_183">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="81.988199" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_184">
+      <path d="M 65.577656 77.421214 
+L 648.127656 77.421214 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_185">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="77.421214" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_186">
+      <path d="M 65.577656 73.559883 
+L 648.127656 73.559883 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_187">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="73.559883" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_188">
+      <path d="M 65.577656 70.215046 
+L 648.127656 70.215046 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_189">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="70.215046" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_190">
+      <path d="M 65.577656 67.264691 
+L 648.127656 67.264691 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_191">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="67.264691" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_192">
+      <path d="M 65.577656 47.262818 
+L 648.127656 47.262818 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_193">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="47.262818" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_194">
+      <path d="M 65.577656 37.106295 
+L 648.127656 37.106295 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_195">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="37.106295" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_196">
+      <path d="M 65.577656 29.900127 
+L 648.127656 29.900127 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_197">
+      <g>
+       <use xlink:href="#mccfc9c15e0" x="65.577656" y="29.900127" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
      <!-- time per call (log scale) -->
      <g transform="translate(15.178359 247.113359) rotate(-90) scale(0.105 -0.105)">
       <defs>
@@ -1934,34 +2449,87 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_119">
-    <path d="M 65.577656 55.262673 
-L 615.869023 55.262673 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
+   <g id="line2d_198">
+    <path d="M 65.577656 162.618036 
+L 648.127656 162.618036 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
    </g>
-   <g id="patch_3">
+   <g id="patch_4">
     <path d="M 65.577656 342.857031 
 L 65.577656 27.558281 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_4">
-    <path d="M 615.869023 342.857031 
-L 615.869023 27.558281 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
    <g id="patch_5">
-    <path d="M 65.577656 342.857031 
-L 615.869023 342.857031 
+    <path d="M 648.127656 342.857031 
+L 648.127656 27.558281 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 65.577656 27.558281 
-L 615.869023 27.558281 
+    <path d="M 65.577656 342.857031 
+L 648.127656 342.857031 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_15">
+   <g id="patch_7">
+    <path d="M 65.577656 27.558281 
+L 648.127656 27.558281 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- VALIDATOR_REGISTRY_LIMIT = 4096 -->
+    <g style="fill: #b01010" transform="translate(386.710557 322.418933) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(62.033203 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(130.441406 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(186.154297 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(215.646484 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(290.898438 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(351.556641 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(412.640625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(491.351562 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(560.833984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(610.833984 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(680.316406 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(743.5 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(820.990234 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(850.482422 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(913.958984 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(975.042969 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1038.150391 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(1099.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1149.234375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1204.947266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(1234.439453 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1320.71875 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1350.210938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1411.294922 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(1443.082031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1526.871094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1558.658203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1622.28125 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(1685.904297 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1749.527344 0)"/>
+    </g>
+    <!-- (leanSpec cap) -->
+    <g style="fill: #b01010" transform="translate(386.710557 331.599683) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-28"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(39.013672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(66.796875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(128.320312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(189.599609 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(252.978516 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(316.455078 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(379.931641 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(441.455078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(496.435547 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(528.222656 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(583.203125 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(644.482422 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(707.958984 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
     <!-- SLO target 200 ms (1 interval) -->
-    <g style="fill: #555555" transform="translate(474.085657 49.67653) scale(0.085 -0.085)">
+    <g style="fill: #555555" transform="translate(69.33147 158.900253) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-53"/>
      <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
      <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
@@ -1994,31 +2562,31 @@ L 615.869023 27.558281
      <use xlink:href="#DejaVuSans-29" transform="translate(1481.539062 0)"/>
     </g>
    </g>
-   <g id="text_16">
-    <!-- 323 µs -->
-    <g style="fill: #0b3d6e" transform="translate(63.731626 303.224892) scale(0.083 -0.083)">
+   <g id="text_21">
+    <!-- 324 µs -->
+    <g style="fill: #0b3d6e" transform="translate(58.749907 314.597482) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
      <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
     </g>
    </g>
-   <g id="text_17">
-    <!-- 362 µs -->
-    <g style="fill: #0b3d6e" transform="translate(115.750134 298.666084) scale(0.083 -0.083)">
+   <g id="text_22">
+    <!-- 344 µs -->
+    <g style="fill: #0b3d6e" transform="translate(89.521261 313.102581) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
      <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
     </g>
    </g>
-   <g id="text_18">
-    <!-- 706 µs -->
-    <g style="fill: #0b3d6e" transform="translate(271.805656 271.974185) scale(0.083 -0.083)">
+   <g id="text_23">
+    <!-- 712 µs -->
+    <g style="fill: #0b3d6e" transform="translate(181.835323 294.837511) scale(0.083 -0.083)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -2032,16 +2600,16 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
      <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
     </g>
    </g>
-   <g id="text_19">
-    <!-- 3.83 ms -->
-    <g style="fill: #0b3d6e" transform="translate(425.140335 204.358114) scale(0.083 -0.083)">
+   <g id="text_24">
+    <!-- 3.85 ms -->
+    <g style="fill: #0b3d6e" transform="translate(271.428542 252.56797) scale(0.083 -0.083)">
      <defs>
       <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -2054,37 +2622,37 @@ z
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(222.65625 0)"/>
      <use xlink:href="#DejaVuSans-6d" transform="translate(254.443359 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
     </g>
    </g>
-   <g id="text_20">
-    <!-- 29.06 ms -->
-    <g style="fill: #0b3d6e" transform="translate(578.55542 123.361043) scale(0.083 -0.083)">
+   <g id="text_25">
+    <!-- 26.40 ms -->
+    <g style="fill: #0b3d6e" transform="translate(361.102167 204.341229) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
      <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
     </g>
    </g>
-   <g id="patch_7">
-    <path d="M 435.478303 252.302529 
-Q 515.914263 192.925674 595.360771 134.27922 
+   <g id="patch_8">
+    <path d="M 314.685812 275.103917 
+Q 346.865759 244.907715 378.148876 215.553058 
 " style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
-    <path d="M 591.57165 134.938431 
-L 595.360771 134.27922 
-L 593.614668 137.706044 
+    <path d="M 374.463388 216.652687 
+L 378.148876 215.553058 
+L 376.817287 219.161225 
 " style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
    </g>
-   <g id="text_21">
+   <g id="text_26">
     <!-- V=4096 (leanSpec max) -->
-    <g style="fill: #0b6e0b" transform="translate(349.769533 262.026763) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(233.690301 285.010082) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -2124,8 +2692,8 @@ z
      <use xlink:href="#DejaVuSans-78" transform="translate(1125.390625 0)"/>
      <use xlink:href="#DejaVuSans-29" transform="translate(1184.570312 0)"/>
     </g>
-    <!-- 29.06 ms — green, -->
-    <g style="fill: #0b6e0b" transform="translate(349.769533 271.656881) scale(0.086 -0.086)">
+    <!-- 26.40 ms — green, -->
+    <g style="fill: #0b6e0b" transform="translate(233.690301 294.640201) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2145,10 +2713,10 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
      <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
@@ -2162,8 +2730,8 @@ z
      <use xlink:href="#DejaVuSans-6e" transform="translate(856.539062 0)"/>
      <use xlink:href="#DejaVuSans-2c" transform="translate(919.917969 0)"/>
     </g>
-    <!-- 7× under the 200 ms budget -->
-    <g style="fill: #0b6e0b" transform="translate(349.769533 281.287) scale(0.086 -0.086)">
+    <!-- 8× under the 200 ms budget -->
+    <g style="fill: #0b6e0b" transform="translate(233.690301 304.27032) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-d7" d="M 4488 3438 
 L 3059 2003 
@@ -2226,7 +2794,7 @@ L 1159 2969
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-d7" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-75" transform="translate(179.199219 0)"/>
@@ -2254,9 +2822,104 @@ z
      <use xlink:href="#DejaVuSans-74" transform="translate(1419.042969 0)"/>
     </g>
    </g>
-   <g id="text_22">
-    <!-- state_transition benchmark — realistic STF (real hash_tree_root, A=8 valid attestations) -->
-    <g transform="translate(98.872012 15.558281) scale(0.11 -0.11)">
+   <g id="patch_9">
+    <path d="M 554.924448 79.211223 
+Q 588.801958 67.472103 621.517418 56.135651 
+" style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 617.703874 55.636771 
+L 621.517418 56.135651 
+L 618.830188 58.887158 
+" style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_27">
+    <!-- V=1M (mainnet, out-of-spec) -->
+    <g style="fill: #b01010" transform="translate(458.995943 88.401477) scale(0.086 -0.086)">
+     <defs>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(215.820312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(302.099609 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(333.886719 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(372.900391 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(470.3125 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(531.591797 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(559.375 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(622.753906 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(686.132812 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(747.65625 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(786.865234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(818.652344 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(850.439453 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(911.621094 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(975 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1014.208984 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1052.167969 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(1113.349609 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1143.054688 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1179.138672 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1231.238281 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1294.714844 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1356.238281 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1411.21875 0)"/>
+    </g>
+    <!-- 14.64 s — over budget -->
+    <g style="fill: #b01010" transform="translate(458.995943 98.031596) scale(0.086 -0.086)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(370.166016 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(401.953125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(501.953125 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(533.740234 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(594.921875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(654.101562 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(715.625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(756.738281 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(788.525391 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(852.001953 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(915.380859 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(978.857422 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1042.333984 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1103.857422 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- state_transition benchmark — SHA-256 hash_tree_root, A=8 valid attestations -->
+    <g transform="translate(140.995703 15.558281) scale(0.11 -0.11)">
      <defs>
       <path id="DejaVuSans-6b" d="M 581 4863 
 L 1159 4863 
@@ -2272,14 +2935,16 @@ L 581 0
 L 581 4863 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-46" d="M 628 4666 
-L 3309 4666 
-L 3309 4134 
-L 1259 4134 
-L 1259 2759 
-L 3109 2759 
-L 3109 2228 
-L 1259 2228 
+      <path id="DejaVuSans-48" d="M 628 4666 
+L 1259 4666 
+L 1259 2753 
+L 3553 2753 
+L 3553 4666 
+L 4184 4666 
+L 4184 0 
+L 3553 0 
+L 3553 2222 
+L 1259 2222 
 L 1259 0 
 L 628 0 
 L 628 4666 
@@ -2315,76 +2980,85 @@ z
      <use xlink:href="#DejaVuSans-20" transform="translate(1375.976562 0)"/>
      <use xlink:href="#DejaVuSans-2014" transform="translate(1407.763672 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(1507.763672 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1539.550781 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1578.414062 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1639.9375 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(1701.216797 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1729 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1756.783203 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1808.882812 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1848.091797 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1875.875 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1930.855469 0)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1962.642578 0)"/>
-     <use xlink:href="#DejaVuSans-54" transform="translate(2026.119141 0)"/>
-     <use xlink:href="#DejaVuSans-46" transform="translate(2087.203125 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2144.722656 0)"/>
-     <use xlink:href="#DejaVuSans-28" transform="translate(2176.509766 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2215.523438 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2254.386719 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2315.910156 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(2377.189453 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2404.972656 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(2436.759766 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2500.138672 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2561.417969 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(2613.517578 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(2676.896484 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2726.896484 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2766.105469 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2804.96875 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2866.492188 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(2928.015625 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2978.015625 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3016.878906 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3078.060547 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3139.242188 0)"/>
-     <use xlink:href="#DejaVuSans-2c" transform="translate(3178.451172 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3210.238281 0)"/>
-     <use xlink:href="#DejaVuSans-41" transform="translate(3242.025391 0)"/>
-     <use xlink:href="#DejaVuSans-3d" transform="translate(3310.433594 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(3394.222656 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3457.845703 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(3489.632812 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3548.8125 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3610.091797 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3637.875 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(3665.658203 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3729.134766 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3760.921875 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3822.201172 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3861.410156 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3900.619141 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3962.142578 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(4014.242188 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(4053.451172 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(4114.730469 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(4153.939453 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(4181.722656 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(4242.904297 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(4306.283203 0)"/>
-     <use xlink:href="#DejaVuSans-29" transform="translate(4358.382812 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1539.550781 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1603.027344 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(1678.222656 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1744.380859 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(1780.464844 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(1844.087891 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1907.710938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1971.333984 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2003.121094 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2066.5 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2127.779297 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2179.878906 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(2243.257812 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2293.257812 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2332.466797 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2371.330078 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2432.853516 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(2494.376953 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2544.376953 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2583.240234 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2644.421875 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2705.603516 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2744.8125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2776.599609 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(2808.386719 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(2876.794922 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(2960.583984 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3024.207031 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(3055.994141 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3115.173828 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3176.453125 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3204.236328 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(3232.019531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3295.496094 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3327.283203 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3388.5625 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3427.771484 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3466.980469 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3528.503906 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3580.603516 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3619.8125 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3681.091797 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3720.300781 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3748.083984 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3809.265625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3872.644531 0)"/>
     </g>
    </g>
-   <g id="line2d_120">
-    <path d="M 77.774189 312.224892 
-L 129.792696 307.666084 
-L 285.848219 280.974185 
-L 441.903741 213.358114 
-L 597.959264 132.361043 
-" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
+   <g id="line2d_199">
+    <path d="M 380.506011 213.341229 
+L 624.571115 55.077495 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
     <defs>
-     <path id="mb6950196d0" d="M 0 4 
+     <path id="m154de8bcf0" d="M 0 4 
+C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
+C 3.578535 2.078319 4 1.060812 4 0 
+C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
+C 2.078319 -3.578535 1.060812 -4 0 -4 
+C -1.060812 -4 -2.078319 -3.578535 -2.828427 -2.828427 
+C -3.578535 -2.078319 -4 -1.060812 -4 0 
+C -4 1.060812 -3.578535 2.078319 -2.828427 2.828427 
+C -2.078319 3.578535 -1.060812 4 0 4 
+z
+" style="stroke: #d62728"/>
+    </defs>
+    <g clip-path="url(#p289f9afc26)">
+     <use xlink:href="#m154de8bcf0" x="380.506011" y="213.341229" style="fill: #ffffff; stroke: #d62728"/>
+     <use xlink:href="#m154de8bcf0" x="624.571115" y="55.077495" style="fill: #ffffff; stroke: #d62728"/>
+    </g>
+   </g>
+   <g id="line2d_200">
+    <path d="M 72.79247 323.597482 
+L 103.563824 322.102581 
+L 195.877886 303.837511 
+L 288.191948 261.56797 
+L 380.506011 213.341229 
+" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
+    <defs>
+     <path id="m6292887d37" d="M 0 4 
 C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
 C 3.578535 2.078319 4 1.060812 4 0 
 C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
@@ -2396,64 +3070,40 @@ C -2.078319 3.578535 -1.060812 4 0 4
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pca2a7c435e)">
-     <use xlink:href="#mb6950196d0" x="77.774189" y="312.224892" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb6950196d0" x="129.792696" y="307.666084" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb6950196d0" x="285.848219" y="280.974185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb6950196d0" x="441.903741" y="213.358114" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mb6950196d0" x="597.959264" y="132.361043" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p289f9afc26)">
+     <use xlink:href="#m6292887d37" x="72.79247" y="323.597482" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m6292887d37" x="103.563824" y="322.102581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m6292887d37" x="195.877886" y="303.837511" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m6292887d37" x="288.191948" y="261.56797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m6292887d37" x="380.506011" y="213.341229" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="legend_1">
-    <g id="patch_8">
-     <path d="M 71.737656 47.759781 
-L 362.316406 47.759781 
-Q 364.076406 47.759781 364.076406 45.999781 
-L 364.076406 33.718281 
-Q 364.076406 31.958281 362.316406 31.958281 
+    <g id="patch_10">
+     <path d="M 71.737656 60.676531 
+L 342.847781 60.676531 
+Q 344.607781 60.676531 344.607781 58.916531 
+L 344.607781 33.718281 
+Q 344.607781 31.958281 342.847781 31.958281 
 L 71.737656 31.958281 
 Q 69.977656 31.958281 69.977656 33.718281 
-L 69.977656 45.999781 
-Q 69.977656 47.759781 71.737656 47.759781 
+L 69.977656 58.916531 
+Q 69.977656 60.676531 71.737656 60.676531 
 z
 " style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_121">
+    <g id="line2d_201">
      <path d="M 73.497656 39.084906 
 L 82.297656 39.084906 
 L 91.097656 39.084906 
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb6950196d0" x="82.297656" y="39.084906" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#m6292887d37" x="82.297656" y="39.084906" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
-    <g id="text_23">
-     <!-- state_transition pipeline (incl. real SHA-256 hash_tree_root) -->
+    <g id="text_29">
+     <!-- state_transition pipeline (incl. SHA-256 hash_tree_root) -->
      <g transform="translate(98.137656 42.164906) scale(0.088 -0.088)">
-      <defs>
-       <path id="DejaVuSans-48" d="M 628 4666 
-L 1259 4666 
-L 1259 2753 
-L 3553 2753 
-L 3553 4666 
-L 4184 4666 
-L 4184 0 
-L 3553 0 
-L 3553 2222 
-L 1259 2222 
-L 1259 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-2d" d="M 313 2009 
-L 1997 2009 
-L 1997 1497 
-L 313 1497 
-L 313 2009 
-z
-" transform="scale(0.015625)"/>
-      </defs>
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
@@ -2487,42 +3137,88 @@ z
       <use xlink:href="#DejaVuSans-6c" transform="translate(1425.195312 0)"/>
       <use xlink:href="#DejaVuSans-2e" transform="translate(1452.978516 0)"/>
       <use xlink:href="#DejaVuSans-20" transform="translate(1484.765625 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(1516.552734 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1555.416016 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1616.939453 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1678.21875 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1706.001953 0)"/>
-      <use xlink:href="#DejaVuSans-53" transform="translate(1737.789062 0)"/>
-      <use xlink:href="#DejaVuSans-48" transform="translate(1801.265625 0)"/>
-      <use xlink:href="#DejaVuSans-41" transform="translate(1876.460938 0)"/>
-      <use xlink:href="#DejaVuSans-2d" transform="translate(1942.619141 0)"/>
-      <use xlink:href="#DejaVuSans-32" transform="translate(1978.703125 0)"/>
-      <use xlink:href="#DejaVuSans-35" transform="translate(2042.326172 0)"/>
-      <use xlink:href="#DejaVuSans-36" transform="translate(2105.949219 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(2169.572266 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(2201.359375 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(2264.738281 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(2326.017578 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(2378.117188 0)"/>
-      <use xlink:href="#DejaVuSans-5f" transform="translate(2441.496094 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(2491.496094 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(2530.705078 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2569.568359 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2631.091797 0)"/>
-      <use xlink:href="#DejaVuSans-5f" transform="translate(2692.615234 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(2742.615234 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(2781.478516 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(2842.660156 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(2903.841797 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(2943.050781 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1516.552734 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1580.029297 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1655.224609 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1721.382812 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(1757.466797 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(1821.089844 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(1884.712891 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1948.335938 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1980.123047 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2043.501953 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2104.78125 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(2156.880859 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2220.259766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2270.259766 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2309.46875 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2348.332031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2409.855469 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2471.378906 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2521.378906 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2560.242188 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2621.423828 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2682.605469 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2721.814453 0)"/>
+     </g>
+    </g>
+    <g id="line2d_202">
+     <path d="M 73.497656 52.246406 
+L 82.297656 52.246406 
+L 91.097656 52.246406 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
+     <g>
+      <use xlink:href="#m154de8bcf0" x="82.297656" y="52.246406" style="fill: #ffffff; stroke: #d62728"/>
+     </g>
+    </g>
+    <g id="text_30">
+     <!-- V=1M (mainnet, out-of-spec reference) -->
+     <g transform="translate(98.137656 55.326406) scale(0.088 -0.088)">
+      <use xlink:href="#DejaVuSans-56"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(152.197266 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(215.820312 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(302.099609 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(333.886719 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(372.900391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(470.3125 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(531.591797 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(559.375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(622.753906 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(686.132812 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(747.65625 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(786.865234 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(818.652344 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(850.439453 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(911.621094 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(975 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1014.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1052.167969 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(1113.349609 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1143.054688 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1179.138672 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1231.238281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1294.714844 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1356.238281 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1411.21875 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1443.005859 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1481.869141 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(1543.392578 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1578.597656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1640.121094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1678.984375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1740.507812 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1803.886719 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1858.867188 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1920.390625 0)"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pca2a7c435e">
-   <rect x="65.577656" y="27.558281" width="550.291367" height="315.29875"/>
+  <clipPath id="p289f9afc26">
+   <rect x="65.577656" y="27.558281" width="582.55" height="315.29875"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/bench-htr-results.svg
+++ b/docs/assets/bench-htr-results.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="658.15325pt" height="407.461031pt" viewBox="0 0 658.15325 407.461031" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="658.15325pt" height="407.801109pt" viewBox="0 0 658.15325 407.801109" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-26T01:09:03.579063</dc:date>
+    <dc:date>2026-06-26T01:11:22.732596</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,55 +21,55 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 407.461031 
-L 658.15325 407.461031 
-L 658.15325 0 
-L 0 0 
+   <path d="M 0 407.801109 
+L 658.15325 407.801109 
+L 658.15325 -0 
+L 0 -0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 66.926625 342.857031 
-L 649.476625 342.857031 
-L 649.476625 27.558281 
-L 66.926625 27.558281 
+    <path d="M 66.926625 343.197109 
+L 649.476625 343.197109 
+L 649.476625 27.178359 
+L 66.926625 27.178359 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 381.854979 342.857031 
-L 646.785275 342.857031 
-L 646.785275 27.558281 
-L 381.854979 27.558281 
+    <path d="M 381.854979 343.197109 
+L 646.785275 343.197109 
+L 646.785275 27.178359 
+L 381.854979 27.178359 
 z
-" clip-path="url(#pc0eca37085)" style="fill: #d62728; opacity: 0.06; stroke: #d62728; stroke-linejoin: miter"/>
+" clip-path="url(#p4927199f3f)" style="fill: #d62728; opacity: 0.06; stroke: #d62728; stroke-linejoin: miter"/>
    </g>
    <g id="line2d_1">
-    <path d="M 381.854979 342.857031 
-L 381.854979 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
+    <path d="M 381.854979 343.197109 
+L 381.854979 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_2">
-      <path d="M 74.141438 342.857031 
-L 74.141438 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 74.141438 343.197109 
+L 74.141438 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_3">
       <defs>
-       <path id="mb391ed1507" d="M 0 0 
+       <path id="mddcd902c46" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb391ed1507" x="74.141438" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mddcd902c46" x="74.141438" y="343.197109" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 4 -->
-      <g transform="translate(70.960188 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(70.960188 357.795547) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -97,18 +97,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_4">
-      <path d="M 104.912792 342.857031 
-L 104.912792 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 104.912792 343.197109 
+L 104.912792 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb391ed1507" x="104.912792" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mddcd902c46" x="104.912792" y="343.197109" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 8 -->
-      <g transform="translate(101.731542 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(101.731542 357.795547) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -156,18 +156,18 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_6">
-      <path d="M 197.226855 342.857031 
-L 197.226855 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 197.226855 343.197109 
+L 197.226855 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mb391ed1507" x="197.226855" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mddcd902c46" x="197.226855" y="343.197109" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 64 -->
-      <g transform="translate(190.864355 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(190.864355 357.795547) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -207,18 +207,18 @@ z
     </g>
     <g id="xtick_4">
      <g id="line2d_8">
-      <path d="M 289.540917 342.857031 
-L 289.540917 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 289.540917 343.197109 
+L 289.540917 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mb391ed1507" x="289.540917" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mddcd902c46" x="289.540917" y="343.197109" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 512 -->
-      <g transform="translate(279.997167 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(279.997167 357.795547) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -292,18 +292,18 @@ z
     </g>
     <g id="xtick_5">
      <g id="line2d_10">
-      <path d="M 381.854979 342.857031 
-L 381.854979 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 381.854979 343.197109 
+L 381.854979 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mb391ed1507" x="381.854979" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mddcd902c46" x="381.854979" y="343.197109" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 4096 -->
-      <g transform="translate(369.129979 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(369.129979 357.795547) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -366,18 +366,18 @@ z
     </g>
     <g id="xtick_6">
      <g id="line2d_12">
-      <path d="M 625.920084 342.857031 
-L 625.920084 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 625.920084 343.197109 
+L 625.920084 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mb391ed1507" x="625.920084" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mddcd902c46" x="625.920084" y="343.197109" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 1M -->
-      <g transform="translate(618.424772 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(618.424772 357.795547) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4d" d="M 628 4666 
 L 1569 4666 
@@ -403,540 +403,540 @@ z
     </g>
     <g id="xtick_7">
      <g id="line2d_14">
-      <path d="M 84.047602 342.857031 
-L 84.047602 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 84.047602 343.197109 
+L 84.047602 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_15">
       <defs>
-       <path id="mfb936d361c" d="M 0 0 
+       <path id="m97297b0dd9" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mfb936d361c" x="84.047602" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="84.047602" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_16">
-      <path d="M 92.141527 342.857031 
-L 92.141527 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 92.141527 343.197109 
+L 92.141527 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mfb936d361c" x="92.141527" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="92.141527" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_18">
-      <path d="M 98.984843 342.857031 
-L 98.984843 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 98.984843 343.197109 
+L 98.984843 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mfb936d361c" x="98.984843" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="98.984843" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_20">
-      <path d="M 110.141615 342.857031 
-L 110.141615 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 110.141615 343.197109 
+L 110.141615 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mfb936d361c" x="110.141615" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="110.141615" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_22">
-      <path d="M 145.59031 342.857031 
-L 145.59031 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 145.59031 343.197109 
+L 145.59031 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mfb936d361c" x="145.59031" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="145.59031" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_24">
-      <path d="M 163.590398 342.857031 
-L 163.590398 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 163.590398 343.197109 
+L 163.590398 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mfb936d361c" x="163.590398" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="163.590398" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_26">
-      <path d="M 176.361664 342.857031 
-L 176.361664 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 176.361664 343.197109 
+L 176.361664 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mfb936d361c" x="176.361664" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="176.361664" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_28">
-      <path d="M 186.267827 342.857031 
-L 186.267827 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 186.267827 343.197109 
+L 186.267827 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#mfb936d361c" x="186.267827" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="186.267827" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_30">
-      <path d="M 194.361752 342.857031 
-L 194.361752 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 194.361752 343.197109 
+L 194.361752 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#mfb936d361c" x="194.361752" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="194.361752" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_32">
-      <path d="M 201.205068 342.857031 
-L 201.205068 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 201.205068 343.197109 
+L 201.205068 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#mfb936d361c" x="201.205068" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="201.205068" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_34">
-      <path d="M 207.133018 342.857031 
-L 207.133018 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 207.133018 343.197109 
+L 207.133018 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#mfb936d361c" x="207.133018" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="207.133018" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_36">
-      <path d="M 212.361841 342.857031 
-L 212.361841 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 212.361841 343.197109 
+L 212.361841 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#mfb936d361c" x="212.361841" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="212.361841" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_38">
-      <path d="M 247.810536 342.857031 
-L 247.810536 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 247.810536 343.197109 
+L 247.810536 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#mfb936d361c" x="247.810536" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="247.810536" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_40">
-      <path d="M 265.810624 342.857031 
-L 265.810624 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 265.810624 343.197109 
+L 265.810624 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#mfb936d361c" x="265.810624" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="265.810624" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_42">
-      <path d="M 278.58189 342.857031 
-L 278.58189 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 278.58189 343.197109 
+L 278.58189 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#mfb936d361c" x="278.58189" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="278.58189" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_44">
-      <path d="M 288.488053 342.857031 
-L 288.488053 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 288.488053 343.197109 
+L 288.488053 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#mfb936d361c" x="288.488053" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="288.488053" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
      <g id="line2d_46">
-      <path d="M 296.581978 342.857031 
-L 296.581978 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 296.581978 343.197109 
+L 296.581978 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mfb936d361c" x="296.581978" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="296.581978" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
      <g id="line2d_48">
-      <path d="M 303.425294 342.857031 
-L 303.425294 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 303.425294 343.197109 
+L 303.425294 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mfb936d361c" x="303.425294" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="303.425294" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_25">
      <g id="line2d_50">
-      <path d="M 309.353244 342.857031 
-L 309.353244 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 309.353244 343.197109 
+L 309.353244 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mfb936d361c" x="309.353244" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="309.353244" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_26">
      <g id="line2d_52">
-      <path d="M 314.582066 342.857031 
-L 314.582066 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 314.582066 343.197109 
+L 314.582066 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#mfb936d361c" x="314.582066" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="314.582066" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_27">
      <g id="line2d_54">
-      <path d="M 350.030761 342.857031 
-L 350.030761 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 350.030761 343.197109 
+L 350.030761 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#mfb936d361c" x="350.030761" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="350.030761" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_28">
      <g id="line2d_56">
-      <path d="M 368.03085 342.857031 
-L 368.03085 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 368.03085 343.197109 
+L 368.03085 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#mfb936d361c" x="368.03085" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="368.03085" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_29">
      <g id="line2d_58">
-      <path d="M 380.802115 342.857031 
-L 380.802115 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 380.802115 343.197109 
+L 380.802115 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#mfb936d361c" x="380.802115" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="380.802115" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_30">
      <g id="line2d_60">
-      <path d="M 390.708279 342.857031 
-L 390.708279 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 390.708279 343.197109 
+L 390.708279 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#mfb936d361c" x="390.708279" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="390.708279" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_31">
      <g id="line2d_62">
-      <path d="M 398.802204 342.857031 
-L 398.802204 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 398.802204 343.197109 
+L 398.802204 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#mfb936d361c" x="398.802204" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="398.802204" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_32">
      <g id="line2d_64">
-      <path d="M 405.64552 342.857031 
-L 405.64552 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 405.64552 343.197109 
+L 405.64552 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#mfb936d361c" x="405.64552" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="405.64552" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_33">
      <g id="line2d_66">
-      <path d="M 411.573469 342.857031 
-L 411.573469 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 411.573469 343.197109 
+L 411.573469 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#mfb936d361c" x="411.573469" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="411.573469" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_34">
      <g id="line2d_68">
-      <path d="M 416.802292 342.857031 
-L 416.802292 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 416.802292 343.197109 
+L 416.802292 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#mfb936d361c" x="416.802292" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="416.802292" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_35">
      <g id="line2d_70">
-      <path d="M 452.250987 342.857031 
-L 452.250987 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 452.250987 343.197109 
+L 452.250987 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#mfb936d361c" x="452.250987" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="452.250987" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_36">
      <g id="line2d_72">
-      <path d="M 470.251075 342.857031 
-L 470.251075 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 470.251075 343.197109 
+L 470.251075 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#mfb936d361c" x="470.251075" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="470.251075" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_37">
      <g id="line2d_74">
-      <path d="M 483.022341 342.857031 
-L 483.022341 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 483.022341 343.197109 
+L 483.022341 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#mfb936d361c" x="483.022341" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="483.022341" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_38">
      <g id="line2d_76">
-      <path d="M 492.928504 342.857031 
-L 492.928504 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 492.928504 343.197109 
+L 492.928504 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#mfb936d361c" x="492.928504" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="492.928504" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_39">
      <g id="line2d_78">
-      <path d="M 501.022429 342.857031 
-L 501.022429 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 501.022429 343.197109 
+L 501.022429 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#mfb936d361c" x="501.022429" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="501.022429" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_40">
      <g id="line2d_80">
-      <path d="M 507.865745 342.857031 
-L 507.865745 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 507.865745 343.197109 
+L 507.865745 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#mfb936d361c" x="507.865745" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="507.865745" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_41">
      <g id="line2d_82">
-      <path d="M 513.793695 342.857031 
-L 513.793695 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 513.793695 343.197109 
+L 513.793695 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#mfb936d361c" x="513.793695" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="513.793695" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_42">
      <g id="line2d_84">
-      <path d="M 519.022518 342.857031 
-L 519.022518 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 519.022518 343.197109 
+L 519.022518 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#mfb936d361c" x="519.022518" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="519.022518" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_43">
      <g id="line2d_86">
-      <path d="M 554.471213 342.857031 
-L 554.471213 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 554.471213 343.197109 
+L 554.471213 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#mfb936d361c" x="554.471213" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="554.471213" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_44">
      <g id="line2d_88">
-      <path d="M 572.471301 342.857031 
-L 572.471301 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 572.471301 343.197109 
+L 572.471301 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#mfb936d361c" x="572.471301" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="572.471301" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_45">
      <g id="line2d_90">
-      <path d="M 585.242567 342.857031 
-L 585.242567 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 585.242567 343.197109 
+L 585.242567 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#mfb936d361c" x="585.242567" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="585.242567" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_46">
      <g id="line2d_92">
-      <path d="M 595.14873 342.857031 
-L 595.14873 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 595.14873 343.197109 
+L 595.14873 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_93">
       <g>
-       <use xlink:href="#mfb936d361c" x="595.14873" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="595.14873" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_47">
      <g id="line2d_94">
-      <path d="M 603.242655 342.857031 
-L 603.242655 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 603.242655 343.197109 
+L 603.242655 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_95">
       <g>
-       <use xlink:href="#mfb936d361c" x="603.242655" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="603.242655" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_48">
      <g id="line2d_96">
-      <path d="M 610.085971 342.857031 
-L 610.085971 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 610.085971 343.197109 
+L 610.085971 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#mfb936d361c" x="610.085971" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="610.085971" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_49">
      <g id="line2d_98">
-      <path d="M 616.013921 342.857031 
-L 616.013921 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 616.013921 343.197109 
+L 616.013921 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_99">
       <g>
-       <use xlink:href="#mfb936d361c" x="616.013921" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="616.013921" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_50">
      <g id="line2d_100">
-      <path d="M 621.242743 342.857031 
-L 621.242743 27.558281 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 621.242743 343.197109 
+L 621.242743 27.178359 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_101">
       <g>
-       <use xlink:href="#mfb936d361c" x="621.242743" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97297b0dd9" x="621.242743" y="343.197109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_7">
      <!-- validator count  V  (≤ leanSpec VALIDATOR_REGISTRY_LIMIT = 2¹² = 4096) -->
-     <g transform="translate(161.907406 371.513516) scale(0.105 -0.105)">
+     <g transform="translate(161.907406 371.853594) scale(0.105 -0.105)">
       <defs>
        <path id="DejaVuSans-76" d="M 191 3500 
 L 800 3500 
@@ -1577,23 +1577,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_102">
-      <path d="M 66.926625 325.494341 
-L 649.476625 325.494341 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 325.79477 
+L 649.476625 325.79477 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_103">
       <defs>
-       <path id="m3be459f841" d="M 0 0 
+       <path id="mee7f1c5194" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="325.494341" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="325.79477" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 300 µs -->
-      <g transform="translate(26.089125 329.29356) scale(0.1 -0.1)">
+      <g transform="translate(26.089125 329.593989) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1698,18 +1698,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_104">
-      <path d="M 66.926625 295.335945 
-L 649.476625 295.335945 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 295.567506 
+L 649.476625 295.567506 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_105">
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="295.335945" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="295.567506" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 1 ms -->
-      <g transform="translate(35.436 299.135164) scale(0.1 -0.1)">
+      <g transform="translate(35.436 299.366725) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1751,18 +1751,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_106">
-      <path d="M 66.926625 267.816732 
-L 649.476625 267.816732 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 267.985452 
+L 649.476625 267.985452 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_107">
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="267.816732" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="267.985452" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 3 ms -->
-      <g transform="translate(35.436 271.61595) scale(0.1 -0.1)">
+      <g transform="translate(35.436 271.78467) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
@@ -1772,18 +1772,18 @@ L 649.476625 267.816732
     </g>
     <g id="ytick_4">
      <g id="line2d_108">
-      <path d="M 66.926625 237.658336 
-L 649.476625 237.658336 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 237.758187 
+L 649.476625 237.758187 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_109">
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="237.658336" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="237.758187" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10 ms -->
-      <g transform="translate(29.0735 241.457554) scale(0.1 -0.1)">
+      <g transform="translate(29.0735 241.557406) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -1794,18 +1794,18 @@ L 649.476625 237.658336
     </g>
     <g id="ytick_5">
      <g id="line2d_110">
-      <path d="M 66.926625 210.139122 
-L 649.476625 210.139122 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 210.176133 
+L 649.476625 210.176133 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_111">
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="210.139122" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="210.176133" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 30 ms -->
-      <g transform="translate(29.0735 213.938341) scale(0.1 -0.1)">
+      <g transform="translate(29.0735 213.975351) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -1816,18 +1816,18 @@ L 649.476625 210.139122
     </g>
     <g id="ytick_6">
      <g id="line2d_112">
-      <path d="M 66.926625 179.980726 
-L 649.476625 179.980726 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 179.948869 
+L 649.476625 179.948869 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_113">
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="179.980726" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="179.948869" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 100 ms -->
-      <g transform="translate(22.711 183.779945) scale(0.1 -0.1)">
+      <g transform="translate(22.711 183.748087) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1839,18 +1839,18 @@ L 649.476625 179.980726
     </g>
     <g id="ytick_7">
      <g id="line2d_114">
-      <path d="M 66.926625 152.461513 
-L 649.476625 152.461513 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 152.366814 
+L 649.476625 152.366814 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_115">
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="152.461513" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="152.366814" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 300 ms -->
-      <g transform="translate(22.711 156.260732) scale(0.1 -0.1)">
+      <g transform="translate(22.711 156.166033) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1862,18 +1862,18 @@ L 649.476625 152.461513
     </g>
     <g id="ytick_8">
      <g id="line2d_116">
-      <path d="M 66.926625 122.303117 
-L 649.476625 122.303117 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 122.13955 
+L 649.476625 122.13955 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_117">
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="122.303117" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="122.13955" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 1 s -->
-      <g transform="translate(45.176625 126.102336) scale(0.1 -0.1)">
+      <g transform="translate(45.176625 125.938769) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -1882,18 +1882,18 @@ L 649.476625 122.303117
     </g>
     <g id="ytick_9">
      <g id="line2d_118">
-      <path d="M 66.926625 94.783904 
-L 649.476625 94.783904 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 94.557495 
+L 649.476625 94.557495 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_119">
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="94.783904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="94.557495" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 3 s -->
-      <g transform="translate(45.176625 98.583123) scale(0.1 -0.1)">
+      <g transform="translate(45.176625 98.356714) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -1902,18 +1902,18 @@ L 649.476625 94.783904
     </g>
     <g id="ytick_10">
      <g id="line2d_120">
-      <path d="M 66.926625 64.625508 
-L 649.476625 64.625508 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 64.330231 
+L 649.476625 64.330231 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_121">
       <g>
-       <use xlink:href="#m3be459f841" x="66.926625" y="64.625508" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee7f1c5194" x="66.926625" y="64.330231" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 10 s -->
-      <g transform="translate(38.814125 68.424727) scale(0.1 -0.1)">
+      <g transform="translate(38.814125 68.12945) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -1923,468 +1923,468 @@ L 649.476625 64.625508
     </g>
     <g id="ytick_11">
      <g id="line2d_122">
-      <path d="M 66.926625 335.650864 
-L 649.476625 335.650864 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 335.974486 
+L 649.476625 335.974486 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_123">
       <defs>
-       <path id="mf5ec83d541" d="M 0 0 
+       <path id="mc767cb2550" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="335.650864" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="335.974486" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_124">
-      <path d="M 66.926625 318.288173 
-L 649.476625 318.288173 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 318.572147 
+L 649.476625 318.572147 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_125">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="318.288173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="318.572147" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_126">
-      <path d="M 66.926625 312.698635 
-L 649.476625 312.698635 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 312.969845 
+L 649.476625 312.969845 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_127">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="312.698635" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="312.969845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_128">
-      <path d="M 66.926625 308.13165 
-L 649.476625 308.13165 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 308.392431 
+L 649.476625 308.392431 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_129">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="308.13165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="308.392431" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_130">
-      <path d="M 66.926625 304.27032 
-L 649.476625 304.27032 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 304.522283 
+L 649.476625 304.522283 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_131">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="304.27032" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="304.522283" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_132">
-      <path d="M 66.926625 300.925483 
-L 649.476625 300.925483 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 301.169808 
+L 649.476625 301.169808 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_133">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="300.925483" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="301.169808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_134">
-      <path d="M 66.926625 297.975128 
-L 649.476625 297.975128 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 298.212716 
+L 649.476625 298.212716 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_135">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="297.975128" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="298.212716" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_136">
-      <path d="M 66.926625 277.973254 
-L 649.476625 277.973254 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 278.165167 
+L 649.476625 278.165167 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_137">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="277.973254" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="278.165167" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_138">
-      <path d="M 66.926625 260.610564 
-L 649.476625 260.610564 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 260.762828 
+L 649.476625 260.762828 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_139">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="260.610564" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="260.762828" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_140">
-      <path d="M 66.926625 255.021026 
-L 649.476625 255.021026 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 255.160526 
+L 649.476625 255.160526 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_141">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="255.021026" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="255.160526" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_142">
-      <path d="M 66.926625 250.454041 
-L 649.476625 250.454041 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 250.583113 
+L 649.476625 250.583113 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_143">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="250.454041" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="250.583113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_144">
-      <path d="M 66.926625 246.59271 
-L 649.476625 246.59271 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 246.712964 
+L 649.476625 246.712964 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_145">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="246.59271" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="246.712964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_146">
-      <path d="M 66.926625 243.247874 
-L 649.476625 243.247874 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 243.360489 
+L 649.476625 243.360489 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_147">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="243.247874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="243.360489" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_148">
-      <path d="M 66.926625 240.297518 
-L 649.476625 240.297518 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 240.403397 
+L 649.476625 240.403397 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_149">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="240.297518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="240.403397" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_150">
-      <path d="M 66.926625 220.295645 
-L 649.476625 220.295645 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 220.355848 
+L 649.476625 220.355848 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_151">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="220.295645" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="220.355848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_152">
-      <path d="M 66.926625 202.932955 
-L 649.476625 202.932955 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 202.953509 
+L 649.476625 202.953509 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_153">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="202.932955" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="202.953509" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_154">
-      <path d="M 66.926625 197.343417 
-L 649.476625 197.343417 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 197.351208 
+L 649.476625 197.351208 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_155">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="197.343417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="197.351208" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_156">
-      <path d="M 66.926625 192.776432 
-L 649.476625 192.776432 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 192.773794 
+L 649.476625 192.773794 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_157">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="192.776432" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="192.773794" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_158">
-      <path d="M 66.926625 188.915101 
-L 649.476625 188.915101 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 188.903645 
+L 649.476625 188.903645 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_159">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="188.915101" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="188.903645" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_160">
-      <path d="M 66.926625 185.570264 
-L 649.476625 185.570264 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 185.55117 
+L 649.476625 185.55117 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_161">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="185.570264" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="185.55117" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_162">
-      <path d="M 66.926625 182.619909 
-L 649.476625 182.619909 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 182.594078 
+L 649.476625 182.594078 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_163">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="182.619909" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="182.594078" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_164">
-      <path d="M 66.926625 162.618036 
-L 649.476625 162.618036 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 162.54653 
+L 649.476625 162.54653 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_165">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="162.618036" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="162.54653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_166">
-      <path d="M 66.926625 145.255346 
-L 649.476625 145.255346 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 145.144191 
+L 649.476625 145.144191 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_167">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="145.255346" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="145.144191" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_168">
-      <path d="M 66.926625 139.665808 
-L 649.476625 139.665808 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 139.541889 
+L 649.476625 139.541889 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_169">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="139.665808" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="139.541889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_170">
-      <path d="M 66.926625 135.098823 
-L 649.476625 135.098823 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 134.964475 
+L 649.476625 134.964475 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_171">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="135.098823" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="134.964475" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_172">
-      <path d="M 66.926625 131.237492 
-L 649.476625 131.237492 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 131.094327 
+L 649.476625 131.094327 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_173">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="131.237492" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="131.094327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_174">
-      <path d="M 66.926625 127.892655 
-L 649.476625 127.892655 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 127.741852 
+L 649.476625 127.741852 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_175">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="127.892655" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="127.741852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_176">
-      <path d="M 66.926625 124.9423 
-L 649.476625 124.9423 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 124.784759 
+L 649.476625 124.784759 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_177">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="124.9423" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="124.784759" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_178">
-      <path d="M 66.926625 104.940427 
-L 649.476625 104.940427 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 104.737211 
+L 649.476625 104.737211 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_179">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="104.940427" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="104.737211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_180">
-      <path d="M 66.926625 87.577736 
-L 649.476625 87.577736 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 87.334872 
+L 649.476625 87.334872 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_181">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="87.577736" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="87.334872" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_182">
-      <path d="M 66.926625 81.988199 
-L 649.476625 81.988199 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 81.73257 
+L 649.476625 81.73257 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_183">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="81.988199" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="81.73257" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_184">
-      <path d="M 66.926625 77.421214 
-L 649.476625 77.421214 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 77.155156 
+L 649.476625 77.155156 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_185">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="77.421214" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="77.155156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_186">
-      <path d="M 66.926625 73.559883 
-L 649.476625 73.559883 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 73.285008 
+L 649.476625 73.285008 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_187">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="73.559883" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="73.285008" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_188">
-      <path d="M 66.926625 70.215046 
-L 649.476625 70.215046 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 69.932533 
+L 649.476625 69.932533 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_189">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="70.215046" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="69.932533" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_190">
-      <path d="M 66.926625 67.264691 
-L 649.476625 67.264691 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 66.97544 
+L 649.476625 66.97544 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_191">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="67.264691" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="66.97544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_192">
-      <path d="M 66.926625 47.262818 
-L 649.476625 47.262818 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 46.927892 
+L 649.476625 46.927892 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_193">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="47.262818" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="46.927892" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_194">
-      <path d="M 66.926625 37.106295 
-L 649.476625 37.106295 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 36.748176 
+L 649.476625 36.748176 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_195">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="37.106295" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="36.748176" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_196">
-      <path d="M 66.926625 29.900127 
-L 649.476625 29.900127 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 29.525553 
+L 649.476625 29.525553 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_197">
       <g>
-       <use xlink:href="#mf5ec83d541" x="66.926625" y="29.900127" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc767cb2550" x="66.926625" y="29.525553" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_18">
      <!-- time per call (log scale) -->
-     <g transform="translate(16.527328 247.113359) rotate(-90) scale(0.105 -0.105)">
+     <g transform="translate(16.527328 247.093438) rotate(-90) scale(0.105 -0.105)">
       <defs>
        <path id="DejaVuSans-67" d="M 2906 1791 
 Q 2906 2416 2648 2759 
@@ -2450,33 +2450,33 @@ z
     </g>
    </g>
    <g id="line2d_198">
-    <path d="M 66.926625 162.618036 
-L 649.476625 162.618036 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
+    <path d="M 66.926625 162.54653 
+L 649.476625 162.54653 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
    </g>
    <g id="patch_4">
-    <path d="M 66.926625 342.857031 
-L 66.926625 27.558281 
+    <path d="M 66.926625 343.197109 
+L 66.926625 27.178359 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 649.476625 342.857031 
-L 649.476625 27.558281 
+    <path d="M 649.476625 343.197109 
+L 649.476625 27.178359 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 66.926625 342.857031 
-L 649.476625 342.857031 
+    <path d="M 66.926625 343.197109 
+L 649.476625 343.197109 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 66.926625 27.558281 
-L 649.476625 27.558281 
+    <path d="M 66.926625 27.178359 
+L 649.476625 27.178359 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_19">
     <!-- VALIDATOR_REGISTRY_LIMIT = 4096 -->
-    <g style="fill: #b01010" transform="translate(388.059526 322.418933) scale(0.08 -0.08)">
+    <g style="fill: #b01010" transform="translate(388.059526 322.737103) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-56"/>
      <use xlink:href="#DejaVuSans-41" transform="translate(62.033203 0)"/>
      <use xlink:href="#DejaVuSans-4c" transform="translate(130.441406 0)"/>
@@ -2510,7 +2510,7 @@ L 649.476625 27.558281
      <use xlink:href="#DejaVuSans-36" transform="translate(1749.527344 0)"/>
     </g>
     <!-- (leanSpec cap) -->
-    <g style="fill: #b01010" transform="translate(388.059526 331.599683) scale(0.08 -0.08)">
+    <g style="fill: #b01010" transform="translate(388.059526 331.917853) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-28"/>
      <use xlink:href="#DejaVuSans-6c" transform="translate(39.013672 0)"/>
      <use xlink:href="#DejaVuSans-65" transform="translate(66.796875 0)"/>
@@ -2529,7 +2529,7 @@ L 649.476625 27.558281
    </g>
    <g id="text_20">
     <!-- SLO target 200 ms (1 interval) -->
-    <g style="fill: #555555" transform="translate(70.680439 158.900253) scale(0.085 -0.085)">
+    <g style="fill: #555555" transform="translate(70.680439 158.820257) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-53"/>
      <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
      <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
@@ -2564,7 +2564,7 @@ L 649.476625 27.558281
    </g>
    <g id="text_21">
     <!-- 324 µs -->
-    <g style="fill: #0b3d6e" transform="translate(60.098876 314.597482) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(60.098876 314.89358) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
@@ -2575,7 +2575,7 @@ L 649.476625 27.558281
    </g>
    <g id="text_22">
     <!-- 344 µs -->
-    <g style="fill: #0b3d6e" transform="translate(90.87023 313.102581) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(90.87023 313.395265) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
@@ -2586,7 +2586,7 @@ L 649.476625 27.558281
    </g>
    <g id="text_23">
     <!-- 712 µs -->
-    <g style="fill: #0b3d6e" transform="translate(183.184292 294.837511) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(183.184292 295.088486) scale(0.083 -0.083)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -2609,7 +2609,7 @@ z
    </g>
    <g id="text_24">
     <!-- 3.85 ms -->
-    <g style="fill: #0b3d6e" transform="translate(272.777511 252.56797) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(272.777511 252.72242) scale(0.083 -0.083)">
      <defs>
       <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -2630,7 +2630,7 @@ z
    </g>
    <g id="text_25">
     <!-- 26.40 ms -->
-    <g style="fill: #0b3d6e" transform="translate(362.451136 204.341229) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(362.451136 204.385552) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
@@ -2642,17 +2642,17 @@ z
     </g>
    </g>
    <g id="patch_8">
-    <path d="M 316.034781 275.103917 
-Q 348.214728 244.907715 379.497844 215.553058 
+    <path d="M 315.985471 275.35712 
+Q 348.191536 245.056904 379.501875 215.599407 
 " style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
-    <path d="M 375.812357 216.652687 
-L 379.497844 215.553058 
-L 378.166256 219.161225 
+    <path d="M 375.817833 216.703868 
+L 379.501875 215.599407 
+L 378.175018 219.209317 
 " style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
    </g>
    <g id="text_26">
     <!-- V=4096 (leanSpec max) -->
-    <g style="fill: #0b6e0b" transform="translate(235.03927 285.010082) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(235.03927 285.262046) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -2693,7 +2693,7 @@ z
      <use xlink:href="#DejaVuSans-29" transform="translate(1184.570312 0)"/>
     </g>
     <!-- 26.40 ms — green, -->
-    <g style="fill: #0b6e0b" transform="translate(235.03927 294.640201) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(235.03927 294.892164) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2731,7 +2731,7 @@ z
      <use xlink:href="#DejaVuSans-2c" transform="translate(919.917969 0)"/>
     </g>
     <!-- 8× under the 200 ms budget -->
-    <g style="fill: #0b6e0b" transform="translate(235.03927 304.27032) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(235.03927 304.522283) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-d7" d="M 4488 3438 
 L 3059 2003 
@@ -2823,17 +2823,17 @@ z
     </g>
    </g>
    <g id="patch_9">
-    <path d="M 556.273417 79.211223 
-Q 590.150926 67.472103 622.866387 56.135651 
+    <path d="M 556.187551 78.990165 
+Q 590.111083 67.202858 622.872909 55.819207 
 " style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
-    <path d="M 619.052843 55.636771 
-L 622.866387 56.135651 
-L 620.179156 58.887158 
+    <path d="M 619.058943 55.323561 
+L 622.872909 55.819207 
+L 620.188013 58.572992 
 " style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
    </g>
    <g id="text_27">
     <!-- V=1M (mainnet, out-of-spec) -->
-    <g style="fill: #b01010" transform="translate(460.344912 88.401477) scale(0.086 -0.086)">
+    <g style="fill: #b01010" transform="translate(460.344912 88.182485) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -2893,7 +2893,7 @@ z
      <use xlink:href="#DejaVuSans-29" transform="translate(1411.21875 0)"/>
     </g>
     <!-- 14.64 s — over budget -->
-    <g style="fill: #b01010" transform="translate(460.344912 98.031596) scale(0.086 -0.086)">
+    <g style="fill: #b01010" transform="translate(460.344912 97.812603) scale(0.086 -0.086)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
@@ -2918,9 +2918,22 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- state_transition benchmark — SHA-256 hash_tree_root, A=8 valid attestations -->
-    <g transform="translate(142.344672 15.558281) scale(0.11 -0.11)">
+    <!-- state_transition (full STF) benchmark — A=8 valid attestations, incl. SHA-256 hash_tree_root -->
+    <g transform="translate(114.603266 15.178359) scale(0.105 -0.105)">
      <defs>
+      <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-6b" d="M 581 4863 
 L 1159 4863 
 L 1159 1991 
@@ -2968,72 +2981,89 @@ z
      <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
      <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(811.523438 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(875 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(936.523438 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(999.902344 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(1054.882812 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(1118.261719 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1215.673828 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1276.953125 0)"/>
-     <use xlink:href="#DejaVuSans-6b" transform="translate(1318.066406 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1375.976562 0)"/>
-     <use xlink:href="#DejaVuSans-2014" transform="translate(1407.763672 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1507.763672 0)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1539.550781 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1603.027344 0)"/>
-     <use xlink:href="#DejaVuSans-41" transform="translate(1678.222656 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(1744.380859 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(1780.464844 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(1844.087891 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(1907.710938 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1971.333984 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(2003.121094 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2066.5 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2127.779297 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(2179.878906 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(2243.257812 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2293.257812 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2332.466797 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2371.330078 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2432.853516 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(2494.376953 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2544.376953 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2583.240234 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2644.421875 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2705.603516 0)"/>
-     <use xlink:href="#DejaVuSans-2c" transform="translate(2744.8125 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2776.599609 0)"/>
-     <use xlink:href="#DejaVuSans-41" transform="translate(2808.386719 0)"/>
-     <use xlink:href="#DejaVuSans-3d" transform="translate(2876.794922 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(2960.583984 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3024.207031 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(3055.994141 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3115.173828 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3176.453125 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3204.236328 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(3232.019531 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3295.496094 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3327.283203 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3388.5625 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3427.771484 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3466.980469 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3528.503906 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3580.603516 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3619.8125 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3681.091797 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3720.300781 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3748.083984 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3809.265625 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3872.644531 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(811.523438 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(850.537109 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(885.742188 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(949.121094 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(976.904297 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1004.6875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1036.474609 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(1099.951172 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1161.035156 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1218.554688 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1257.568359 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1289.355469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1352.832031 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1414.355469 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1477.734375 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1532.714844 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1596.09375 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1693.505859 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1754.785156 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(1795.898438 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1853.808594 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1885.595703 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1985.595703 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(2017.382812 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(2085.791016 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(2169.580078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2233.203125 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(2264.990234 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2324.169922 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2385.449219 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2413.232422 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2441.015625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2504.492188 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2536.279297 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2597.558594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2636.767578 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2675.976562 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2737.5 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2789.599609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2828.808594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2890.087891 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2929.296875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2957.080078 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3018.261719 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3081.640625 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(3133.740234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3165.527344 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3197.314453 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3225.097656 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3288.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3343.457031 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3371.240234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3403.027344 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(3434.814453 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(3498.291016 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(3573.486328 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(3639.644531 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(3675.728516 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(3739.351562 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(3802.974609 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3866.597656 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3898.384766 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3961.763672 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4023.042969 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(4075.142578 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(4138.521484 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4188.521484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(4227.730469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4266.59375 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4328.117188 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(4389.640625 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(4439.640625 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4478.503906 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4539.685547 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4600.867188 0)"/>
     </g>
    </g>
    <g id="line2d_199">
-    <path d="M 381.854979 213.341229 
-L 625.920084 55.077495 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 381.854979 213.385552 
+L 625.920084 54.760414 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
     <defs>
-     <path id="m8c8d148425" d="M 0 4 
+     <path id="m3907471811" d="M 0 4 
 C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
 C 3.578535 2.078319 4 1.060812 4 0 
 C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
@@ -3045,20 +3075,20 @@ C -2.078319 3.578535 -1.060812 4 0 4
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pc0eca37085)">
-     <use xlink:href="#m8c8d148425" x="381.854979" y="213.341229" style="fill: #ffffff; stroke: #d62728"/>
-     <use xlink:href="#m8c8d148425" x="625.920084" y="55.077495" style="fill: #ffffff; stroke: #d62728"/>
+    <g clip-path="url(#p4927199f3f)">
+     <use xlink:href="#m3907471811" x="381.854979" y="213.385552" style="fill: #ffffff; stroke: #d62728"/>
+     <use xlink:href="#m3907471811" x="625.920084" y="54.760414" style="fill: #ffffff; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_200">
-    <path d="M 74.141438 323.597482 
-L 104.912792 322.102581 
-L 197.226855 303.837511 
-L 289.540917 261.56797 
-L 381.854979 213.341229 
-" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
+    <path d="M 74.141438 323.89358 
+L 104.912792 322.395265 
+L 197.226855 304.088486 
+L 289.540917 261.72242 
+L 381.854979 213.385552 
+" clip-path="url(#p4927199f3f)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
     <defs>
-     <path id="md663bc701b" d="M 0 4 
+     <path id="ma1d832450f" d="M 0 4 
 C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
 C 3.578535 2.078319 4 1.060812 4 0 
 C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
@@ -3070,40 +3100,40 @@ C -2.078319 3.578535 -1.060812 4 0 4
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pc0eca37085)">
-     <use xlink:href="#md663bc701b" x="74.141438" y="323.597482" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md663bc701b" x="104.912792" y="322.102581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md663bc701b" x="197.226855" y="303.837511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md663bc701b" x="289.540917" y="261.56797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md663bc701b" x="381.854979" y="213.341229" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p4927199f3f)">
+     <use xlink:href="#ma1d832450f" x="74.141438" y="323.89358" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#ma1d832450f" x="104.912792" y="322.395265" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#ma1d832450f" x="197.226855" y="304.088486" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#ma1d832450f" x="289.540917" y="261.72242" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#ma1d832450f" x="381.854979" y="213.385552" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_10">
-     <path d="M 73.086625 60.676531 
-L 344.19675 60.676531 
-Q 345.95675 60.676531 345.95675 58.916531 
-L 345.95675 33.718281 
-Q 345.95675 31.958281 344.19675 31.958281 
-L 73.086625 31.958281 
-Q 71.326625 31.958281 71.326625 33.718281 
-L 71.326625 58.916531 
-Q 71.326625 60.676531 73.086625 60.676531 
+     <path d="M 73.086625 60.296609 
+L 344.19675 60.296609 
+Q 345.95675 60.296609 345.95675 58.536609 
+L 345.95675 33.338359 
+Q 345.95675 31.578359 344.19675 31.578359 
+L 73.086625 31.578359 
+Q 71.326625 31.578359 71.326625 33.338359 
+L 71.326625 58.536609 
+Q 71.326625 60.296609 73.086625 60.296609 
 z
 " style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
     <g id="line2d_201">
-     <path d="M 74.846625 39.084906 
-L 83.646625 39.084906 
-L 92.446625 39.084906 
+     <path d="M 74.846625 38.704984 
+L 83.646625 38.704984 
+L 92.446625 38.704984 
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md663bc701b" x="83.646625" y="39.084906" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#ma1d832450f" x="83.646625" y="38.704984" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_29">
      <!-- state_transition pipeline (incl. SHA-256 hash_tree_root) -->
-     <g transform="translate(99.486625 42.164906) scale(0.088 -0.088)">
+     <g transform="translate(99.486625 41.784984) scale(0.088 -0.088)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
@@ -3163,17 +3193,17 @@ L 92.446625 39.084906
      </g>
     </g>
     <g id="line2d_202">
-     <path d="M 74.846625 52.246406 
-L 83.646625 52.246406 
-L 92.446625 52.246406 
+     <path d="M 74.846625 51.866484 
+L 83.646625 51.866484 
+L 92.446625 51.866484 
 " style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
      <g>
-      <use xlink:href="#m8c8d148425" x="83.646625" y="52.246406" style="fill: #ffffff; stroke: #d62728"/>
+      <use xlink:href="#m3907471811" x="83.646625" y="51.866484" style="fill: #ffffff; stroke: #d62728"/>
      </g>
     </g>
     <g id="text_30">
      <!-- V=1M (mainnet, out-of-spec reference) -->
-     <g transform="translate(99.486625 55.326406) scale(0.088 -0.088)">
+     <g transform="translate(99.486625 54.946484) scale(0.088 -0.088)">
       <use xlink:href="#DejaVuSans-56"/>
       <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
       <use xlink:href="#DejaVuSans-31" transform="translate(152.197266 0)"/>
@@ -3217,7 +3247,7 @@ L 92.446625 52.246406
   </g>
   <g id="text_31">
    <!-- AMD Ryzen 9 PRO 8945HS (Zen 4 mobile, 8C/16T)  ·  Linux 6.18.12+kali-amd64 x86_64  ·  Lean v4.28.0-rc1  ·  Rust release + thin LTO + codegen-units=1  ·  2026-06-26 -->
-   <g style="fill: #666666" transform="translate(7.2 398.469094) scale(0.076 -0.076)">
+   <g style="fill: #666666" transform="translate(7.2 398.809172) scale(0.076 -0.076)">
     <defs>
      <path id="DejaVuSans-79" d="M 2059 -325 
 Q 1816 -950 1584 -1140 
@@ -3501,8 +3531,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pc0eca37085">
-   <rect x="66.926625" y="27.558281" width="582.55" height="315.29875"/>
+  <clipPath id="p4927199f3f">
+   <rect x="66.926625" y="27.178359" width="582.55" height="316.01875"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/bench-htr-results.svg
+++ b/docs/assets/bench-htr-results.svg
@@ -1,0 +1,3189 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="624.563108pt" height="381.189219pt" viewBox="0 0 624.563108 381.189219" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-26T00:53:09.233469</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7+dfsg1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 381.189219 
+L 624.563108 381.189219 
+L 624.563108 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 65.577656 342.857031 
+L 615.869023 342.857031 
+L 615.869023 27.558281 
+L 65.577656 27.558281 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 77.774189 342.857031 
+L 77.774189 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mc21427e8de" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc21427e8de" x="77.774189" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 4 -->
+      <g transform="translate(74.592939 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 129.792696 342.857031 
+L 129.792696 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mc21427e8de" x="129.792696" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 8 -->
+      <g transform="translate(126.611446 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 285.848219 342.857031 
+L 285.848219 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mc21427e8de" x="285.848219" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 64 -->
+      <g transform="translate(279.485719 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 441.903741 342.857031 
+L 441.903741 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mc21427e8de" x="441.903741" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 512 -->
+      <g transform="translate(432.359991 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 597.959264 342.857031 
+L 597.959264 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mc21427e8de" x="597.959264" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4096 -->
+      <g transform="translate(585.234264 357.455469) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 94.520408 342.857031 
+L 94.520408 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="md92ba940fc" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#md92ba940fc" x="94.520408" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 108.203065 342.857031 
+L 108.203065 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#md92ba940fc" x="108.203065" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 119.771587 342.857031 
+L 119.771587 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#md92ba940fc" x="119.771587" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 138.631941 342.857031 
+L 138.631941 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#md92ba940fc" x="138.631941" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 198.557423 342.857031 
+L 198.557423 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#md92ba940fc" x="198.557423" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 228.986299 342.857031 
+L 228.986299 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#md92ba940fc" x="228.986299" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 250.57593 342.857031 
+L 250.57593 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#md92ba940fc" x="250.57593" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 267.322149 342.857031 
+L 267.322149 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#md92ba940fc" x="267.322149" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 281.004807 342.857031 
+L 281.004807 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#md92ba940fc" x="281.004807" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 292.573328 342.857031 
+L 292.573328 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#md92ba940fc" x="292.573328" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 302.594438 342.857031 
+L 302.594438 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#md92ba940fc" x="302.594438" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 311.433683 342.857031 
+L 311.433683 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#md92ba940fc" x="311.433683" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 371.359164 342.857031 
+L 371.359164 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#md92ba940fc" x="371.359164" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 401.788041 342.857031 
+L 401.788041 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#md92ba940fc" x="401.788041" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 423.377672 342.857031 
+L 423.377672 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#md92ba940fc" x="423.377672" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 440.123891 342.857031 
+L 440.123891 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#md92ba940fc" x="440.123891" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 453.806548 342.857031 
+L 453.806548 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#md92ba940fc" x="453.806548" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 465.37507 342.857031 
+L 465.37507 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#md92ba940fc" x="465.37507" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 475.396179 342.857031 
+L 475.396179 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#md92ba940fc" x="475.396179" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 484.235424 342.857031 
+L 484.235424 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#md92ba940fc" x="484.235424" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 544.160906 342.857031 
+L 544.160906 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#md92ba940fc" x="544.160906" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 574.589782 342.857031 
+L 574.589782 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#md92ba940fc" x="574.589782" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 596.179413 342.857031 
+L 596.179413 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#md92ba940fc" x="596.179413" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 612.925632 342.857031 
+L 612.925632 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#md92ba940fc" x="612.925632" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- validator count  V  (≤ leanSpec VALIDATOR_REGISTRY_LIMIT = 2¹² = 4096) -->
+     <g transform="translate(144.429121 371.513516) scale(0.105 -0.105)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2264" d="M 4684 3175 
+L 1684 2309 
+L 4684 1453 
+L 4684 897 
+L 678 2047 
+L 678 2578 
+L 4684 3725 
+L 4684 3175 
+z
+M 678 531 
+L 4684 531 
+L 4684 0 
+L 678 0 
+L 678 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 628 4666 
+L 3578 4666 
+L 3578 4134 
+L 1259 4134 
+L 1259 2753 
+L 3481 2753 
+L 3481 2222 
+L 1259 2222 
+L 1259 531 
+L 3634 531 
+L 3634 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b9" d="M 488 2431 
+L 1125 2431 
+L 1125 4341 
+L 428 4213 
+L 428 4575 
+L 1147 4697 
+L 1575 4697 
+L 1575 2431 
+L 2216 2431 
+L 2216 2088 
+L 488 2088 
+L 488 2431 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b2" d="M 838 2444 
+L 2163 2444 
+L 2163 2088 
+L 294 2088 
+L 294 2431 
+Q 400 2528 597 2703 
+Q 1672 3656 1672 3950 
+Q 1672 4156 1509 4282 
+Q 1347 4409 1081 4409 
+Q 919 4409 728 4354 
+Q 538 4300 313 4191 
+L 313 4575 
+Q 553 4663 761 4706 
+Q 969 4750 1147 4750 
+Q 1600 4750 1872 4544 
+Q 2144 4338 2144 4000 
+Q 2144 3566 1109 2678 
+Q 934 2528 838 2444 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(148.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(176.025391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(239.501953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(300.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(339.990234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(401.171875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(442.285156 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(474.072266 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(529.052734 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(590.234375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(653.613281 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(716.992188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(756.201172 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(787.988281 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(819.775391 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(888.183594 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(919.970703 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(951.757812 0)"/>
+      <use xlink:href="#DejaVuSans-2264" transform="translate(990.771484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1074.560547 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1106.347656 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1134.130859 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1195.654297 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1256.933594 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1320.3125 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1383.789062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1447.265625 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1508.789062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1563.769531 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1595.556641 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1657.589844 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1725.998047 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(1781.710938 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1811.203125 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1886.455078 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(1947.113281 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(2008.197266 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2086.908203 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2156.390625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2206.390625 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(2275.873047 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(2339.056641 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2416.546875 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(2446.039062 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2509.515625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2570.599609 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(2633.707031 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2694.791016 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(2744.791016 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2800.503906 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(2829.996094 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(2916.275391 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(2945.767578 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3006.851562 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3038.638672 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3122.427734 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(3154.214844 0)"/>
+      <use xlink:href="#DejaVuSans-b9" transform="translate(3217.837891 0)"/>
+      <use xlink:href="#DejaVuSans-b2" transform="translate(3257.925781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3298.013672 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(3329.800781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(3413.589844 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(3445.376953 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(3509 0)"/>
+      <use xlink:href="#DejaVuSans-39" transform="translate(3572.623047 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(3636.246094 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(3699.869141 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_59">
+      <path d="M 65.577656 338.937576 
+L 615.869023 338.937576 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <defs>
+       <path id="m57994abb82" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m57994abb82" x="65.577656" y="338.937576" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 10 ns -->
+      <g transform="translate(31.127656 342.736794) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(222.412109 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_61">
+      <path d="M 65.577656 298.493296 
+L 615.869023 298.493296 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m57994abb82" x="65.577656" y="298.493296" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 100 ns -->
+      <g transform="translate(24.765156 302.292515) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(286.035156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_63">
+      <path d="M 65.577656 258.049017 
+L 615.869023 258.049017 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m57994abb82" x="65.577656" y="258.049017" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 1 µs -->
+      <g transform="translate(37.465156 261.848235) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_65">
+      <path d="M 65.577656 217.604737 
+L 615.869023 217.604737 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m57994abb82" x="65.577656" y="217.604737" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 10 µs -->
+      <g transform="translate(31.102656 221.403956) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_67">
+      <path d="M 65.577656 177.160458 
+L 615.869023 177.160458 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m57994abb82" x="65.577656" y="177.160458" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 100 µs -->
+      <g transform="translate(24.740156 180.959677) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_69">
+      <path d="M 65.577656 136.716178 
+L 615.869023 136.716178 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m57994abb82" x="65.577656" y="136.716178" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 1 ms -->
+      <g transform="translate(34.087031 140.515397) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_71">
+      <path d="M 65.577656 96.271899 
+L 615.869023 96.271899 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m57994abb82" x="65.577656" y="96.271899" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 10 ms -->
+      <g transform="translate(27.724531 100.071118) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_73">
+      <path d="M 65.577656 55.827619 
+L 615.869023 55.827619 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m57994abb82" x="65.577656" y="55.827619" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 100 ms -->
+      <g transform="translate(21.362031 59.626838) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_75">
+      <path d="M 65.577656 342.857031 
+L 615.869023 342.857031 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_76">
+      <defs>
+       <path id="m4d245dbd04" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_77">
+      <path d="M 65.577656 340.788204 
+L 615.869023 340.788204 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="340.788204" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_79">
+      <path d="M 65.577656 326.762634 
+L 615.869023 326.762634 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="326.762634" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_81">
+      <path d="M 65.577656 319.64075 
+L 615.869023 319.64075 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="319.64075" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_83">
+      <path d="M 65.577656 314.587693 
+L 615.869023 314.587693 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="314.587693" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_85">
+      <path d="M 65.577656 310.668237 
+L 615.869023 310.668237 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="310.668237" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_87">
+      <path d="M 65.577656 307.465809 
+L 615.869023 307.465809 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="307.465809" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_89">
+      <path d="M 65.577656 304.758194 
+L 615.869023 304.758194 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="304.758194" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_91">
+      <path d="M 65.577656 302.412752 
+L 615.869023 302.412752 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="302.412752" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_93">
+      <path d="M 65.577656 300.343925 
+L 615.869023 300.343925 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="300.343925" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_95">
+      <path d="M 65.577656 286.318355 
+L 615.869023 286.318355 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="286.318355" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_97">
+      <path d="M 65.577656 279.196471 
+L 615.869023 279.196471 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="279.196471" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_99">
+      <path d="M 65.577656 274.143414 
+L 615.869023 274.143414 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="274.143414" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_101">
+      <path d="M 65.577656 270.223958 
+L 615.869023 270.223958 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="270.223958" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_103">
+      <path d="M 65.577656 267.02153 
+L 615.869023 267.02153 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="267.02153" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_105">
+      <path d="M 65.577656 264.313915 
+L 615.869023 264.313915 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="264.313915" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_107">
+      <path d="M 65.577656 261.968472 
+L 615.869023 261.968472 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="261.968472" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_109">
+      <path d="M 65.577656 259.899645 
+L 615.869023 259.899645 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="259.899645" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_111">
+      <path d="M 65.577656 245.874075 
+L 615.869023 245.874075 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="245.874075" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_113">
+      <path d="M 65.577656 238.752191 
+L 615.869023 238.752191 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="238.752191" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_115">
+      <path d="M 65.577656 233.699134 
+L 615.869023 233.699134 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="233.699134" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_117">
+      <path d="M 65.577656 229.779679 
+L 615.869023 229.779679 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="229.779679" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_119">
+      <path d="M 65.577656 226.57725 
+L 615.869023 226.57725 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="226.57725" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_121">
+      <path d="M 65.577656 223.869635 
+L 615.869023 223.869635 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_122">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="223.869635" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_123">
+      <path d="M 65.577656 221.524193 
+L 615.869023 221.524193 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_124">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="221.524193" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_125">
+      <path d="M 65.577656 219.455366 
+L 615.869023 219.455366 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_126">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="219.455366" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_127">
+      <path d="M 65.577656 205.429796 
+L 615.869023 205.429796 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_128">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="205.429796" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_129">
+      <path d="M 65.577656 198.307912 
+L 615.869023 198.307912 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_130">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="198.307912" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_131">
+      <path d="M 65.577656 193.254855 
+L 615.869023 193.254855 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_132">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="193.254855" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_133">
+      <path d="M 65.577656 189.335399 
+L 615.869023 189.335399 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_134">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="189.335399" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_135">
+      <path d="M 65.577656 186.132971 
+L 615.869023 186.132971 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_136">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="186.132971" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_137">
+      <path d="M 65.577656 183.425356 
+L 615.869023 183.425356 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_138">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="183.425356" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_139">
+      <path d="M 65.577656 181.079913 
+L 615.869023 181.079913 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_140">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="181.079913" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_141">
+      <path d="M 65.577656 179.011087 
+L 615.869023 179.011087 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_142">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="179.011087" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_143">
+      <path d="M 65.577656 164.985517 
+L 615.869023 164.985517 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_144">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="164.985517" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_145">
+      <path d="M 65.577656 157.863632 
+L 615.869023 157.863632 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_146">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="157.863632" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_147">
+      <path d="M 65.577656 152.810575 
+L 615.869023 152.810575 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_148">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="152.810575" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_149">
+      <path d="M 65.577656 148.89112 
+L 615.869023 148.89112 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_150">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="148.89112" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_151">
+      <path d="M 65.577656 145.688691 
+L 615.869023 145.688691 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_152">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="145.688691" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_153">
+      <path d="M 65.577656 142.981076 
+L 615.869023 142.981076 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_154">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="142.981076" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_49">
+     <g id="line2d_155">
+      <path d="M 65.577656 140.635634 
+L 615.869023 140.635634 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_156">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="140.635634" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_50">
+     <g id="line2d_157">
+      <path d="M 65.577656 138.566807 
+L 615.869023 138.566807 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_158">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="138.566807" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_159">
+      <path d="M 65.577656 124.541237 
+L 615.869023 124.541237 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_160">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="124.541237" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_161">
+      <path d="M 65.577656 117.419353 
+L 615.869023 117.419353 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_162">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="117.419353" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_163">
+      <path d="M 65.577656 112.366296 
+L 615.869023 112.366296 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_164">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="112.366296" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_165">
+      <path d="M 65.577656 108.44684 
+L 615.869023 108.44684 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_166">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="108.44684" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_55">
+     <g id="line2d_167">
+      <path d="M 65.577656 105.244412 
+L 615.869023 105.244412 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_168">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="105.244412" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_56">
+     <g id="line2d_169">
+      <path d="M 65.577656 102.536797 
+L 615.869023 102.536797 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_170">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="102.536797" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_57">
+     <g id="line2d_171">
+      <path d="M 65.577656 100.191355 
+L 615.869023 100.191355 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_172">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="100.191355" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_58">
+     <g id="line2d_173">
+      <path d="M 65.577656 98.122528 
+L 615.869023 98.122528 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_174">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="98.122528" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_59">
+     <g id="line2d_175">
+      <path d="M 65.577656 84.096958 
+L 615.869023 84.096958 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_176">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="84.096958" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_60">
+     <g id="line2d_177">
+      <path d="M 65.577656 76.975074 
+L 615.869023 76.975074 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_178">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="76.975074" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_61">
+     <g id="line2d_179">
+      <path d="M 65.577656 71.922016 
+L 615.869023 71.922016 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_180">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="71.922016" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_62">
+     <g id="line2d_181">
+      <path d="M 65.577656 68.002561 
+L 615.869023 68.002561 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_182">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="68.002561" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_63">
+     <g id="line2d_183">
+      <path d="M 65.577656 64.800132 
+L 615.869023 64.800132 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_184">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="64.800132" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_64">
+     <g id="line2d_185">
+      <path d="M 65.577656 62.092518 
+L 615.869023 62.092518 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_186">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="62.092518" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_65">
+     <g id="line2d_187">
+      <path d="M 65.577656 59.747075 
+L 615.869023 59.747075 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_188">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="59.747075" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_66">
+     <g id="line2d_189">
+      <path d="M 65.577656 57.678248 
+L 615.869023 57.678248 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_190">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="57.678248" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_67">
+     <g id="line2d_191">
+      <path d="M 65.577656 43.652678 
+L 615.869023 43.652678 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_192">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="43.652678" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_68">
+     <g id="line2d_193">
+      <path d="M 65.577656 36.530794 
+L 615.869023 36.530794 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_194">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="36.530794" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_69">
+     <g id="line2d_195">
+      <path d="M 65.577656 31.477737 
+L 615.869023 31.477737 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_196">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="31.477737" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_70">
+     <g id="line2d_197">
+      <path d="M 65.577656 27.558281 
+L 615.869023 27.558281 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_198">
+      <g>
+       <use xlink:href="#m4d245dbd04" x="65.577656" y="27.558281" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_15">
+     <!-- time per call (log scale) -->
+     <g transform="translate(15.178359 247.113359) rotate(-90) scale(0.105 -0.105)">
+      <defs>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-74"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(39.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(66.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(164.404297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.927734 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(257.714844 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(321.191406 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(382.714844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(423.828125 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(455.615234 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(510.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(571.875 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(599.658203 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(627.441406 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(659.228516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(698.242188 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(726.025391 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(787.207031 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(850.683594 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(882.470703 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(934.570312 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(989.550781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1050.830078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1078.613281 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1140.136719 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_199">
+    <path d="M 65.577656 43.652678 
+L 615.869023 43.652678 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 65.577656 342.857031 
+L 65.577656 27.558281 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 615.869023 342.857031 
+L 615.869023 27.558281 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 65.577656 342.857031 
+L 615.869023 342.857031 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 65.577656 27.558281 
+L 615.869023 27.558281 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_16">
+    <!-- SLO target 200 ms (1 interval) -->
+    <g style="fill: #555555" transform="translate(84.926917 41.197798) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(194.275391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(226.0625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(265.271484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(326.550781 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(365.914062 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(429.390625 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(490.914062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(530.123047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(561.910156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(625.533203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(689.15625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(752.779297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(784.566406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(881.978516 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(934.078125 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(965.865234 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1004.878906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1068.501953 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1100.289062 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1128.072266 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1191.451172 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1230.660156 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1292.183594 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1333.296875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1392.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1453.755859 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1481.539062 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 323 µs -->
+    <g style="fill: #0b3d6e" transform="translate(63.731626 147.577008) scale(0.083 -0.083)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 362 µs -->
+    <g style="fill: #0b3d6e" transform="translate(115.750134 145.573599) scale(0.083 -0.083)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 706 µs -->
+    <g style="fill: #0b3d6e" transform="translate(271.805656 133.843607) scale(0.083 -0.083)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 3.83 ms -->
+    <g style="fill: #0b3d6e" transform="translate(425.140335 104.129124) scale(0.083 -0.083)">
+     <defs>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(254.443359 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 29.06 ms -->
+    <g style="fill: #0b3d6e" transform="translate(578.55542 68.534242) scale(0.083 -0.083)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 502.595439 129.118878 
+Q 549.396994 103.802767 595.116827 79.071786 
+" style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 591.272783 79.195612 
+L 595.116827 79.071786 
+L 592.909461 82.221316 
+" style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
+   </g>
+   <g id="text_22">
+    <!-- V=4096 (leanSpec max) -->
+    <g style="fill: #0b6e0b" transform="translate(408.940769 138.603395) scale(0.086 -0.086)">
+     <defs>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(215.820312 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(279.443359 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(343.066406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(406.689453 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(438.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(477.490234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(505.273438 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(566.796875 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(628.076172 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(691.455078 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(754.931641 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(818.408203 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(879.931641 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(934.912109 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(966.699219 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1064.111328 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(1125.390625 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1184.570312 0)"/>
+    </g>
+    <!-- 29.06 ms — green, -->
+    <g style="fill: #0b6e0b" transform="translate(408.940769 148.233514) scale(0.086 -0.086)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(467.578125 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(499.365234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(599.365234 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(631.152344 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(694.628906 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(733.492188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(795.015625 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(856.539062 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(919.917969 0)"/>
+    </g>
+    <!-- 7× under the 200 ms budget -->
+    <g style="fill: #0b6e0b" transform="translate(408.940769 157.863632) scale(0.086 -0.086)">
+     <defs>
+      <path id="DejaVuSans-d7" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(179.199219 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(242.578125 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(305.957031 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(369.433594 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(430.957031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(472.070312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(503.857422 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(543.066406 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(606.445312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(667.96875 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(699.755859 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(763.378906 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(827.001953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(890.625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(922.412109 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1019.824219 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1071.923828 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1103.710938 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1167.1875 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1230.566406 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1294.042969 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1357.519531 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1419.042969 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- state_transition benchmark — realistic STF (real hash_tree_root, A=8 valid attestations) -->
+    <g transform="translate(98.872012 15.558281) scale(0.11 -0.11)">
+     <defs>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(811.523438 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(875 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(936.523438 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(999.902344 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1054.882812 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1118.261719 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1215.673828 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1276.953125 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(1318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1375.976562 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(1407.763672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1507.763672 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1539.550781 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1578.414062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1639.9375 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1701.216797 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1729 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1756.783203 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1808.882812 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1848.091797 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1875.875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1930.855469 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1962.642578 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(2026.119141 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(2087.203125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2144.722656 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2176.509766 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2215.523438 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2254.386719 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2315.910156 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2377.189453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2404.972656 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2436.759766 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2500.138672 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2561.417969 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2613.517578 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(2676.896484 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2726.896484 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2766.105469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2804.96875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2866.492188 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(2928.015625 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2978.015625 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3016.878906 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3078.060547 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3139.242188 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(3178.451172 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3210.238281 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(3242.025391 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(3310.433594 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(3394.222656 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3457.845703 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(3489.632812 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3548.8125 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3610.091797 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3637.875 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(3665.658203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3729.134766 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3760.921875 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3822.201172 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3861.410156 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3900.619141 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3962.142578 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4014.242188 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(4053.451172 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4114.730469 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(4153.939453 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4181.722656 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4242.904297 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4306.283203 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(4358.382812 0)"/>
+    </g>
+   </g>
+   <g id="line2d_200">
+    <path d="M 77.774189 329.929968 
+L 129.792696 329.309972 
+L 285.848219 309.251503 
+L 441.903741 268.921017 
+L 597.959264 232.306722 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+    <defs>
+     <path id="m095b82ad1b" d="M 0 -3 
+L -3 3 
+L 3 3 
+z
+" style="stroke: #ff7f0e; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#pfaab8aa9fd)">
+     <use xlink:href="#m095b82ad1b" x="77.774189" y="329.929968" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m095b82ad1b" x="129.792696" y="329.309972" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m095b82ad1b" x="285.848219" y="309.251503" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m095b82ad1b" x="441.903741" y="268.921017" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m095b82ad1b" x="597.959264" y="232.306722" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_201">
+    <path d="M 77.774189 156.577008 
+L 129.792696 154.573599 
+L 285.848219 142.843607 
+L 441.903741 113.129124 
+L 597.959264 77.534242 
+" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
+    <defs>
+     <path id="m44972813ad" d="M 0 4 
+C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
+C 3.578535 2.078319 4 1.060812 4 0 
+C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
+C 2.078319 -3.578535 1.060812 -4 0 -4 
+C -1.060812 -4 -2.078319 -3.578535 -2.828427 -2.828427 
+C -3.578535 -2.078319 -4 -1.060812 -4 0 
+C -4 1.060812 -3.578535 2.078319 -2.828427 2.828427 
+C -2.078319 3.578535 -1.060812 4 0 4 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#pfaab8aa9fd)">
+     <use xlink:href="#m44972813ad" x="77.774189" y="156.577008" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m44972813ad" x="129.792696" y="154.573599" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m44972813ad" x="285.848219" y="142.843607" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m44972813ad" x="441.903741" y="113.129124" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m44972813ad" x="597.959264" y="77.534242" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 71.737656 60.676531 
+L 362.316406 60.676531 
+Q 364.076406 60.676531 364.076406 58.916531 
+L 364.076406 33.718281 
+Q 364.076406 31.958281 362.316406 31.958281 
+L 71.737656 31.958281 
+Q 69.977656 31.958281 69.977656 33.718281 
+L 69.977656 58.916531 
+Q 69.977656 60.676531 71.737656 60.676531 
+z
+" style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_202">
+     <path d="M 73.497656 39.084906 
+L 82.297656 39.084906 
+L 91.097656 39.084906 
+" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m44972813ad" x="82.297656" y="39.084906" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- state_transition pipeline (incl. real SHA-256 hash_tree_root) -->
+     <g transform="translate(98.137656 42.164906) scale(0.088 -0.088)">
+      <defs>
+       <path id="DejaVuSans-48" d="M 628 4666 
+L 1259 4666 
+L 1259 2753 
+L 3553 2753 
+L 3553 4666 
+L 4184 4666 
+L 4184 0 
+L 3553 0 
+L 3553 2222 
+L 1259 2222 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(811.523438 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(875 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(902.783203 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(966.259766 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1027.783203 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1055.566406 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1083.349609 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1146.728516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1208.251953 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1240.039062 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1279.052734 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1306.835938 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1370.214844 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1425.195312 0)"/>
+      <use xlink:href="#DejaVuSans-2e" transform="translate(1452.978516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1484.765625 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1516.552734 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1555.416016 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1616.939453 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1678.21875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1706.001953 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1737.789062 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1801.265625 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(1876.460938 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1942.619141 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(1978.703125 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(2042.326172 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(2105.949219 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2169.572266 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(2201.359375 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2264.738281 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2326.017578 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(2378.117188 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2441.496094 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2491.496094 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2530.705078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2569.568359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2631.091797 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(2692.615234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2742.615234 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2781.478516 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2842.660156 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2903.841797 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2943.050781 0)"/>
+     </g>
+    </g>
+    <g id="line2d_203">
+     <path d="M 73.497656 52.246406 
+L 82.297656 52.246406 
+L 91.097656 52.246406 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m095b82ad1b" x="82.297656" y="52.246406" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_25">
+     <!-- Rust→Lean ByteArray marshal (one-way boundary cost) -->
+     <g transform="translate(98.137656 55.326406) scale(0.088 -0.088)">
+      <defs>
+       <path id="DejaVuSans-2192" d="M 5050 2147 
+L 5050 1866 
+L 3822 638 
+L 3447 1013 
+L 4175 1741 
+L 366 1741 
+L 366 2272 
+L 4175 2272 
+L 3447 3000 
+L 3822 3375 
+L 5050 2147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(64.982422 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(128.361328 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(180.460938 0)"/>
+      <use xlink:href="#DejaVuSans-2192" transform="translate(219.669922 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(303.458984 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(357.421875 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(418.945312 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(480.224609 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(543.603516 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(575.390625 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(643.994141 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(703.173828 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(742.382812 0)"/>
+      <use xlink:href="#DejaVuSans-41" transform="translate(803.90625 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(872.314453 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(911.677734 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(952.791016 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(1014.070312 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1073.25 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1105.037109 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1202.449219 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1263.728516 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1304.841797 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1356.941406 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1420.320312 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1481.599609 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1509.382812 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1541.169922 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1580.183594 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1641.365234 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1704.744141 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(1766.267578 0)"/>
+      <use xlink:href="#DejaVuSans-77" transform="translate(1802.351562 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1884.138672 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(1945.417969 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2004.597656 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(2036.384766 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2099.861328 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(2161.042969 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(2224.421875 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(2287.800781 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2351.277344 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2412.556641 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(2453.669922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2512.849609 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(2544.636719 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(2599.617188 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2660.798828 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(2712.898438 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2752.107422 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pfaab8aa9fd">
+   <rect x="65.577656" y="27.558281" width="550.291367" height="315.29875"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/bench-htr-results.svg
+++ b/docs/assets/bench-htr-results.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-26T00:53:09.233469</dc:date>
+    <dc:date>2026-06-26T00:58:45.155613</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 77.774189 342.857031 
 L 77.774189 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mc21427e8de" d="M 0 0 
+       <path id="m61b459e77d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc21427e8de" x="77.774189" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61b459e77d" x="77.774189" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -86,11 +86,11 @@ z
      <g id="line2d_3">
       <path d="M 129.792696 342.857031 
 L 129.792696 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc21427e8de" x="129.792696" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61b459e77d" x="129.792696" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -145,11 +145,11 @@ z
      <g id="line2d_5">
       <path d="M 285.848219 342.857031 
 L 285.848219 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc21427e8de" x="285.848219" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61b459e77d" x="285.848219" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -196,11 +196,11 @@ z
      <g id="line2d_7">
       <path d="M 441.903741 342.857031 
 L 441.903741 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc21427e8de" x="441.903741" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61b459e77d" x="441.903741" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -281,11 +281,11 @@ z
      <g id="line2d_9">
       <path d="M 597.959264 342.857031 
 L 597.959264 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc21427e8de" x="597.959264" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61b459e77d" x="597.959264" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -355,16 +355,16 @@ z
      <g id="line2d_11">
       <path d="M 94.520408 342.857031 
 L 94.520408 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_12">
       <defs>
-       <path id="md92ba940fc" d="M 0 0 
+       <path id="mda7365c716" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#md92ba940fc" x="94.520408" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="94.520408" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -372,11 +372,11 @@ L 0 2
      <g id="line2d_13">
       <path d="M 108.203065 342.857031 
 L 108.203065 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md92ba940fc" x="108.203065" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="108.203065" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -384,11 +384,11 @@ L 108.203065 27.558281
      <g id="line2d_15">
       <path d="M 119.771587 342.857031 
 L 119.771587 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md92ba940fc" x="119.771587" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="119.771587" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -396,11 +396,11 @@ L 119.771587 27.558281
      <g id="line2d_17">
       <path d="M 138.631941 342.857031 
 L 138.631941 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md92ba940fc" x="138.631941" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="138.631941" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -408,11 +408,11 @@ L 138.631941 27.558281
      <g id="line2d_19">
       <path d="M 198.557423 342.857031 
 L 198.557423 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md92ba940fc" x="198.557423" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="198.557423" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -420,11 +420,11 @@ L 198.557423 27.558281
      <g id="line2d_21">
       <path d="M 228.986299 342.857031 
 L 228.986299 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md92ba940fc" x="228.986299" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="228.986299" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -432,11 +432,11 @@ L 228.986299 27.558281
      <g id="line2d_23">
       <path d="M 250.57593 342.857031 
 L 250.57593 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md92ba940fc" x="250.57593" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="250.57593" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -444,11 +444,11 @@ L 250.57593 27.558281
      <g id="line2d_25">
       <path d="M 267.322149 342.857031 
 L 267.322149 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md92ba940fc" x="267.322149" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="267.322149" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -456,11 +456,11 @@ L 267.322149 27.558281
      <g id="line2d_27">
       <path d="M 281.004807 342.857031 
 L 281.004807 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#md92ba940fc" x="281.004807" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="281.004807" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -468,11 +468,11 @@ L 281.004807 27.558281
      <g id="line2d_29">
       <path d="M 292.573328 342.857031 
 L 292.573328 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#md92ba940fc" x="292.573328" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="292.573328" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -480,11 +480,11 @@ L 292.573328 27.558281
      <g id="line2d_31">
       <path d="M 302.594438 342.857031 
 L 302.594438 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#md92ba940fc" x="302.594438" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="302.594438" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -492,11 +492,11 @@ L 302.594438 27.558281
      <g id="line2d_33">
       <path d="M 311.433683 342.857031 
 L 311.433683 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#md92ba940fc" x="311.433683" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="311.433683" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -504,11 +504,11 @@ L 311.433683 27.558281
      <g id="line2d_35">
       <path d="M 371.359164 342.857031 
 L 371.359164 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#md92ba940fc" x="371.359164" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="371.359164" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -516,11 +516,11 @@ L 371.359164 27.558281
      <g id="line2d_37">
       <path d="M 401.788041 342.857031 
 L 401.788041 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#md92ba940fc" x="401.788041" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="401.788041" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -528,11 +528,11 @@ L 401.788041 27.558281
      <g id="line2d_39">
       <path d="M 423.377672 342.857031 
 L 423.377672 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#md92ba940fc" x="423.377672" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="423.377672" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -540,11 +540,11 @@ L 423.377672 27.558281
      <g id="line2d_41">
       <path d="M 440.123891 342.857031 
 L 440.123891 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#md92ba940fc" x="440.123891" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="440.123891" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -552,11 +552,11 @@ L 440.123891 27.558281
      <g id="line2d_43">
       <path d="M 453.806548 342.857031 
 L 453.806548 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#md92ba940fc" x="453.806548" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="453.806548" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -564,11 +564,11 @@ L 453.806548 27.558281
      <g id="line2d_45">
       <path d="M 465.37507 342.857031 
 L 465.37507 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#md92ba940fc" x="465.37507" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="465.37507" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -576,11 +576,11 @@ L 465.37507 27.558281
      <g id="line2d_47">
       <path d="M 475.396179 342.857031 
 L 475.396179 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#md92ba940fc" x="475.396179" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="475.396179" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -588,11 +588,11 @@ L 475.396179 27.558281
      <g id="line2d_49">
       <path d="M 484.235424 342.857031 
 L 484.235424 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#md92ba940fc" x="484.235424" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="484.235424" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -600,11 +600,11 @@ L 484.235424 27.558281
      <g id="line2d_51">
       <path d="M 544.160906 342.857031 
 L 544.160906 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#md92ba940fc" x="544.160906" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="544.160906" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -612,11 +612,11 @@ L 544.160906 27.558281
      <g id="line2d_53">
       <path d="M 574.589782 342.857031 
 L 574.589782 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#md92ba940fc" x="574.589782" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="574.589782" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -624,11 +624,11 @@ L 574.589782 27.558281
      <g id="line2d_55">
       <path d="M 596.179413 342.857031 
 L 596.179413 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#md92ba940fc" x="596.179413" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="596.179413" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -636,11 +636,11 @@ L 596.179413 27.558281
      <g id="line2d_57">
       <path d="M 612.925632 342.857031 
 L 612.925632 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#md92ba940fc" x="612.925632" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mda7365c716" x="612.925632" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1303,24 +1303,84 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_59">
-      <path d="M 65.577656 338.937576 
-L 615.869023 338.937576 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 65.577656 315.152639 
+L 615.869023 315.152639 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <defs>
-       <path id="m57994abb82" d="M 0 0 
+       <path id="mb25f9954e2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m57994abb82" x="65.577656" y="338.937576" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb25f9954e2" x="65.577656" y="315.152639" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
-      <!-- 10 ns -->
-      <g transform="translate(31.127656 342.736794) scale(0.1 -0.1)">
+      <!-- 300 µs -->
+      <g transform="translate(24.740156 318.951858) scale(0.1 -0.1)">
        <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
 Q 2591 2978 2328 3040 
@@ -1353,125 +1413,7 @@ Q 2597 3491 2834 3397
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(159.033203 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(222.412109 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_2">
-     <g id="line2d_61">
-      <path d="M 65.577656 298.493296 
-L 615.869023 298.493296 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_62">
-      <g>
-       <use xlink:href="#m57994abb82" x="65.577656" y="298.493296" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <!-- 100 ns -->
-      <g transform="translate(24.765156 302.292515) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(222.65625 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(286.035156 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_3">
-     <g id="line2d_63">
-      <path d="M 65.577656 258.049017 
-L 615.869023 258.049017 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_64">
-      <g>
-       <use xlink:href="#m57994abb82" x="65.577656" y="258.049017" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_9">
-      <!-- 1 µs -->
-      <g transform="translate(37.465156 261.848235) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-b5" d="M 544 -1331 
-L 544 3500 
-L 1119 3500 
-L 1119 1325 
-Q 1119 872 1334 640 
-Q 1550 409 1972 409 
-Q 2434 409 2667 671 
-Q 2900 934 2900 1459 
-L 2900 3500 
-L 3475 3500 
-L 3475 806 
-Q 3475 619 3529 530 
-Q 3584 441 3700 441 
-Q 3728 441 3778 458 
-Q 3828 475 3916 513 
-L 3916 50 
-Q 3788 -22 3673 -56 
-Q 3559 -91 3450 -91 
-Q 3234 -91 3106 31 
-Q 2978 153 2931 403 
-Q 2775 156 2548 32 
-Q 2322 -91 2016 -91 
-Q 1697 -91 1473 31 
-Q 1250 153 1119 397 
-L 1119 -1331 
-L 544 -1331 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-b5" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(159.033203 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_65">
-      <path d="M 65.577656 217.604737 
-L 615.869023 217.604737 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_66">
-      <g>
-       <use xlink:href="#m57994abb82" x="65.577656" y="217.604737" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_10">
-      <!-- 10 µs -->
-      <g transform="translate(31.102656 221.403956) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
-       <use xlink:href="#DejaVuSans-b5" transform="translate(159.033203 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_67">
-      <path d="M 65.577656 177.160458 
-L 615.869023 177.160458 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_68">
-      <g>
-       <use xlink:href="#m57994abb82" x="65.577656" y="177.160458" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_11">
-      <!-- 100 µs -->
-      <g transform="translate(24.740156 180.959677) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
@@ -1480,20 +1422,20 @@ L 615.869023 177.160458
       </g>
      </g>
     </g>
-    <g id="ytick_6">
-     <g id="line2d_69">
-      <path d="M 65.577656 136.716178 
-L 615.869023 136.716178 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+    <g id="ytick_2">
+     <g id="line2d_61">
+      <path d="M 65.577656 267.031063 
+L 615.869023 267.031063 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_70">
+     <g id="line2d_62">
       <g>
-       <use xlink:href="#m57994abb82" x="65.577656" y="136.716178" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb25f9954e2" x="65.577656" y="267.031063" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_12">
+     <g id="text_8">
       <!-- 1 ms -->
-      <g transform="translate(34.087031 140.515397) scale(0.1 -0.1)">
+      <g transform="translate(34.087031 270.830282) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1533,20 +1475,41 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_7">
-     <g id="line2d_71">
-      <path d="M 65.577656 96.271899 
-L 615.869023 96.271899 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+    <g id="ytick_3">
+     <g id="line2d_63">
+      <path d="M 65.577656 223.12064 
+L 615.869023 223.12064 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_72">
+     <g id="line2d_64">
       <g>
-       <use xlink:href="#m57994abb82" x="65.577656" y="96.271899" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb25f9954e2" x="65.577656" y="223.12064" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_13">
+     <g id="text_9">
+      <!-- 3 ms -->
+      <g transform="translate(34.087031 226.919859) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(192.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_65">
+      <path d="M 65.577656 174.999064 
+L 615.869023 174.999064 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#mb25f9954e2" x="65.577656" y="174.999064" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
       <!-- 10 ms -->
-      <g transform="translate(27.724531 100.071118) scale(0.1 -0.1)">
+      <g transform="translate(27.724531 178.798283) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -1555,20 +1518,42 @@ L 615.869023 96.271899
       </g>
      </g>
     </g>
-    <g id="ytick_8">
-     <g id="line2d_73">
-      <path d="M 65.577656 55.827619 
-L 615.869023 55.827619 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+    <g id="ytick_5">
+     <g id="line2d_67">
+      <path d="M 65.577656 131.088642 
+L 615.869023 131.088642 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_74">
+     <g id="line2d_68">
       <g>
-       <use xlink:href="#m57994abb82" x="65.577656" y="55.827619" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb25f9954e2" x="65.577656" y="131.088642" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_14">
+     <g id="text_11">
+      <!-- 30 ms -->
+      <g transform="translate(27.724531 134.88786) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(256.445312 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_69">
+      <path d="M 65.577656 82.967066 
+L 615.869023 82.967066 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#mb25f9954e2" x="65.577656" y="82.967066" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
       <!-- 100 ms -->
-      <g transform="translate(21.362031 59.626838) scale(0.1 -0.1)">
+      <g transform="translate(21.362031 86.766284) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1578,756 +1563,311 @@ L 615.869023 55.827619
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_75">
-      <path d="M 65.577656 342.857031 
-L 615.869023 342.857031 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+    <g id="ytick_7">
+     <g id="line2d_71">
+      <path d="M 65.577656 39.056643 
+L 615.869023 39.056643 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_76">
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#mb25f9954e2" x="65.577656" y="39.056643" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 300 ms -->
+      <g transform="translate(21.362031 42.855862) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_73">
+      <path d="M 65.577656 331.35867 
+L 615.869023 331.35867 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_74">
       <defs>
-       <path id="m4d245dbd04" d="M 0 0 
+       <path id="medb7f47c58" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="331.35867" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_75">
+      <path d="M 65.577656 303.654277 
+L 615.869023 303.654277 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="303.654277" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_77">
-      <path d="M 65.577656 340.788204 
-L 615.869023 340.788204 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 294.735455 
+L 615.869023 294.735455 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="340.788204" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="294.735455" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_79">
-      <path d="M 65.577656 326.762634 
-L 615.869023 326.762634 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 287.448247 
+L 615.869023 287.448247 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="326.762634" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="287.448247" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_81">
-      <path d="M 65.577656 319.64075 
-L 615.869023 319.64075 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 281.287 
+L 615.869023 281.287 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="319.64075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="281.287" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_83">
-      <path d="M 65.577656 314.587693 
-L 615.869023 314.587693 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 275.949885 
+L 615.869023 275.949885 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="314.587693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="275.949885" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_85">
-      <path d="M 65.577656 310.668237 
-L 615.869023 310.668237 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 271.242216 
+L 615.869023 271.242216 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="310.668237" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="271.242216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_87">
-      <path d="M 65.577656 307.465809 
-L 615.869023 307.465809 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 239.326671 
+L 615.869023 239.326671 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="307.465809" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="239.326671" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_89">
-      <path d="M 65.577656 304.758194 
-L 615.869023 304.758194 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 211.622279 
+L 615.869023 211.622279 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="304.758194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="211.622279" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_91">
-      <path d="M 65.577656 302.412752 
-L 615.869023 302.412752 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 202.703457 
+L 615.869023 202.703457 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="302.412752" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="202.703457" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_93">
-      <path d="M 65.577656 300.343925 
-L 615.869023 300.343925 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 195.416248 
+L 615.869023 195.416248 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="300.343925" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="195.416248" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_95">
-      <path d="M 65.577656 286.318355 
-L 615.869023 286.318355 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 189.255001 
+L 615.869023 189.255001 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="286.318355" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="189.255001" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_97">
-      <path d="M 65.577656 279.196471 
-L 615.869023 279.196471 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 183.917887 
+L 615.869023 183.917887 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="279.196471" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="183.917887" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_99">
-      <path d="M 65.577656 274.143414 
-L 615.869023 274.143414 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 179.210218 
+L 615.869023 179.210218 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="274.143414" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="179.210218" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_101">
-      <path d="M 65.577656 270.223958 
-L 615.869023 270.223958 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 147.294672 
+L 615.869023 147.294672 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="270.223958" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="147.294672" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_103">
-      <path d="M 65.577656 267.02153 
-L 615.869023 267.02153 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 119.59028 
+L 615.869023 119.59028 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="267.02153" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="119.59028" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_105">
-      <path d="M 65.577656 264.313915 
-L 615.869023 264.313915 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 110.671458 
+L 615.869023 110.671458 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="264.313915" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="110.671458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_107">
-      <path d="M 65.577656 261.968472 
-L 615.869023 261.968472 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 103.384249 
+L 615.869023 103.384249 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_108">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="261.968472" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="103.384249" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_109">
-      <path d="M 65.577656 259.899645 
-L 615.869023 259.899645 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 97.223003 
+L 615.869023 97.223003 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_110">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="259.899645" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="97.223003" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_111">
-      <path d="M 65.577656 245.874075 
-L 615.869023 245.874075 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 91.885888 
+L 615.869023 91.885888 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_112">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="245.874075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="91.885888" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_113">
-      <path d="M 65.577656 238.752191 
-L 615.869023 238.752191 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 87.178219 
+L 615.869023 87.178219 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_114">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="238.752191" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="87.178219" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_115">
-      <path d="M 65.577656 233.699134 
-L 615.869023 233.699134 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 55.262673 
+L 615.869023 55.262673 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_116">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="233.699134" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="55.262673" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_117">
-      <path d="M 65.577656 229.779679 
-L 615.869023 229.779679 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 65.577656 27.558281 
+L 615.869023 27.558281 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_118">
       <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="229.779679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#medb7f47c58" x="65.577656" y="27.558281" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="ytick_31">
-     <g id="line2d_119">
-      <path d="M 65.577656 226.57725 
-L 615.869023 226.57725 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_120">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="226.57725" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_32">
-     <g id="line2d_121">
-      <path d="M 65.577656 223.869635 
-L 615.869023 223.869635 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_122">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="223.869635" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_33">
-     <g id="line2d_123">
-      <path d="M 65.577656 221.524193 
-L 615.869023 221.524193 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_124">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="221.524193" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_34">
-     <g id="line2d_125">
-      <path d="M 65.577656 219.455366 
-L 615.869023 219.455366 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_126">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="219.455366" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_35">
-     <g id="line2d_127">
-      <path d="M 65.577656 205.429796 
-L 615.869023 205.429796 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_128">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="205.429796" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_36">
-     <g id="line2d_129">
-      <path d="M 65.577656 198.307912 
-L 615.869023 198.307912 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_130">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="198.307912" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_37">
-     <g id="line2d_131">
-      <path d="M 65.577656 193.254855 
-L 615.869023 193.254855 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_132">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="193.254855" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_38">
-     <g id="line2d_133">
-      <path d="M 65.577656 189.335399 
-L 615.869023 189.335399 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_134">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="189.335399" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_39">
-     <g id="line2d_135">
-      <path d="M 65.577656 186.132971 
-L 615.869023 186.132971 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_136">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="186.132971" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_40">
-     <g id="line2d_137">
-      <path d="M 65.577656 183.425356 
-L 615.869023 183.425356 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_138">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="183.425356" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_41">
-     <g id="line2d_139">
-      <path d="M 65.577656 181.079913 
-L 615.869023 181.079913 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_140">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="181.079913" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_42">
-     <g id="line2d_141">
-      <path d="M 65.577656 179.011087 
-L 615.869023 179.011087 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_142">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="179.011087" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_43">
-     <g id="line2d_143">
-      <path d="M 65.577656 164.985517 
-L 615.869023 164.985517 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_144">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="164.985517" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_44">
-     <g id="line2d_145">
-      <path d="M 65.577656 157.863632 
-L 615.869023 157.863632 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_146">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="157.863632" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_45">
-     <g id="line2d_147">
-      <path d="M 65.577656 152.810575 
-L 615.869023 152.810575 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_148">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="152.810575" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_46">
-     <g id="line2d_149">
-      <path d="M 65.577656 148.89112 
-L 615.869023 148.89112 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_150">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="148.89112" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_47">
-     <g id="line2d_151">
-      <path d="M 65.577656 145.688691 
-L 615.869023 145.688691 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_152">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="145.688691" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_48">
-     <g id="line2d_153">
-      <path d="M 65.577656 142.981076 
-L 615.869023 142.981076 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_154">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="142.981076" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_49">
-     <g id="line2d_155">
-      <path d="M 65.577656 140.635634 
-L 615.869023 140.635634 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_156">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="140.635634" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_50">
-     <g id="line2d_157">
-      <path d="M 65.577656 138.566807 
-L 615.869023 138.566807 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_158">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="138.566807" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_51">
-     <g id="line2d_159">
-      <path d="M 65.577656 124.541237 
-L 615.869023 124.541237 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_160">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="124.541237" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_52">
-     <g id="line2d_161">
-      <path d="M 65.577656 117.419353 
-L 615.869023 117.419353 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_162">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="117.419353" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_53">
-     <g id="line2d_163">
-      <path d="M 65.577656 112.366296 
-L 615.869023 112.366296 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_164">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="112.366296" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_54">
-     <g id="line2d_165">
-      <path d="M 65.577656 108.44684 
-L 615.869023 108.44684 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_166">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="108.44684" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_55">
-     <g id="line2d_167">
-      <path d="M 65.577656 105.244412 
-L 615.869023 105.244412 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_168">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="105.244412" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_56">
-     <g id="line2d_169">
-      <path d="M 65.577656 102.536797 
-L 615.869023 102.536797 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_170">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="102.536797" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_57">
-     <g id="line2d_171">
-      <path d="M 65.577656 100.191355 
-L 615.869023 100.191355 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_172">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="100.191355" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_58">
-     <g id="line2d_173">
-      <path d="M 65.577656 98.122528 
-L 615.869023 98.122528 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_174">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="98.122528" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_59">
-     <g id="line2d_175">
-      <path d="M 65.577656 84.096958 
-L 615.869023 84.096958 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_176">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="84.096958" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_60">
-     <g id="line2d_177">
-      <path d="M 65.577656 76.975074 
-L 615.869023 76.975074 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_178">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="76.975074" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_61">
-     <g id="line2d_179">
-      <path d="M 65.577656 71.922016 
-L 615.869023 71.922016 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_180">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="71.922016" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_62">
-     <g id="line2d_181">
-      <path d="M 65.577656 68.002561 
-L 615.869023 68.002561 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_182">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="68.002561" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_63">
-     <g id="line2d_183">
-      <path d="M 65.577656 64.800132 
-L 615.869023 64.800132 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_184">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="64.800132" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_64">
-     <g id="line2d_185">
-      <path d="M 65.577656 62.092518 
-L 615.869023 62.092518 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_186">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="62.092518" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_65">
-     <g id="line2d_187">
-      <path d="M 65.577656 59.747075 
-L 615.869023 59.747075 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_188">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="59.747075" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_66">
-     <g id="line2d_189">
-      <path d="M 65.577656 57.678248 
-L 615.869023 57.678248 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_190">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="57.678248" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_67">
-     <g id="line2d_191">
-      <path d="M 65.577656 43.652678 
-L 615.869023 43.652678 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_192">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="43.652678" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_68">
-     <g id="line2d_193">
-      <path d="M 65.577656 36.530794 
-L 615.869023 36.530794 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_194">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="36.530794" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_69">
-     <g id="line2d_195">
-      <path d="M 65.577656 31.477737 
-L 615.869023 31.477737 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_196">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="31.477737" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_70">
-     <g id="line2d_197">
-      <path d="M 65.577656 27.558281 
-L 615.869023 27.558281 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
-     </g>
-     <g id="line2d_198">
-      <g>
-       <use xlink:href="#m4d245dbd04" x="65.577656" y="27.558281" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_15">
+    <g id="text_14">
      <!-- time per call (log scale) -->
      <g transform="translate(15.178359 247.113359) rotate(-90) scale(0.105 -0.105)">
       <defs>
@@ -2394,10 +1934,10 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_199">
-    <path d="M 65.577656 43.652678 
-L 615.869023 43.652678 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
+   <g id="line2d_119">
+    <path d="M 65.577656 55.262673 
+L 615.869023 55.262673 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
    </g>
    <g id="patch_3">
     <path d="M 65.577656 342.857031 
@@ -2419,9 +1959,9 @@ L 615.869023 342.857031
 L 615.869023 27.558281 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_16">
+   <g id="text_15">
     <!-- SLO target 200 ms (1 interval) -->
-    <g style="fill: #555555" transform="translate(84.926917 41.197798) scale(0.085 -0.085)">
+    <g style="fill: #555555" transform="translate(474.085657 49.67653) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-53"/>
      <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
      <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
@@ -2454,43 +1994,9 @@ L 615.869023 27.558281
      <use xlink:href="#DejaVuSans-29" transform="translate(1481.539062 0)"/>
     </g>
    </g>
-   <g id="text_17">
+   <g id="text_16">
     <!-- 323 µs -->
-    <g style="fill: #0b3d6e" transform="translate(63.731626 147.577008) scale(0.083 -0.083)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g style="fill: #0b3d6e" transform="translate(63.731626 303.224892) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -2499,9 +2005,9 @@ z
      <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
     </g>
    </g>
-   <g id="text_18">
+   <g id="text_17">
     <!-- 362 µs -->
-    <g style="fill: #0b3d6e" transform="translate(115.750134 145.573599) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(115.750134 298.666084) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -2510,9 +2016,9 @@ z
      <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
     </g>
    </g>
-   <g id="text_19">
+   <g id="text_18">
     <!-- 706 µs -->
-    <g style="fill: #0b3d6e" transform="translate(271.805656 133.843607) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(271.805656 271.974185) scale(0.083 -0.083)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -2533,9 +2039,9 @@ z
      <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
     </g>
    </g>
-   <g id="text_20">
+   <g id="text_19">
     <!-- 3.83 ms -->
-    <g style="fill: #0b3d6e" transform="translate(425.140335 104.129124) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(425.140335 204.358114) scale(0.083 -0.083)">
      <defs>
       <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -2554,9 +2060,9 @@ z
      <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
     </g>
    </g>
-   <g id="text_21">
+   <g id="text_20">
     <!-- 29.06 ms -->
-    <g style="fill: #0b3d6e" transform="translate(578.55542 68.534242) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(578.55542 123.361043) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
@@ -2568,17 +2074,17 @@ z
     </g>
    </g>
    <g id="patch_7">
-    <path d="M 502.595439 129.118878 
-Q 549.396994 103.802767 595.116827 79.071786 
+    <path d="M 435.478303 252.302529 
+Q 515.914263 192.925674 595.360771 134.27922 
 " style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
-    <path d="M 591.272783 79.195612 
-L 595.116827 79.071786 
-L 592.909461 82.221316 
+    <path d="M 591.57165 134.938431 
+L 595.360771 134.27922 
+L 593.614668 137.706044 
 " style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
    </g>
-   <g id="text_22">
+   <g id="text_21">
     <!-- V=4096 (leanSpec max) -->
-    <g style="fill: #0b6e0b" transform="translate(408.940769 138.603395) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(349.769533 262.026763) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -2619,7 +2125,7 @@ z
      <use xlink:href="#DejaVuSans-29" transform="translate(1184.570312 0)"/>
     </g>
     <!-- 29.06 ms — green, -->
-    <g style="fill: #0b6e0b" transform="translate(408.940769 148.233514) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(349.769533 271.656881) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2657,7 +2163,7 @@ z
      <use xlink:href="#DejaVuSans-2c" transform="translate(919.917969 0)"/>
     </g>
     <!-- 7× under the 200 ms budget -->
-    <g style="fill: #0b6e0b" transform="translate(408.940769 157.863632) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(349.769533 281.287) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-d7" d="M 4488 3438 
 L 3059 2003 
@@ -2748,7 +2254,7 @@ z
      <use xlink:href="#DejaVuSans-74" transform="translate(1419.042969 0)"/>
     </g>
    </g>
-   <g id="text_23">
+   <g id="text_22">
     <!-- state_transition benchmark — realistic STF (real hash_tree_root, A=8 valid attestations) -->
     <g transform="translate(98.872012 15.558281) scale(0.11 -0.11)">
      <defs>
@@ -2870,37 +2376,15 @@ z
      <use xlink:href="#DejaVuSans-29" transform="translate(4358.382812 0)"/>
     </g>
    </g>
-   <g id="line2d_200">
-    <path d="M 77.774189 329.929968 
-L 129.792696 329.309972 
-L 285.848219 309.251503 
-L 441.903741 268.921017 
-L 597.959264 232.306722 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+   <g id="line2d_120">
+    <path d="M 77.774189 312.224892 
+L 129.792696 307.666084 
+L 285.848219 280.974185 
+L 441.903741 213.358114 
+L 597.959264 132.361043 
+" clip-path="url(#pca2a7c435e)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
     <defs>
-     <path id="m095b82ad1b" d="M 0 -3 
-L -3 3 
-L 3 3 
-z
-" style="stroke: #ff7f0e; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#pfaab8aa9fd)">
-     <use xlink:href="#m095b82ad1b" x="77.774189" y="329.929968" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#m095b82ad1b" x="129.792696" y="329.309972" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#m095b82ad1b" x="285.848219" y="309.251503" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#m095b82ad1b" x="441.903741" y="268.921017" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#m095b82ad1b" x="597.959264" y="232.306722" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_201">
-    <path d="M 77.774189 156.577008 
-L 129.792696 154.573599 
-L 285.848219 142.843607 
-L 441.903741 113.129124 
-L 597.959264 77.534242 
-" clip-path="url(#pfaab8aa9fd)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
-    <defs>
-     <path id="m44972813ad" d="M 0 4 
+     <path id="mb6950196d0" d="M 0 4 
 C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
 C 3.578535 2.078319 4 1.060812 4 0 
 C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
@@ -2912,38 +2396,38 @@ C -2.078319 3.578535 -1.060812 4 0 4
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pfaab8aa9fd)">
-     <use xlink:href="#m44972813ad" x="77.774189" y="156.577008" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m44972813ad" x="129.792696" y="154.573599" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m44972813ad" x="285.848219" y="142.843607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m44972813ad" x="441.903741" y="113.129124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m44972813ad" x="597.959264" y="77.534242" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pca2a7c435e)">
+     <use xlink:href="#mb6950196d0" x="77.774189" y="312.224892" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mb6950196d0" x="129.792696" y="307.666084" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mb6950196d0" x="285.848219" y="280.974185" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mb6950196d0" x="441.903741" y="213.358114" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mb6950196d0" x="597.959264" y="132.361043" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_8">
-     <path d="M 71.737656 60.676531 
-L 362.316406 60.676531 
-Q 364.076406 60.676531 364.076406 58.916531 
+     <path d="M 71.737656 47.759781 
+L 362.316406 47.759781 
+Q 364.076406 47.759781 364.076406 45.999781 
 L 364.076406 33.718281 
 Q 364.076406 31.958281 362.316406 31.958281 
 L 71.737656 31.958281 
 Q 69.977656 31.958281 69.977656 33.718281 
-L 69.977656 58.916531 
-Q 69.977656 60.676531 71.737656 60.676531 
+L 69.977656 45.999781 
+Q 69.977656 47.759781 71.737656 47.759781 
 z
 " style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_202">
+    <g id="line2d_121">
      <path d="M 73.497656 39.084906 
 L 82.297656 39.084906 
 L 91.097656 39.084906 
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m44972813ad" x="82.297656" y="39.084906" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#mb6950196d0" x="82.297656" y="39.084906" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
-    <g id="text_24">
+    <g id="text_23">
      <!-- state_transition pipeline (incl. real SHA-256 hash_tree_root) -->
      <g transform="translate(98.137656 42.164906) scale(0.088 -0.088)">
       <defs>
@@ -3033,156 +2517,11 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(2943.050781 0)"/>
      </g>
     </g>
-    <g id="line2d_203">
-     <path d="M 73.497656 52.246406 
-L 82.297656 52.246406 
-L 91.097656 52.246406 
-" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m095b82ad1b" x="82.297656" y="52.246406" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_25">
-     <!-- Rust→Lean ByteArray marshal (one-way boundary cost) -->
-     <g transform="translate(98.137656 55.326406) scale(0.088 -0.088)">
-      <defs>
-       <path id="DejaVuSans-2192" d="M 5050 2147 
-L 5050 1866 
-L 3822 638 
-L 3447 1013 
-L 4175 1741 
-L 366 1741 
-L 366 2272 
-L 4175 2272 
-L 3447 3000 
-L 3822 3375 
-L 5050 2147 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
-z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-79" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-77" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-52"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(64.982422 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(128.361328 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(180.460938 0)"/>
-      <use xlink:href="#DejaVuSans-2192" transform="translate(219.669922 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(303.458984 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(357.421875 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(418.945312 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(480.224609 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(543.603516 0)"/>
-      <use xlink:href="#DejaVuSans-42" transform="translate(575.390625 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(643.994141 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(703.173828 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(742.382812 0)"/>
-      <use xlink:href="#DejaVuSans-41" transform="translate(803.90625 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(872.314453 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(911.677734 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(952.791016 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(1014.070312 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1073.25 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(1105.037109 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1202.449219 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(1263.728516 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1304.841797 0)"/>
-      <use xlink:href="#DejaVuSans-68" transform="translate(1356.941406 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1420.320312 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(1481.599609 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1509.382812 0)"/>
-      <use xlink:href="#DejaVuSans-28" transform="translate(1541.169922 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(1580.183594 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(1641.365234 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1704.744141 0)"/>
-      <use xlink:href="#DejaVuSans-2d" transform="translate(1766.267578 0)"/>
-      <use xlink:href="#DejaVuSans-77" transform="translate(1802.351562 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1884.138672 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(1945.417969 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(2004.597656 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(2036.384766 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(2099.861328 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(2161.042969 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(2224.421875 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(2287.800781 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(2351.277344 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(2412.556641 0)"/>
-      <use xlink:href="#DejaVuSans-79" transform="translate(2453.669922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(2512.849609 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(2544.636719 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(2599.617188 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(2660.798828 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(2712.898438 0)"/>
-      <use xlink:href="#DejaVuSans-29" transform="translate(2752.107422 0)"/>
-     </g>
-    </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfaab8aa9fd">
+  <clipPath id="pca2a7c435e">
    <rect x="65.577656" y="27.558281" width="550.291367" height="315.29875"/>
   </clipPath>
  </defs>

--- a/docs/assets/bench-htr-results.svg
+++ b/docs/assets/bench-htr-results.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="655.327656pt" height="381.189219pt" viewBox="0 0 655.327656 381.189219" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="658.15325pt" height="407.461031pt" viewBox="0 0 658.15325 407.461031" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-26T01:06:13.908992</dc:date>
+    <dc:date>2026-06-26T01:09:03.579063</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,55 +21,55 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 381.189219 
-L 655.327656 381.189219 
-L 655.327656 0 
+   <path d="M 0 407.461031 
+L 658.15325 407.461031 
+L 658.15325 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 65.577656 342.857031 
-L 648.127656 342.857031 
-L 648.127656 27.558281 
-L 65.577656 27.558281 
+    <path d="M 66.926625 342.857031 
+L 649.476625 342.857031 
+L 649.476625 27.558281 
+L 66.926625 27.558281 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 380.506011 342.857031 
-L 645.436306 342.857031 
-L 645.436306 27.558281 
-L 380.506011 27.558281 
+    <path d="M 381.854979 342.857031 
+L 646.785275 342.857031 
+L 646.785275 27.558281 
+L 381.854979 27.558281 
 z
-" clip-path="url(#p289f9afc26)" style="fill: #d62728; opacity: 0.06; stroke: #d62728; stroke-linejoin: miter"/>
+" clip-path="url(#pc0eca37085)" style="fill: #d62728; opacity: 0.06; stroke: #d62728; stroke-linejoin: miter"/>
    </g>
    <g id="line2d_1">
-    <path d="M 380.506011 342.857031 
-L 380.506011 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
+    <path d="M 381.854979 342.857031 
+L 381.854979 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_2">
-      <path d="M 72.79247 342.857031 
-L 72.79247 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 74.141438 342.857031 
+L 74.141438 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_3">
       <defs>
-       <path id="m53e1c9a5e6" d="M 0 0 
+       <path id="mb391ed1507" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m53e1c9a5e6" x="72.79247" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb391ed1507" x="74.141438" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 4 -->
-      <g transform="translate(69.61122 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(70.960188 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -97,18 +97,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_4">
-      <path d="M 103.563824 342.857031 
-L 103.563824 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 104.912792 342.857031 
+L 104.912792 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m53e1c9a5e6" x="103.563824" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb391ed1507" x="104.912792" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 8 -->
-      <g transform="translate(100.382574 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(101.731542 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -156,18 +156,18 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_6">
-      <path d="M 195.877886 342.857031 
-L 195.877886 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 197.226855 342.857031 
+L 197.226855 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m53e1c9a5e6" x="195.877886" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb391ed1507" x="197.226855" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 64 -->
-      <g transform="translate(189.515386 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(190.864355 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -207,18 +207,18 @@ z
     </g>
     <g id="xtick_4">
      <g id="line2d_8">
-      <path d="M 288.191948 342.857031 
-L 288.191948 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 289.540917 342.857031 
+L 289.540917 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m53e1c9a5e6" x="288.191948" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb391ed1507" x="289.540917" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 512 -->
-      <g transform="translate(278.648198 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(279.997167 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -292,18 +292,18 @@ z
     </g>
     <g id="xtick_5">
      <g id="line2d_10">
-      <path d="M 380.506011 342.857031 
-L 380.506011 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 381.854979 342.857031 
+L 381.854979 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m53e1c9a5e6" x="380.506011" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb391ed1507" x="381.854979" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 4096 -->
-      <g transform="translate(367.781011 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(369.129979 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -366,18 +366,18 @@ z
     </g>
     <g id="xtick_6">
      <g id="line2d_12">
-      <path d="M 624.571115 342.857031 
-L 624.571115 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 625.920084 342.857031 
+L 625.920084 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m53e1c9a5e6" x="624.571115" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb391ed1507" x="625.920084" y="342.857031" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 1M -->
-      <g transform="translate(617.075803 357.455469) scale(0.1 -0.1)">
+      <g transform="translate(618.424772 357.455469) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4d" d="M 628 4666 
 L 1569 4666 
@@ -403,540 +403,540 @@ z
     </g>
     <g id="xtick_7">
      <g id="line2d_14">
-      <path d="M 82.698633 342.857031 
-L 82.698633 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 84.047602 342.857031 
+L 84.047602 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_15">
       <defs>
-       <path id="m056fec7c1d" d="M 0 0 
+       <path id="mfb936d361c" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m056fec7c1d" x="82.698633" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="84.047602" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_16">
-      <path d="M 90.792558 342.857031 
-L 90.792558 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 92.141527 342.857031 
+L 92.141527 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m056fec7c1d" x="90.792558" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="92.141527" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_18">
-      <path d="M 97.635874 342.857031 
-L 97.635874 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 98.984843 342.857031 
+L 98.984843 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m056fec7c1d" x="97.635874" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="98.984843" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_20">
-      <path d="M 108.792646 342.857031 
-L 108.792646 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 110.141615 342.857031 
+L 110.141615 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m056fec7c1d" x="108.792646" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="110.141615" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_22">
-      <path d="M 144.241341 342.857031 
-L 144.241341 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 145.59031 342.857031 
+L 145.59031 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m056fec7c1d" x="144.241341" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="145.59031" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_24">
-      <path d="M 162.241429 342.857031 
-L 162.241429 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 163.590398 342.857031 
+L 163.590398 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m056fec7c1d" x="162.241429" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="163.590398" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_26">
-      <path d="M 175.012695 342.857031 
-L 175.012695 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 176.361664 342.857031 
+L 176.361664 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m056fec7c1d" x="175.012695" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="176.361664" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_28">
-      <path d="M 184.918859 342.857031 
-L 184.918859 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 186.267827 342.857031 
+L 186.267827 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m056fec7c1d" x="184.918859" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="186.267827" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_30">
-      <path d="M 193.012784 342.857031 
-L 193.012784 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 194.361752 342.857031 
+L 194.361752 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m056fec7c1d" x="193.012784" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="194.361752" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_32">
-      <path d="M 199.856099 342.857031 
-L 199.856099 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 201.205068 342.857031 
+L 201.205068 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m056fec7c1d" x="199.856099" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="201.205068" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_34">
-      <path d="M 205.784049 342.857031 
-L 205.784049 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 207.133018 342.857031 
+L 207.133018 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m056fec7c1d" x="205.784049" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="207.133018" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_36">
-      <path d="M 211.012872 342.857031 
-L 211.012872 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 212.361841 342.857031 
+L 212.361841 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m056fec7c1d" x="211.012872" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="212.361841" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_38">
-      <path d="M 246.461567 342.857031 
-L 246.461567 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 247.810536 342.857031 
+L 247.810536 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m056fec7c1d" x="246.461567" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="247.810536" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_40">
-      <path d="M 264.461655 342.857031 
-L 264.461655 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 265.810624 342.857031 
+L 265.810624 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m056fec7c1d" x="264.461655" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="265.810624" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_42">
-      <path d="M 277.232921 342.857031 
-L 277.232921 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 278.58189 342.857031 
+L 278.58189 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m056fec7c1d" x="277.232921" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="278.58189" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_44">
-      <path d="M 287.139084 342.857031 
-L 287.139084 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 288.488053 342.857031 
+L 288.488053 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m056fec7c1d" x="287.139084" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="288.488053" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
      <g id="line2d_46">
-      <path d="M 295.233009 342.857031 
-L 295.233009 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 296.581978 342.857031 
+L 296.581978 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m056fec7c1d" x="295.233009" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="296.581978" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
      <g id="line2d_48">
-      <path d="M 302.076325 342.857031 
-L 302.076325 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 303.425294 342.857031 
+L 303.425294 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m056fec7c1d" x="302.076325" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="303.425294" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_25">
      <g id="line2d_50">
-      <path d="M 308.004275 342.857031 
-L 308.004275 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 309.353244 342.857031 
+L 309.353244 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m056fec7c1d" x="308.004275" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="309.353244" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_26">
      <g id="line2d_52">
-      <path d="M 313.233097 342.857031 
-L 313.233097 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 314.582066 342.857031 
+L 314.582066 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m056fec7c1d" x="313.233097" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="314.582066" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_27">
      <g id="line2d_54">
-      <path d="M 348.681793 342.857031 
-L 348.681793 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 350.030761 342.857031 
+L 350.030761 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m056fec7c1d" x="348.681793" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="350.030761" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_28">
      <g id="line2d_56">
-      <path d="M 366.681881 342.857031 
-L 366.681881 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 368.03085 342.857031 
+L 368.03085 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m056fec7c1d" x="366.681881" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="368.03085" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_29">
      <g id="line2d_58">
-      <path d="M 379.453147 342.857031 
-L 379.453147 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 380.802115 342.857031 
+L 380.802115 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m056fec7c1d" x="379.453147" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="380.802115" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_30">
      <g id="line2d_60">
-      <path d="M 389.35931 342.857031 
-L 389.35931 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 390.708279 342.857031 
+L 390.708279 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m056fec7c1d" x="389.35931" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="390.708279" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_31">
      <g id="line2d_62">
-      <path d="M 397.453235 342.857031 
-L 397.453235 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 398.802204 342.857031 
+L 398.802204 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m056fec7c1d" x="397.453235" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="398.802204" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_32">
      <g id="line2d_64">
-      <path d="M 404.296551 342.857031 
-L 404.296551 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 405.64552 342.857031 
+L 405.64552 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m056fec7c1d" x="404.296551" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="405.64552" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_33">
      <g id="line2d_66">
-      <path d="M 410.224501 342.857031 
-L 410.224501 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 411.573469 342.857031 
+L 411.573469 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m056fec7c1d" x="410.224501" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="411.573469" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_34">
      <g id="line2d_68">
-      <path d="M 415.453323 342.857031 
-L 415.453323 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 416.802292 342.857031 
+L 416.802292 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m056fec7c1d" x="415.453323" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="416.802292" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_35">
      <g id="line2d_70">
-      <path d="M 450.902018 342.857031 
-L 450.902018 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 452.250987 342.857031 
+L 452.250987 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m056fec7c1d" x="450.902018" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="452.250987" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_36">
      <g id="line2d_72">
-      <path d="M 468.902106 342.857031 
-L 468.902106 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 470.251075 342.857031 
+L 470.251075 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m056fec7c1d" x="468.902106" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="470.251075" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_37">
      <g id="line2d_74">
-      <path d="M 481.673372 342.857031 
-L 481.673372 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 483.022341 342.857031 
+L 483.022341 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m056fec7c1d" x="481.673372" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="483.022341" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_38">
      <g id="line2d_76">
-      <path d="M 491.579536 342.857031 
-L 491.579536 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 492.928504 342.857031 
+L 492.928504 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m056fec7c1d" x="491.579536" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="492.928504" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_39">
      <g id="line2d_78">
-      <path d="M 499.673461 342.857031 
-L 499.673461 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 501.022429 342.857031 
+L 501.022429 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m056fec7c1d" x="499.673461" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="501.022429" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_40">
      <g id="line2d_80">
-      <path d="M 506.516777 342.857031 
-L 506.516777 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 507.865745 342.857031 
+L 507.865745 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#m056fec7c1d" x="506.516777" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="507.865745" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_41">
      <g id="line2d_82">
-      <path d="M 512.444726 342.857031 
-L 512.444726 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 513.793695 342.857031 
+L 513.793695 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#m056fec7c1d" x="512.444726" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="513.793695" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_42">
      <g id="line2d_84">
-      <path d="M 517.673549 342.857031 
-L 517.673549 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 519.022518 342.857031 
+L 519.022518 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#m056fec7c1d" x="517.673549" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="519.022518" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_43">
      <g id="line2d_86">
-      <path d="M 553.122244 342.857031 
-L 553.122244 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 554.471213 342.857031 
+L 554.471213 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#m056fec7c1d" x="553.122244" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="554.471213" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_44">
      <g id="line2d_88">
-      <path d="M 571.122332 342.857031 
-L 571.122332 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 572.471301 342.857031 
+L 572.471301 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#m056fec7c1d" x="571.122332" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="572.471301" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_45">
      <g id="line2d_90">
-      <path d="M 583.893598 342.857031 
-L 583.893598 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 585.242567 342.857031 
+L 585.242567 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#m056fec7c1d" x="583.893598" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="585.242567" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_46">
      <g id="line2d_92">
-      <path d="M 593.799761 342.857031 
-L 593.799761 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 595.14873 342.857031 
+L 595.14873 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_93">
       <g>
-       <use xlink:href="#m056fec7c1d" x="593.799761" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="595.14873" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_47">
      <g id="line2d_94">
-      <path d="M 601.893686 342.857031 
-L 601.893686 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 603.242655 342.857031 
+L 603.242655 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_95">
       <g>
-       <use xlink:href="#m056fec7c1d" x="601.893686" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="603.242655" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_48">
      <g id="line2d_96">
-      <path d="M 608.737002 342.857031 
-L 608.737002 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 610.085971 342.857031 
+L 610.085971 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#m056fec7c1d" x="608.737002" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="610.085971" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_49">
      <g id="line2d_98">
-      <path d="M 614.664952 342.857031 
-L 614.664952 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 616.013921 342.857031 
+L 616.013921 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_99">
       <g>
-       <use xlink:href="#m056fec7c1d" x="614.664952" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="616.013921" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_50">
      <g id="line2d_100">
-      <path d="M 619.893774 342.857031 
-L 619.893774 27.558281 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 621.242743 342.857031 
+L 621.242743 27.558281 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_101">
       <g>
-       <use xlink:href="#m056fec7c1d" x="619.893774" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfb936d361c" x="621.242743" y="342.857031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_7">
      <!-- validator count  V  (≤ leanSpec VALIDATOR_REGISTRY_LIMIT = 2¹² = 4096) -->
-     <g transform="translate(160.558437 371.513516) scale(0.105 -0.105)">
+     <g transform="translate(161.907406 371.513516) scale(0.105 -0.105)">
       <defs>
        <path id="DejaVuSans-76" d="M 191 3500 
 L 800 3500 
@@ -1577,23 +1577,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_102">
-      <path d="M 65.577656 325.494341 
-L 648.127656 325.494341 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 325.494341 
+L 649.476625 325.494341 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_103">
       <defs>
-       <path id="m005af03624" d="M 0 0 
+       <path id="m3be459f841" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="325.494341" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="325.494341" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 300 µs -->
-      <g transform="translate(24.740156 329.29356) scale(0.1 -0.1)">
+      <g transform="translate(26.089125 329.29356) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1698,18 +1698,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_104">
-      <path d="M 65.577656 295.335945 
-L 648.127656 295.335945 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 295.335945 
+L 649.476625 295.335945 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_105">
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="295.335945" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="295.335945" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 1 ms -->
-      <g transform="translate(34.087031 299.135164) scale(0.1 -0.1)">
+      <g transform="translate(35.436 299.135164) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1751,18 +1751,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_106">
-      <path d="M 65.577656 267.816732 
-L 648.127656 267.816732 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 267.816732 
+L 649.476625 267.816732 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_107">
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="267.816732" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="267.816732" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 3 ms -->
-      <g transform="translate(34.087031 271.61595) scale(0.1 -0.1)">
+      <g transform="translate(35.436 271.61595) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
@@ -1772,18 +1772,18 @@ L 648.127656 267.816732
     </g>
     <g id="ytick_4">
      <g id="line2d_108">
-      <path d="M 65.577656 237.658336 
-L 648.127656 237.658336 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 237.658336 
+L 649.476625 237.658336 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_109">
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="237.658336" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="237.658336" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10 ms -->
-      <g transform="translate(27.724531 241.457554) scale(0.1 -0.1)">
+      <g transform="translate(29.0735 241.457554) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -1794,18 +1794,18 @@ L 648.127656 237.658336
     </g>
     <g id="ytick_5">
      <g id="line2d_110">
-      <path d="M 65.577656 210.139122 
-L 648.127656 210.139122 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 210.139122 
+L 649.476625 210.139122 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_111">
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="210.139122" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="210.139122" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 30 ms -->
-      <g transform="translate(27.724531 213.938341) scale(0.1 -0.1)">
+      <g transform="translate(29.0735 213.938341) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -1816,18 +1816,18 @@ L 648.127656 210.139122
     </g>
     <g id="ytick_6">
      <g id="line2d_112">
-      <path d="M 65.577656 179.980726 
-L 648.127656 179.980726 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 179.980726 
+L 649.476625 179.980726 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_113">
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="179.980726" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="179.980726" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 100 ms -->
-      <g transform="translate(21.362031 183.779945) scale(0.1 -0.1)">
+      <g transform="translate(22.711 183.779945) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1839,18 +1839,18 @@ L 648.127656 179.980726
     </g>
     <g id="ytick_7">
      <g id="line2d_114">
-      <path d="M 65.577656 152.461513 
-L 648.127656 152.461513 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 152.461513 
+L 649.476625 152.461513 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_115">
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="152.461513" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="152.461513" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 300 ms -->
-      <g transform="translate(21.362031 156.260732) scale(0.1 -0.1)">
+      <g transform="translate(22.711 156.260732) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1862,18 +1862,18 @@ L 648.127656 152.461513
     </g>
     <g id="ytick_8">
      <g id="line2d_116">
-      <path d="M 65.577656 122.303117 
-L 648.127656 122.303117 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 122.303117 
+L 649.476625 122.303117 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_117">
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="122.303117" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="122.303117" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 1 s -->
-      <g transform="translate(43.827656 126.102336) scale(0.1 -0.1)">
+      <g transform="translate(45.176625 126.102336) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -1882,18 +1882,18 @@ L 648.127656 122.303117
     </g>
     <g id="ytick_9">
      <g id="line2d_118">
-      <path d="M 65.577656 94.783904 
-L 648.127656 94.783904 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 94.783904 
+L 649.476625 94.783904 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_119">
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="94.783904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="94.783904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 3 s -->
-      <g transform="translate(43.827656 98.583123) scale(0.1 -0.1)">
+      <g transform="translate(45.176625 98.583123) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -1902,18 +1902,18 @@ L 648.127656 94.783904
     </g>
     <g id="ytick_10">
      <g id="line2d_120">
-      <path d="M 65.577656 64.625508 
-L 648.127656 64.625508 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 66.926625 64.625508 
+L 649.476625 64.625508 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.35; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_121">
       <g>
-       <use xlink:href="#m005af03624" x="65.577656" y="64.625508" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be459f841" x="66.926625" y="64.625508" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 10 s -->
-      <g transform="translate(37.465156 68.424727) scale(0.1 -0.1)">
+      <g transform="translate(38.814125 68.424727) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -1923,468 +1923,468 @@ L 648.127656 64.625508
     </g>
     <g id="ytick_11">
      <g id="line2d_122">
-      <path d="M 65.577656 335.650864 
-L 648.127656 335.650864 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 335.650864 
+L 649.476625 335.650864 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_123">
       <defs>
-       <path id="mccfc9c15e0" d="M 0 0 
+       <path id="mf5ec83d541" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="335.650864" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="335.650864" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_124">
-      <path d="M 65.577656 318.288173 
-L 648.127656 318.288173 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 318.288173 
+L 649.476625 318.288173 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_125">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="318.288173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="318.288173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_126">
-      <path d="M 65.577656 312.698635 
-L 648.127656 312.698635 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 312.698635 
+L 649.476625 312.698635 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_127">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="312.698635" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="312.698635" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_128">
-      <path d="M 65.577656 308.13165 
-L 648.127656 308.13165 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 308.13165 
+L 649.476625 308.13165 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_129">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="308.13165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="308.13165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_130">
-      <path d="M 65.577656 304.27032 
-L 648.127656 304.27032 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 304.27032 
+L 649.476625 304.27032 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_131">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="304.27032" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="304.27032" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_132">
-      <path d="M 65.577656 300.925483 
-L 648.127656 300.925483 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 300.925483 
+L 649.476625 300.925483 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_133">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="300.925483" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="300.925483" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_134">
-      <path d="M 65.577656 297.975128 
-L 648.127656 297.975128 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 297.975128 
+L 649.476625 297.975128 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_135">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="297.975128" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="297.975128" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_136">
-      <path d="M 65.577656 277.973254 
-L 648.127656 277.973254 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 277.973254 
+L 649.476625 277.973254 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_137">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="277.973254" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="277.973254" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_138">
-      <path d="M 65.577656 260.610564 
-L 648.127656 260.610564 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 260.610564 
+L 649.476625 260.610564 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_139">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="260.610564" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="260.610564" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_140">
-      <path d="M 65.577656 255.021026 
-L 648.127656 255.021026 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 255.021026 
+L 649.476625 255.021026 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_141">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="255.021026" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="255.021026" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_142">
-      <path d="M 65.577656 250.454041 
-L 648.127656 250.454041 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 250.454041 
+L 649.476625 250.454041 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_143">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="250.454041" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="250.454041" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_144">
-      <path d="M 65.577656 246.59271 
-L 648.127656 246.59271 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 246.59271 
+L 649.476625 246.59271 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_145">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="246.59271" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="246.59271" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_146">
-      <path d="M 65.577656 243.247874 
-L 648.127656 243.247874 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 243.247874 
+L 649.476625 243.247874 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_147">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="243.247874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="243.247874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_148">
-      <path d="M 65.577656 240.297518 
-L 648.127656 240.297518 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 240.297518 
+L 649.476625 240.297518 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_149">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="240.297518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="240.297518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_150">
-      <path d="M 65.577656 220.295645 
-L 648.127656 220.295645 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 220.295645 
+L 649.476625 220.295645 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_151">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="220.295645" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="220.295645" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_152">
-      <path d="M 65.577656 202.932955 
-L 648.127656 202.932955 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 202.932955 
+L 649.476625 202.932955 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_153">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="202.932955" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="202.932955" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_154">
-      <path d="M 65.577656 197.343417 
-L 648.127656 197.343417 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 197.343417 
+L 649.476625 197.343417 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_155">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="197.343417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="197.343417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_156">
-      <path d="M 65.577656 192.776432 
-L 648.127656 192.776432 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 192.776432 
+L 649.476625 192.776432 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_157">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="192.776432" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="192.776432" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_158">
-      <path d="M 65.577656 188.915101 
-L 648.127656 188.915101 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 188.915101 
+L 649.476625 188.915101 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_159">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="188.915101" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="188.915101" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_160">
-      <path d="M 65.577656 185.570264 
-L 648.127656 185.570264 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 185.570264 
+L 649.476625 185.570264 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_161">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="185.570264" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="185.570264" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_162">
-      <path d="M 65.577656 182.619909 
-L 648.127656 182.619909 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 182.619909 
+L 649.476625 182.619909 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_163">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="182.619909" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="182.619909" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_164">
-      <path d="M 65.577656 162.618036 
-L 648.127656 162.618036 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 162.618036 
+L 649.476625 162.618036 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_165">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="162.618036" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="162.618036" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_166">
-      <path d="M 65.577656 145.255346 
-L 648.127656 145.255346 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 145.255346 
+L 649.476625 145.255346 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_167">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="145.255346" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="145.255346" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_168">
-      <path d="M 65.577656 139.665808 
-L 648.127656 139.665808 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 139.665808 
+L 649.476625 139.665808 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_169">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="139.665808" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="139.665808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_170">
-      <path d="M 65.577656 135.098823 
-L 648.127656 135.098823 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 135.098823 
+L 649.476625 135.098823 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_171">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="135.098823" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="135.098823" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_172">
-      <path d="M 65.577656 131.237492 
-L 648.127656 131.237492 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 131.237492 
+L 649.476625 131.237492 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_173">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="131.237492" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="131.237492" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_174">
-      <path d="M 65.577656 127.892655 
-L 648.127656 127.892655 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 127.892655 
+L 649.476625 127.892655 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_175">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="127.892655" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="127.892655" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_176">
-      <path d="M 65.577656 124.9423 
-L 648.127656 124.9423 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 124.9423 
+L 649.476625 124.9423 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_177">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="124.9423" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="124.9423" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_178">
-      <path d="M 65.577656 104.940427 
-L 648.127656 104.940427 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 104.940427 
+L 649.476625 104.940427 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_179">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="104.940427" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="104.940427" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_180">
-      <path d="M 65.577656 87.577736 
-L 648.127656 87.577736 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 87.577736 
+L 649.476625 87.577736 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_181">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="87.577736" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="87.577736" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_182">
-      <path d="M 65.577656 81.988199 
-L 648.127656 81.988199 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 81.988199 
+L 649.476625 81.988199 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_183">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="81.988199" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="81.988199" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_184">
-      <path d="M 65.577656 77.421214 
-L 648.127656 77.421214 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 77.421214 
+L 649.476625 77.421214 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_185">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="77.421214" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="77.421214" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_186">
-      <path d="M 65.577656 73.559883 
-L 648.127656 73.559883 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 73.559883 
+L 649.476625 73.559883 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_187">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="73.559883" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="73.559883" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_188">
-      <path d="M 65.577656 70.215046 
-L 648.127656 70.215046 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 70.215046 
+L 649.476625 70.215046 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_189">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="70.215046" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="70.215046" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_190">
-      <path d="M 65.577656 67.264691 
-L 648.127656 67.264691 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 67.264691 
+L 649.476625 67.264691 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_191">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="67.264691" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="67.264691" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_192">
-      <path d="M 65.577656 47.262818 
-L 648.127656 47.262818 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 47.262818 
+L 649.476625 47.262818 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_193">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="47.262818" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="47.262818" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_194">
-      <path d="M 65.577656 37.106295 
-L 648.127656 37.106295 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 37.106295 
+L 649.476625 37.106295 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_195">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="37.106295" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="37.106295" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_196">
-      <path d="M 65.577656 29.900127 
-L 648.127656 29.900127 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
+      <path d="M 66.926625 29.900127 
+L 649.476625 29.900127 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 0.3,0.495; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.2; stroke-width: 0.3"/>
      </g>
      <g id="line2d_197">
       <g>
-       <use xlink:href="#mccfc9c15e0" x="65.577656" y="29.900127" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf5ec83d541" x="66.926625" y="29.900127" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_18">
      <!-- time per call (log scale) -->
-     <g transform="translate(15.178359 247.113359) rotate(-90) scale(0.105 -0.105)">
+     <g transform="translate(16.527328 247.113359) rotate(-90) scale(0.105 -0.105)">
       <defs>
        <path id="DejaVuSans-67" d="M 2906 1791 
 Q 2906 2416 2648 2759 
@@ -2450,33 +2450,33 @@ z
     </g>
    </g>
    <g id="line2d_198">
-    <path d="M 65.577656 162.618036 
-L 648.127656 162.618036 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
+    <path d="M 66.926625 162.618036 
+L 649.476625 162.618036 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #7f7f7f; stroke-width: 1.2"/>
    </g>
    <g id="patch_4">
-    <path d="M 65.577656 342.857031 
-L 65.577656 27.558281 
+    <path d="M 66.926625 342.857031 
+L 66.926625 27.558281 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 648.127656 342.857031 
-L 648.127656 27.558281 
+    <path d="M 649.476625 342.857031 
+L 649.476625 27.558281 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 65.577656 342.857031 
-L 648.127656 342.857031 
+    <path d="M 66.926625 342.857031 
+L 649.476625 342.857031 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 65.577656 27.558281 
-L 648.127656 27.558281 
+    <path d="M 66.926625 27.558281 
+L 649.476625 27.558281 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_19">
     <!-- VALIDATOR_REGISTRY_LIMIT = 4096 -->
-    <g style="fill: #b01010" transform="translate(386.710557 322.418933) scale(0.08 -0.08)">
+    <g style="fill: #b01010" transform="translate(388.059526 322.418933) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-56"/>
      <use xlink:href="#DejaVuSans-41" transform="translate(62.033203 0)"/>
      <use xlink:href="#DejaVuSans-4c" transform="translate(130.441406 0)"/>
@@ -2510,7 +2510,7 @@ L 648.127656 27.558281
      <use xlink:href="#DejaVuSans-36" transform="translate(1749.527344 0)"/>
     </g>
     <!-- (leanSpec cap) -->
-    <g style="fill: #b01010" transform="translate(386.710557 331.599683) scale(0.08 -0.08)">
+    <g style="fill: #b01010" transform="translate(388.059526 331.599683) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-28"/>
      <use xlink:href="#DejaVuSans-6c" transform="translate(39.013672 0)"/>
      <use xlink:href="#DejaVuSans-65" transform="translate(66.796875 0)"/>
@@ -2529,7 +2529,7 @@ L 648.127656 27.558281
    </g>
    <g id="text_20">
     <!-- SLO target 200 ms (1 interval) -->
-    <g style="fill: #555555" transform="translate(69.33147 158.900253) scale(0.085 -0.085)">
+    <g style="fill: #555555" transform="translate(70.680439 158.900253) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-53"/>
      <use xlink:href="#DejaVuSans-4c" transform="translate(63.476562 0)"/>
      <use xlink:href="#DejaVuSans-4f" transform="translate(115.564453 0)"/>
@@ -2564,7 +2564,7 @@ L 648.127656 27.558281
    </g>
    <g id="text_21">
     <!-- 324 µs -->
-    <g style="fill: #0b3d6e" transform="translate(58.749907 314.597482) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(60.098876 314.597482) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
@@ -2575,7 +2575,7 @@ L 648.127656 27.558281
    </g>
    <g id="text_22">
     <!-- 344 µs -->
-    <g style="fill: #0b3d6e" transform="translate(89.521261 313.102581) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(90.87023 313.102581) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
@@ -2586,7 +2586,7 @@ L 648.127656 27.558281
    </g>
    <g id="text_23">
     <!-- 712 µs -->
-    <g style="fill: #0b3d6e" transform="translate(181.835323 294.837511) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(183.184292 294.837511) scale(0.083 -0.083)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -2609,7 +2609,7 @@ z
    </g>
    <g id="text_24">
     <!-- 3.85 ms -->
-    <g style="fill: #0b3d6e" transform="translate(271.428542 252.56797) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(272.777511 252.56797) scale(0.083 -0.083)">
      <defs>
       <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -2630,7 +2630,7 @@ z
    </g>
    <g id="text_25">
     <!-- 26.40 ms -->
-    <g style="fill: #0b3d6e" transform="translate(361.102167 204.341229) scale(0.083 -0.083)">
+    <g style="fill: #0b3d6e" transform="translate(362.451136 204.341229) scale(0.083 -0.083)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
@@ -2642,17 +2642,17 @@ z
     </g>
    </g>
    <g id="patch_8">
-    <path d="M 314.685812 275.103917 
-Q 346.865759 244.907715 378.148876 215.553058 
+    <path d="M 316.034781 275.103917 
+Q 348.214728 244.907715 379.497844 215.553058 
 " style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
-    <path d="M 374.463388 216.652687 
-L 378.148876 215.553058 
-L 376.817287 219.161225 
+    <path d="M 375.812357 216.652687 
+L 379.497844 215.553058 
+L 378.166256 219.161225 
 " style="fill: none; stroke: #0b6e0b; stroke-width: 1.1; stroke-linecap: round"/>
    </g>
    <g id="text_26">
     <!-- V=4096 (leanSpec max) -->
-    <g style="fill: #0b6e0b" transform="translate(233.690301 285.010082) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(235.03927 285.010082) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -2693,7 +2693,7 @@ z
      <use xlink:href="#DejaVuSans-29" transform="translate(1184.570312 0)"/>
     </g>
     <!-- 26.40 ms — green, -->
-    <g style="fill: #0b6e0b" transform="translate(233.690301 294.640201) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(235.03927 294.640201) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2731,7 +2731,7 @@ z
      <use xlink:href="#DejaVuSans-2c" transform="translate(919.917969 0)"/>
     </g>
     <!-- 8× under the 200 ms budget -->
-    <g style="fill: #0b6e0b" transform="translate(233.690301 304.27032) scale(0.086 -0.086)">
+    <g style="fill: #0b6e0b" transform="translate(235.03927 304.27032) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-d7" d="M 4488 3438 
 L 3059 2003 
@@ -2823,17 +2823,17 @@ z
     </g>
    </g>
    <g id="patch_9">
-    <path d="M 554.924448 79.211223 
-Q 588.801958 67.472103 621.517418 56.135651 
+    <path d="M 556.273417 79.211223 
+Q 590.150926 67.472103 622.866387 56.135651 
 " style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
-    <path d="M 617.703874 55.636771 
-L 621.517418 56.135651 
-L 618.830188 58.887158 
+    <path d="M 619.052843 55.636771 
+L 622.866387 56.135651 
+L 620.179156 58.887158 
 " style="fill: none; stroke: #b01010; stroke-width: 1.1; stroke-linecap: round"/>
    </g>
    <g id="text_27">
     <!-- V=1M (mainnet, out-of-spec) -->
-    <g style="fill: #b01010" transform="translate(458.995943 88.401477) scale(0.086 -0.086)">
+    <g style="fill: #b01010" transform="translate(460.344912 88.401477) scale(0.086 -0.086)">
      <defs>
       <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -2893,7 +2893,7 @@ z
      <use xlink:href="#DejaVuSans-29" transform="translate(1411.21875 0)"/>
     </g>
     <!-- 14.64 s — over budget -->
-    <g style="fill: #b01010" transform="translate(458.995943 98.031596) scale(0.086 -0.086)">
+    <g style="fill: #b01010" transform="translate(460.344912 98.031596) scale(0.086 -0.086)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
@@ -2919,7 +2919,7 @@ z
    </g>
    <g id="text_28">
     <!-- state_transition benchmark — SHA-256 hash_tree_root, A=8 valid attestations -->
-    <g transform="translate(140.995703 15.558281) scale(0.11 -0.11)">
+    <g transform="translate(142.344672 15.558281) scale(0.11 -0.11)">
      <defs>
       <path id="DejaVuSans-6b" d="M 581 4863 
 L 1159 4863 
@@ -3029,11 +3029,11 @@ z
     </g>
    </g>
    <g id="line2d_199">
-    <path d="M 380.506011 213.341229 
-L 624.571115 55.077495 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 381.854979 213.341229 
+L 625.920084 55.077495 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
     <defs>
-     <path id="m154de8bcf0" d="M 0 4 
+     <path id="m8c8d148425" d="M 0 4 
 C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
 C 3.578535 2.078319 4 1.060812 4 0 
 C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
@@ -3045,20 +3045,20 @@ C -2.078319 3.578535 -1.060812 4 0 4
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p289f9afc26)">
-     <use xlink:href="#m154de8bcf0" x="380.506011" y="213.341229" style="fill: #ffffff; stroke: #d62728"/>
-     <use xlink:href="#m154de8bcf0" x="624.571115" y="55.077495" style="fill: #ffffff; stroke: #d62728"/>
+    <g clip-path="url(#pc0eca37085)">
+     <use xlink:href="#m8c8d148425" x="381.854979" y="213.341229" style="fill: #ffffff; stroke: #d62728"/>
+     <use xlink:href="#m8c8d148425" x="625.920084" y="55.077495" style="fill: #ffffff; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_200">
-    <path d="M 72.79247 323.597482 
-L 103.563824 322.102581 
-L 195.877886 303.837511 
-L 288.191948 261.56797 
-L 380.506011 213.341229 
-" clip-path="url(#p289f9afc26)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
+    <path d="M 74.141438 323.597482 
+L 104.912792 322.102581 
+L 197.226855 303.837511 
+L 289.540917 261.56797 
+L 381.854979 213.341229 
+" clip-path="url(#pc0eca37085)" style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
     <defs>
-     <path id="m6292887d37" d="M 0 4 
+     <path id="md663bc701b" d="M 0 4 
 C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
 C 3.578535 2.078319 4 1.060812 4 0 
 C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
@@ -3070,40 +3070,40 @@ C -2.078319 3.578535 -1.060812 4 0 4
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p289f9afc26)">
-     <use xlink:href="#m6292887d37" x="72.79247" y="323.597482" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m6292887d37" x="103.563824" y="322.102581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m6292887d37" x="195.877886" y="303.837511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m6292887d37" x="288.191948" y="261.56797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m6292887d37" x="380.506011" y="213.341229" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pc0eca37085)">
+     <use xlink:href="#md663bc701b" x="74.141438" y="323.597482" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md663bc701b" x="104.912792" y="322.102581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md663bc701b" x="197.226855" y="303.837511" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md663bc701b" x="289.540917" y="261.56797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md663bc701b" x="381.854979" y="213.341229" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_10">
-     <path d="M 71.737656 60.676531 
-L 342.847781 60.676531 
-Q 344.607781 60.676531 344.607781 58.916531 
-L 344.607781 33.718281 
-Q 344.607781 31.958281 342.847781 31.958281 
-L 71.737656 31.958281 
-Q 69.977656 31.958281 69.977656 33.718281 
-L 69.977656 58.916531 
-Q 69.977656 60.676531 71.737656 60.676531 
+     <path d="M 73.086625 60.676531 
+L 344.19675 60.676531 
+Q 345.95675 60.676531 345.95675 58.916531 
+L 345.95675 33.718281 
+Q 345.95675 31.958281 344.19675 31.958281 
+L 73.086625 31.958281 
+Q 71.326625 31.958281 71.326625 33.718281 
+L 71.326625 58.916531 
+Q 71.326625 60.676531 73.086625 60.676531 
 z
 " style="fill: #ffffff; opacity: 0.95; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
     <g id="line2d_201">
-     <path d="M 73.497656 39.084906 
-L 82.297656 39.084906 
-L 91.097656 39.084906 
+     <path d="M 74.846625 39.084906 
+L 83.646625 39.084906 
+L 92.446625 39.084906 
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6292887d37" x="82.297656" y="39.084906" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#md663bc701b" x="83.646625" y="39.084906" style="fill: #1f77b4; stroke: #1f77b4"/>
      </g>
     </g>
     <g id="text_29">
      <!-- state_transition pipeline (incl. SHA-256 hash_tree_root) -->
-     <g transform="translate(98.137656 42.164906) scale(0.088 -0.088)">
+     <g transform="translate(99.486625 42.164906) scale(0.088 -0.088)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
@@ -3163,17 +3163,17 @@ L 91.097656 39.084906
      </g>
     </g>
     <g id="line2d_202">
-     <path d="M 73.497656 52.246406 
-L 82.297656 52.246406 
-L 91.097656 52.246406 
+     <path d="M 74.846625 52.246406 
+L 83.646625 52.246406 
+L 92.446625 52.246406 
 " style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
      <g>
-      <use xlink:href="#m154de8bcf0" x="82.297656" y="52.246406" style="fill: #ffffff; stroke: #d62728"/>
+      <use xlink:href="#m8c8d148425" x="83.646625" y="52.246406" style="fill: #ffffff; stroke: #d62728"/>
      </g>
     </g>
     <g id="text_30">
      <!-- V=1M (mainnet, out-of-spec reference) -->
-     <g transform="translate(98.137656 55.326406) scale(0.088 -0.088)">
+     <g transform="translate(99.486625 55.326406) scale(0.088 -0.088)">
       <use xlink:href="#DejaVuSans-56"/>
       <use xlink:href="#DejaVuSans-3d" transform="translate(68.408203 0)"/>
       <use xlink:href="#DejaVuSans-31" transform="translate(152.197266 0)"/>
@@ -3215,10 +3215,294 @@ L 91.097656 52.246406
     </g>
    </g>
   </g>
+  <g id="text_31">
+   <!-- AMD Ryzen 9 PRO 8945HS (Zen 4 mobile, 8C/16T)  ·  Linux 6.18.12+kali-amd64 x86_64  ·  Lean v4.28.0-rc1  ·  Rust release + thin LTO + codegen-units=1  ·  2026-06-26 -->
+   <g style="fill: #666666" transform="translate(7.2 398.469094) scale(0.076 -0.076)">
+    <defs>
+     <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-41"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(68.408203 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(154.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(231.689453 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(263.476562 0)"/>
+    <use xlink:href="#DejaVuSans-79" transform="translate(327.458984 0)"/>
+    <use xlink:href="#DejaVuSans-7a" transform="translate(386.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(439.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(500.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(564.03125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(595.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(659.441406 0)"/>
+    <use xlink:href="#DejaVuSans-50" transform="translate(691.228516 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(751.53125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(821.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(899.724609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(931.511719 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(995.134766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1058.757812 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1122.380859 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(1186.003906 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(1261.199219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1324.675781 0)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(1356.462891 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1395.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1463.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1525.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1620.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1684.294922 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(1716.082031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1813.494141 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(1874.675781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1938.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1965.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1993.71875 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(2055.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2087.029297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2118.816406 0)"/>
+    <use xlink:href="#DejaVuSans-43" transform="translate(2182.439453 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(2252.263672 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(2285.955078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2349.578125 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(2413.201172 0)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(2474.285156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2513.298828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2545.085938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2576.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2608.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2640.447266 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(2672.234375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2727.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2755.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2819.109375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2882.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2941.667969 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2973.455078 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3037.078125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3068.865234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3132.488281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3196.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3227.898438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3291.521484 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(3355.144531 0)"/>
+    <use xlink:href="#DejaVuSans-6b" transform="translate(3438.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3495.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3556.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3584.15625 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(3611.939453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3648.023438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(3709.302734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3806.714844 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3870.191406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3933.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3997.4375 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(4029.224609 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(4088.404297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4152.027344 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(4215.650391 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4265.650391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4329.273438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4392.896484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4424.683594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(4456.470703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4488.257812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4520.044922 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(4551.832031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4605.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4667.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4728.597656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4791.976562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4823.763672 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4882.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4946.566406 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4978.353516 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(5041.976562 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(5105.599609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(5137.386719 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5201.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5237.09375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5275.957031 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5330.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5394.560547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5426.347656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5458.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5489.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5521.708984 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(5553.496094 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5618.478516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(5681.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5733.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5773.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5804.953125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5843.816406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5905.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5933.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5994.646484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6055.925781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6108.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6169.548828 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(6201.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6285.125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6316.912109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6356.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6419.5 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6447.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6510.662109 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(6542.449219 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(6584.412109 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(6645.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6724.207031 0)"/>
+    <use xlink:href="#DejaVuSans-2b" transform="translate(6755.994141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6839.783203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6871.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6926.550781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6987.732422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7051.208984 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(7112.732422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7176.208984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7237.732422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(7301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7337.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7400.574219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7463.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7491.736328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7530.945312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(7583.044922 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(7666.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7730.457031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7762.244141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(7794.03125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7825.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7857.605469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(7889.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(7953.015625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8016.638672 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8080.261719 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8143.884766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(8179.96875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8243.591797 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(8307.214844 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(8343.298828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(8406.921875 0)"/>
+   </g>
+  </g>
  </g>
  <defs>
-  <clipPath id="p289f9afc26">
-   <rect x="65.577656" y="27.558281" width="582.55" height="315.29875"/>
+  <clipPath id="pc0eca37085">
+   <rect x="66.926625" y="27.558281" width="582.55" height="315.29875"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -121,7 +121,7 @@ log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spe
 
 ![state_transition results with real hash_tree_root](./assets/bench-htr-results.svg)
 
-実 HTR 込みの STF pipeline(青)と Rust→Lean ByteArray marshal の境界コスト(橙)。spec 上限 V=4096 でも STF 29 ms ≪ SLO target 200 ms、marshal は ~4 桁下で実質誤差。データは本節の canonical run(2026-06-26, AMD Ryzen 9 PRO 8945HS)。
+実 HTR 込みの STF pipeline。spec 上限 V=4096 でも 29 ms ≪ SLO target 200 ms(約 1/7)。データは本節の canonical run(2026-06-26, AMD Ryzen 9 PRO 8945HS)。
 
 <details><summary>参考: ZERO スタブとの比較図</summary>
 

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -126,6 +126,10 @@ log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spe
 
 SHA-256 `hash_tree_root` 込みの STF pipeline。spec 上限 V=4096 で 26.40 ms ≪ SLO target 200 ms(約 1/8)。赤の破線・網掛けは out-of-spec の V=1M(mainnet 参考、`--include-1m`)で **14.64 s**(🔴、RSS +1.27 GB) — `validator_count > 4096` は leanSpec モデルでは到達不能。HTR が実計算になったことで 1M の merkleize(1M validator を SHA-256 で畳む)が支配し、HTR スタブ時の 4.17 s から ~3.5× に増えた。データは 1 プロセスの canonical run(2026-06-26, AMD Ryzen 9 PRO 8945HS)。
 
+上図は V=1M を含むため spec 範囲(V ≤ 4096)の曲線が縦軸の下端に圧縮される。spec 範囲だけを拡大した版が下図(同一データ、軸を 200 ms SLO 近傍までズーム):
+
+![state_transition results (leanSpec range V ≤ 4096)](./assets/bench-htr-results-spec.svg)
+
 <details><summary>参考: ZERO スタブとの比較図</summary>
 
 ![real hash_tree_root cost vs ZERO stub](./assets/htr-cost.svg)

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -119,7 +119,15 @@ log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spe
 | 512 | 10.91 ms | 7.36 ms | **3.55 ms** | 2.15 ms | +65% | 0 |
 | 4096 (spec max) | 75.68 ms | 48.14 ms | **27.55 ms** | 15.12 ms | **+82%** | 0 |
 
+![state_transition results with real hash_tree_root](./assets/bench-htr-results.svg)
+
+実 HTR 込みの STF pipeline(青)と Rust→Lean ByteArray marshal の境界コスト(橙)。spec 上限 V=4096 でも STF 29 ms ≪ SLO target 200 ms、marshal は ~4 桁下で実質誤差。データは本節の canonical run(2026-06-26, AMD Ryzen 9 PRO 8945HS)。
+
+<details><summary>参考: ZERO スタブとの比較図</summary>
+
 ![real hash_tree_root cost vs ZERO stub](./assets/htr-cost.svg)
+
+</details>
 
 ### 判定・観察
 

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -118,10 +118,13 @@ log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spe
 | 64 | 1.83 ms | 1.06 ms | **761.9 µs** | 536.2 µs | +42% | 0 |
 | 512 | 10.91 ms | 7.36 ms | **3.55 ms** | 2.15 ms | +65% | 0 |
 | 4096 (spec max) | 75.68 ms | 48.14 ms | **27.55 ms** | 15.12 ms | **+82%** | 0 |
+| 1,000,000 ⚠ out-of-spec | 30.16 s | 15.53 s | **14.64 s** | 4.17 s | **+251%** | 0 |
 
-![state_transition results with real hash_tree_root](./assets/bench-htr-results.svg)
+> V=1M は mainnet 範囲外参考(`--include-1m`、1 trial、RSS +1.27 GB)。実 HTR の merkleize(1M validator を SHA-256)が支配し、スタブ時 4.17 s の ~3.5× に。leanSpec モデルでは `validator_count > 4096` は SSZ 検証で不正のため到達不能。
 
-実 HTR 込みの STF pipeline。spec 上限 V=4096 でも 29 ms ≪ SLO target 200 ms(約 1/7)。データは本節の canonical run(2026-06-26, AMD Ryzen 9 PRO 8945HS)。
+![state_transition results with SHA-256 hash_tree_root](./assets/bench-htr-results.svg)
+
+SHA-256 `hash_tree_root` 込みの STF pipeline。spec 上限 V=4096 で 26.40 ms ≪ SLO target 200 ms(約 1/8)。赤の破線・網掛けは out-of-spec の V=1M(mainnet 参考、`--include-1m`)で **14.64 s**(🔴、RSS +1.27 GB) — `validator_count > 4096` は leanSpec モデルでは到達不能。HTR が実計算になったことで 1M の merkleize(1M validator を SHA-256 で畳む)が支配し、HTR スタブ時の 4.17 s から ~3.5× に増えた。データは 1 プロセスの canonical run(2026-06-26, AMD Ryzen 9 PRO 8945HS)。
 
 <details><summary>参考: ZERO スタブとの比較図</summary>
 

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -138,11 +138,11 @@ V–time は単純な線形ではなく、**V 非依存の固定費(床)+ V に�
 
 ![state_transition scaling with baseline, full range incl. out-of-spec V=1M](./assets/bench-htr-results-baseline-full.svg)
 
-#### 外部実装 ethlambda (native Rust) との対照
+#### 別の native Rust 実装との対照
 
-[`lambdaclass/ethlambda`](https://github.com/lambdaclass/ethlambda) は同じ Lean Consensus (3SF) プロトコルの **native Rust** 実装で、spec 定数も一致(`VALIDATOR_REGISTRY_LIMIT = 4096`、`MAX_ATTESTATIONS_DATA = 8`、`HISTORICAL_ROOTS_LIMIT = 262144`)、HTR も SSZ merkleize over **SHA-256**(`libssz_merkle::Sha2Hasher`)。本 poc と同条件(V ≤ 4096、A=8 有効 attestation、HTR 込み)で `crates/blockchain/state_transition::state_transition` を計測した(consistent block を構築、State の clone は計測外、median of N samples、同一マシン 2026-06-26)。
+同じ Lean Consensus (3SF) プロトコルの**独立した native Rust 実装**(spec 定数も一致: `VALIDATOR_REGISTRY_LIMIT = 4096`、`MAX_ATTESTATIONS_DATA = 8`、`HISTORICAL_ROOTS_LIMIT = 262144`、HTR も SSZ merkleize over **SHA-256**)と対照した。本 poc と同条件(V ≤ 4096、A=8 有効 attestation、HTR 込み)でその実装の `state_transition` を計測(consistent block を構築、State の clone は計測外、median of N samples、同一マシン 2026-06-26)。
 
-| V | ethlambda (native Rust) | consensus-ffi-poc (Lean/FFI) | 比 |
+| V | native Rust 実装 | consensus-ffi-poc (Lean/FFI) | 比 |
 |---:|---:|---:|---:|
 | 4 | 61.1 µs | 324 µs | 5.3× |
 | 8 | 67.6 µs | 344 µs | 5.1× |
@@ -150,9 +150,9 @@ V–time は単純な線形ではなく、**V 非依存の固定費(床)+ V に�
 | 512 | 939.7 µs | 3.85 ms | 4.1× |
 | 4096 (spec max) | **7.41 ms** | **26.40 ms** | **3.6×** |
 
-![state_transition: consensus-ffi-poc (Lean/FFI) vs ethlambda (native Rust), V ≤ 4096](./assets/bench-htr-results-spec-ethlambda.svg)
+![state_transition: consensus-ffi-poc (Lean/FFI) vs native-Rust implementation, V ≤ 4096](./assets/bench-htr-results-spec-vs-native-rust.svg)
 
-native Rust の ethlambda が全域で **3.6–5.3× 速い**。差は Aeneas 生成コード + Lean ランタイム + FFI 境界のオーバーヘッドで、これは検証由来ではなく純粋に実装パスのコスト(§前提どおり handwritten fast path でも Lean の `Array`/boxed `lean_object*` を経由する)。**両者とも spec 上限 V=4096 で SLO target 200 ms を大きく下回る**(7.41 ms / 26.40 ms、ともに 🟢)。scaling は両者とも V=512→4096 で ~linear(ethlambda 940 µs→7.41 ms ≈ 7.9×、poc 3.85→26.40 ms ≈ 6.9×)で、§前述の `O(A·V) + HTR merkleize` モデルが実装非依存に効いていることを裏づける。
+native Rust 実装が全域で **3.6–5.3× 速い**。差は Aeneas 生成コード + Lean ランタイム + FFI 境界のオーバーヘッドで、これは検証由来ではなく純粋に実装パスのコスト(§前提どおり handwritten fast path でも Lean の `Array`/boxed `lean_object*` を経由する)。**両者とも spec 上限 V=4096 で SLO target 200 ms を大きく下回る**(7.41 ms / 26.40 ms、ともに 🟢)。scaling は両者とも V=512→4096 で ~linear(native Rust 940 µs→7.41 ms ≈ 7.9×、poc 3.85→26.40 ms ≈ 6.9×)で、§前述の `O(A·V) + HTR merkleize` モデルが実装非依存に効いていることを裏づける。
 
 <details><summary>参考: ZERO スタブとの比較図</summary>
 

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -138,6 +138,22 @@ V–time は単純な線形ではなく、**V 非依存の固定費(床)+ V に�
 
 ![state_transition scaling with baseline, full range incl. out-of-spec V=1M](./assets/bench-htr-results-baseline-full.svg)
 
+#### 外部実装 ethlambda (native Rust) との対照
+
+[`lambdaclass/ethlambda`](https://github.com/lambdaclass/ethlambda) は同じ Lean Consensus (3SF) プロトコルの **native Rust** 実装で、spec 定数も一致(`VALIDATOR_REGISTRY_LIMIT = 4096`、`MAX_ATTESTATIONS_DATA = 8`、`HISTORICAL_ROOTS_LIMIT = 262144`)、HTR も SSZ merkleize over **SHA-256**(`libssz_merkle::Sha2Hasher`)。本 poc と同条件(V ≤ 4096、A=8 有効 attestation、HTR 込み)で `crates/blockchain/state_transition::state_transition` を計測した(consistent block を構築、State の clone は計測外、median of N samples、同一マシン 2026-06-26)。
+
+| V | ethlambda (native Rust) | consensus-ffi-poc (Lean/FFI) | 比 |
+|---:|---:|---:|---:|
+| 4 | 61.1 µs | 324 µs | 5.3× |
+| 8 | 67.6 µs | 344 µs | 5.1× |
+| 64 | 165.7 µs | 712 µs | 4.3× |
+| 512 | 939.7 µs | 3.85 ms | 4.1× |
+| 4096 (spec max) | **7.41 ms** | **26.40 ms** | **3.6×** |
+
+![state_transition: consensus-ffi-poc (Lean/FFI) vs ethlambda (native Rust), V ≤ 4096](./assets/bench-htr-results-spec-ethlambda.svg)
+
+native Rust の ethlambda が全域で **3.6–5.3× 速い**。差は Aeneas 生成コード + Lean ランタイム + FFI 境界のオーバーヘッドで、これは検証由来ではなく純粋に実装パスのコスト(§前提どおり handwritten fast path でも Lean の `Array`/boxed `lean_object*` を経由する)。**両者とも spec 上限 V=4096 で SLO target 200 ms を大きく下回る**(7.41 ms / 26.40 ms、ともに 🟢)。scaling は両者とも V=512→4096 で ~linear(ethlambda 940 µs→7.41 ms ≈ 7.9×、poc 3.85→26.40 ms ≈ 6.9×)で、§前述の `O(A·V) + HTR merkleize` モデルが実装非依存に効いていることを裏づける。
+
 <details><summary>参考: ZERO スタブとの比較図</summary>
 
 ![real hash_tree_root cost vs ZERO stub](./assets/htr-cost.svg)

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -134,6 +134,10 @@ V–time は単純な線形ではなく、**V 非依存の固定費(床)+ V に�
 
 ![state_transition scaling: fixed baseline + linear-in-V (V ≤ 4096)](./assets/bench-htr-results-baseline.svg)
 
+同じ分解を全域(out-of-spec の V=1M 込み)に重ねた版が下図。spec 範囲で導いた線形項を 1M まで外挿すると **6.3 s** だが、実測 1M は **14.64 s**(≈2.3×)。spec 範囲の `床 + 線形` モデルは out-of-spec で破綻し、1M validator の実 HTR merkleize が superlinear に効く(`validator_count > 4096` は leanSpec モデルでは到達不能なので、これはあくまで mainnet 規模の対照):
+
+![state_transition scaling with baseline, full range incl. out-of-spec V=1M](./assets/bench-htr-results-baseline-full.svg)
+
 <details><summary>参考: ZERO スタブとの比較図</summary>
 
 ![real hash_tree_root cost vs ZERO stub](./assets/htr-cost.svg)

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -130,6 +130,10 @@ SHA-256 `hash_tree_root` 込みの STF pipeline。spec 上限 V=4096 で 26.40 m
 
 ![state_transition results (leanSpec range V ≤ 4096)](./assets/bench-htr-results-spec.svg)
 
+V–time は単純な線形ではなく、**V 非依存の固定費(床)+ V に線形な項**のアフィン関係 `t ≈ 0.30 ms + 6.3 µs·V`。下図はこれを分解し、固定費ベースライン(紫の水平線、~0.30 ms: 8 票分の `voteIsValid` 等)と線形項(橙、~6.3 µs·V: `O(A·V)` ホットループ + HTR merkleize)を明示した版。実測(青)は小 V で床に、大 V で線形項に漸近し、両者が交差する **V≈48** が平坦→線形の膝になる(V を 8× しても time 倍率が 2.07→5.41→6.86 と 8× に近づくのはこのため):
+
+![state_transition scaling: fixed baseline + linear-in-V (V ≤ 4096)](./assets/bench-htr-results-baseline.svg)
+
 <details><summary>参考: ZERO スタブとの比較図</summary>
 
 ![real hash_tree_root cost vs ZERO stub](./assets/htr-cost.svg)


### PR DESCRIPTION
SVG of the `state_transition` benchmark with SHA-256 SSZ `hash_tree_root` (issue #5), A=8 valid attestations.

![results](https://raw.githubusercontent.com/NyxFoundation/consensus-ffi-poc/docs/htr-results-chart/docs/assets/bench-htr-results.svg)

- **Blue (solid)**: spec range V = 4…4096. At the leanSpec ceiling **V=4096 → 26.40 ms — green, ~8× under the 200 ms SLO budget**.
- **Red (dashed, out-of-spec)**: mainnet reference **V=1M → 14.64 s** (🔴, RSS +1.27 GB). Beyond `VALIDATOR_REGISTRY_LIMIT = 4096`, so unreachable in the leanSpec model. The 1M-validator SHA-256 merkleize dominates — ~3.5× the HTR-stub's 4.17 s.

Single canonical run on `main`, 2026-06-26, AMD Ryzen 9 PRO 8945HS. Embedded as the headline figure in `docs/rust-ffi-benchmarks.md` §1b (table now includes the 1M row).