### PR TITLE
perf(ffi): add data-realism A/B for state_transition fixture

### DIFF
--- a/ConsensusLean4/Ffi.lean
+++ b/ConsensusLean4/Ffi.lean
@@ -612,3 +612,128 @@ def csfBenchStateTransitionSszDecode (data : ByteArray) : UInt8 :=
   let (state, o) := decodeState data 0
   let (block, _) := decodeBlock data o
   consumeState state ^^^ consumeBlock block
+
+/-! ## Realism probe — scattered aggregation bits + high-entropy roots.
+
+The M5b `*_att_*` fixture sets a *contiguous* ⌈V/2⌉-bit prefix and fills every
+H256 with a single repeated byte. Both make the STF cheaper to *measure* than
+real data would be: the regular bit prefix is near-ideal for the CPU branch
+predictor, and single-byte roots diverge at byte 0 so `H256` comparisons
+short-circuit immediately. This section rebuilds the identical workload (same V,
+same 8 valid votes, same no-bail / `cells = 9` invariant) but
+
+  * scatters the ⌈V/2⌉ set bits with a fixed Fisher-Yates permutation
+    (`mix64` PRNG) so the inner `aggregation_bits` scan is unpredictable, and
+  * fills every H256 with a high-entropy `mix64`-derived byte pattern
+    (`hashOfNatHE`) — non-zero and injective over the historical index.
+
+The vote count stays exactly ⌈V/2⌉ (< 2/3·V for V ≥ 4) so the fast path is
+preserved and `_real_cells` still returns 9. Measuring this against the M5b
+baseline isolates the data-pattern (branch-prediction + comparison) component
+of the timing — the "optimistic bias" of the synthetic fixture. -/
+
+/-- splitmix64 finalizer — deterministic 64-bit avalanche mix. -/
+@[inline] private def mix64 (x : UInt64) : UInt64 :=
+  let z := x + 0x9E3779B97F4A7C15
+  let z := (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9
+  let z := (z ^^^ (z >>> 27)) * 0x94D049BB133111EB
+  z ^^^ (z >>> 31)
+
+/-- High-entropy H256: each byte is a `mix64` output, with byte 0 forced
+non-zero (so `is_zero` is false) and the last byte set to `k` so distinct
+indices yield distinct roots. -/
+private def hashOfNatHE (k : Nat) : types.H256 :=
+  Array.make 32#usize ((List.range 32).map (fun j =>
+    let raw : UInt8 := (mix64 (UInt64.ofNat ((k + 1) * 32 + j))).toUInt8
+    let byte : UInt8 :=
+      if j == 0 then 1 + (raw % 255)
+      else if j == 31 then UInt8.ofNat (k % 256)
+      else raw
+    u8OfUInt8 byte))
+
+/-- Exactly ⌈n/2⌉ set bits, scattered by a fixed Fisher-Yates shuffle so the
+true/false pattern (scanned in index order) is unpredictable to the branch
+predictor. Deterministic: the `mix64` RNG is seeded only by the index. -/
+private def scatteredBitList (n : Nat) : List Bool := Id.run do
+  let half := (n + 1) / 2
+  let mut perm := (List.range n).toArray
+  let mut i := n
+  while i > 1 do
+    i := i - 1
+    let r := (mix64 (UInt64.ofNat (i + 1))).toNat % (i + 1)
+    let tmp := perm[i]!
+    perm := perm.set! i perm[r]!
+    perm := perm.set! r tmp
+  let mut bits := Array.replicate n false
+  let mut k := 0
+  while k < half do
+    bits := bits.set! perm[k]! true
+    k := k + 1
+  pure bits.toList
+
+private def buildAttBitsScattered (n : Nat) : alloc.vec.Vec Bool :=
+  buildVecFromList (scatteredBitList n) (alloc.vec.Vec.new Bool)
+
+private def buildAttHistoricalHE : alloc.vec.Vec types.H256 :=
+  buildVecFromList ((List.range 13).map hashOfNatHE) (alloc.vec.Vec.new types.H256)
+
+private def buildAttestationReal (n : Nat) (t : Nat) : types.AggregatedAttestation :=
+  let source : types.Checkpoint := { root := hashOfNatHE 0, slot := 0#u64 }
+  let target : types.Checkpoint :=
+    { root := hashOfNatHE t, slot := u64OfUInt64 (UInt64.ofNat t) }
+  { aggregation_bits := buildAttBitsScattered n
+    data := { slot := target.slot, head := target, target := target, source := source } }
+
+private def buildAttAttestationsReal (n : Nat) :
+    alloc.vec.Vec types.AggregatedAttestation :=
+  buildVecFromList (attTargetSlots.map (buildAttestationReal n))
+    (alloc.vec.Vec.new types.AggregatedAttestation)
+
+private def buildBenchStateAttReal (n : UInt64) : types.State :=
+  let finalizedCp : types.Checkpoint := { root := hashOfNatHE 0, slot := 0#u64 }
+  let header12 : types.BlockHeader :=
+    { slot := 12#u64
+      proposer_index := 0#u64
+      parent_root := types.H256.ZERO
+      state_root := types.H256.ZERO
+      body_root := types.H256.ZERO }
+  { config := { genesis_time := 0#u64 }
+    slot := 12#u64
+    latest_block_header := header12
+    latest_justified := finalizedCp
+    latest_finalized := finalizedCp
+    historical_block_hashes := buildAttHistoricalHE
+    justified_slots := alloc.vec.Vec.new Bool
+    validators := buildBenchValidators n.toNat
+    justifications_roots := alloc.vec.Vec.new types.H256
+    justifications_validators := alloc.vec.Vec.new Bool }
+
+private def buildBenchBlockAttReal (n : UInt64) : types.Block :=
+  let proposerRaw : UInt64 := if n = 0 then 0 else 13 % n
+  { slot := 13#u64
+    proposer_index := u64OfUInt64 proposerRaw
+    parent_root := types.H256.ZERO
+    state_root := types.H256.ZERO
+    body := { attestations := buildAttAttestationsReal n.toNat } }
+
+/-- Realistic counterpart to `csf_bench_state_transition_att_run`: scattered
+bits + high-entropy roots, otherwise identical. -/
+@[export csf_bench_state_transition_att_real_run]
+def csfBenchStateTransitionAttRealRun (n _a _seed : UInt64) : UInt8 :=
+  let state := buildBenchStateAttReal n
+  let block := mkConsistentBlock state (buildBenchBlockAttReal n)
+  packStatePipeline (ConsensusLean4.FastPath.stateTransitionFast state block)
+
+@[export csf_bench_state_transition_att_real_buildonly]
+def csfBenchStateTransitionAttRealBuildOnly (n _a _seed : UInt64) : UInt8 :=
+  let state := buildBenchStateAttReal n
+  let block := mkConsistentBlock state (buildBenchBlockAttReal n)
+  consumeState state ^^^ consumeBlock block
+
+@[export csf_bench_state_transition_att_real_cells]
+def csfBenchStateTransitionAttRealCells (n : UInt64) : UInt8 :=
+  let state := buildBenchStateAttReal n
+  let block := mkConsistentBlock state (buildBenchBlockAttReal n)
+  match ConsensusLean4.FastPath.stateTransitionFast state block with
+  | .ok (_, s) => (min s.justifications_roots.val.length 255).toUInt8
+  | _          => 0

--- a/docs/assets/bench-realism-abs.svg
+++ b/docs/assets/bench-realism-abs.svg
@@ -1,0 +1,1800 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="526.2975pt" height="303.810375pt" viewBox="0 0 526.2975 303.810375" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-26T09:51:48.226026</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 303.810375 
+L 526.2975 303.810375 
+L 526.2975 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 62.26875 266.254125 
+L 464.02875 266.254125 
+L 464.02875 22.318125 
+L 62.26875 22.318125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 80.530568 266.254125 
+L 80.530568 22.318125 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mf90f236e98" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mf90f236e98" x="80.530568" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 4 -->
+      <g transform="translate(77.349318 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 117.054205 266.254125 
+L 117.054205 22.318125 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mf90f236e98" x="117.054205" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 8 -->
+      <g transform="translate(113.872955 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 226.625114 266.254125 
+L 226.625114 22.318125 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mf90f236e98" x="226.625114" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 64 -->
+      <g transform="translate(220.262614 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 336.196023 266.254125 
+L 336.196023 22.318125 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mf90f236e98" x="336.196023" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 512 -->
+      <g transform="translate(326.652273 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 445.766932 266.254125 
+L 445.766932 22.318125 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mf90f236e98" x="445.766932" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4096 -->
+      <g transform="translate(433.041932 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- validators  V  (leanSpec range, V ≤ 4096) -->
+     <g transform="translate(159.058906 294.530687) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2264" d="M 4684 3175 
+L 1684 2309 
+L 4684 1453 
+L 4684 897 
+L 678 2047 
+L 678 2578 
+L 4684 3725 
+L 4684 3175 
+z
+M 678 531 
+L 4684 531 
+L 4684 0 
+L 678 0 
+L 678 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(148.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(176.025391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(239.501953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(300.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(339.990234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(401.171875 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(442.285156 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(494.384766 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(526.171875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(557.958984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(626.367188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(658.154297 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(689.941406 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(728.955078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(756.738281 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(818.261719 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(879.541016 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(942.919922 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1006.396484 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1069.873047 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1131.396484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1186.376953 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1218.164062 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1259.277344 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1320.556641 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1383.935547 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1447.412109 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1508.935547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1540.722656 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1572.509766 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1640.917969 0)"/>
+      <use xlink:href="#DejaVuSans-2264" transform="translate(1672.705078 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1756.494141 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(1788.28125 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(1851.904297 0)"/>
+      <use xlink:href="#DejaVuSans-39" transform="translate(1915.527344 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(1979.150391 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2042.773438 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path d="M 62.26875 220.018867 
+L 464.02875 220.018867 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m4200388f74" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m4200388f74" x="62.26875" y="220.018867" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(37.66875 223.818085) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path d="M 62.26875 108.847082 
+L 464.02875 108.847082 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m4200388f74" x="62.26875" y="108.847082" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(37.66875 112.646301) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 62.26875 264.258567 
+L 464.02875 264.258567 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="mae9d17dd83" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="264.258567" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 62.26875 253.484908 
+L 464.02875 253.484908 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="253.484908" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 62.26875 244.682188 
+L 464.02875 244.682188 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="244.682188" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path d="M 62.26875 237.239594 
+L 464.02875 237.239594 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="237.239594" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_23">
+      <path d="M 62.26875 230.792526 
+L 464.02875 230.792526 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="230.792526" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_25">
+      <path d="M 62.26875 225.105808 
+L 464.02875 225.105808 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="225.105808" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_27">
+      <path d="M 62.26875 186.552825 
+L 464.02875 186.552825 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="186.552825" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_29">
+      <path d="M 62.26875 166.976445 
+L 464.02875 166.976445 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="166.976445" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_31">
+      <path d="M 62.26875 153.086783 
+L 464.02875 153.086783 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="153.086783" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_33">
+      <path d="M 62.26875 142.313124 
+L 464.02875 142.313124 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="142.313124" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_35">
+      <path d="M 62.26875 133.510403 
+L 464.02875 133.510403 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="133.510403" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_37">
+      <path d="M 62.26875 126.067809 
+L 464.02875 126.067809 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="126.067809" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_39">
+      <path d="M 62.26875 119.620741 
+L 464.02875 119.620741 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="119.620741" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_41">
+      <path d="M 62.26875 113.934024 
+L 464.02875 113.934024 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="113.934024" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_43">
+      <path d="M 62.26875 75.38104 
+L 464.02875 75.38104 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="75.38104" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_45">
+      <path d="M 62.26875 55.804661 
+L 464.02875 55.804661 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="55.804661" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_47">
+      <path d="M 62.26875 41.914998 
+L 464.02875 41.914998 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="41.914998" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_49">
+      <path d="M 62.26875 31.141339 
+L 464.02875 31.141339 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="31.141339" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_51">
+      <path d="M 62.26875 22.338619 
+L 464.02875 22.338619 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#mae9d17dd83" x="62.26875" y="22.338619" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_9">
+     <!-- STF pipeline time  (µs, run − buildonly median) -->
+     <g transform="translate(31.589062 262.710344) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(124.560547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(182.080078 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.867188 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(277.34375 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(305.126953 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(368.603516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(430.126953 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(457.910156 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(485.693359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(549.072266 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(610.595703 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(642.382812 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(681.591797 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(709.375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(806.787109 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(868.310547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(900.097656 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(931.884766 0)"/>
+      <use xlink:href="#DejaVuSans-b5" transform="translate(970.898438 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1034.521484 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1086.621094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1118.408203 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1150.195312 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1191.308594 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1254.6875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1318.066406 0)"/>
+      <use xlink:href="#DejaVuSans-2212" transform="translate(1349.853516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1433.642578 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(1465.429688 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1528.90625 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1592.285156 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1620.068359 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1647.851562 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1711.328125 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1772.509766 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1835.888672 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(1863.671875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1922.851562 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1954.638672 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2052.050781 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(2113.574219 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(2177.050781 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2204.833984 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(2266.113281 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2329.492188 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 80.530568 255.166125 
+L 80.530568 249.28721 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 117.054205 253.551099 
+L 117.054205 247.544363 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 226.625114 216.260548 
+L 226.625114 213.245963 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 336.196023 138.391098 
+L 336.196023 130.553303 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 445.766932 37.912298 
+L 445.766932 33.406125 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+   </g>
+   <g id="line2d_53">
+    <defs>
+     <path id="m062a2f57bc" d="M 3 0 
+L -3 -0 
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#pff67067ba7)">
+     <use xlink:href="#m062a2f57bc" x="80.530568" y="255.166125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m062a2f57bc" x="117.054205" y="253.551099" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m062a2f57bc" x="226.625114" y="216.260548" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m062a2f57bc" x="336.196023" y="138.391098" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m062a2f57bc" x="445.766932" y="37.912298" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_54">
+    <g clip-path="url(#pff67067ba7)">
+     <use xlink:href="#m062a2f57bc" x="80.530568" y="249.28721" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m062a2f57bc" x="117.054205" y="247.544363" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m062a2f57bc" x="226.625114" y="213.245963" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m062a2f57bc" x="336.196023" y="130.553303" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m062a2f57bc" x="445.766932" y="33.406125" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 80.530568 254.085384 
+L 80.530568 248.263237 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 117.054205 251.566683 
+L 117.054205 247.953283 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 226.625114 216.169873 
+L 226.625114 210.832351 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 336.196023 137.525908 
+L 336.196023 133.690571 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 445.766932 40.209893 
+L 445.766932 36.997947 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+   </g>
+   <g id="line2d_55">
+    <defs>
+     <path id="m30cea3fd9c" d="M 3 0 
+L -3 -0 
+" style="stroke: #d62728"/>
+    </defs>
+    <g clip-path="url(#pff67067ba7)">
+     <use xlink:href="#m30cea3fd9c" x="80.530568" y="254.085384" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m30cea3fd9c" x="117.054205" y="251.566683" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m30cea3fd9c" x="226.625114" y="216.169873" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m30cea3fd9c" x="336.196023" y="137.525908" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m30cea3fd9c" x="445.766932" y="40.209893" style="fill: #d62728; stroke: #d62728"/>
+    </g>
+   </g>
+   <g id="line2d_56">
+    <g clip-path="url(#pff67067ba7)">
+     <use xlink:href="#m30cea3fd9c" x="80.530568" y="248.263237" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m30cea3fd9c" x="117.054205" y="247.953283" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m30cea3fd9c" x="226.625114" y="210.832351" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m30cea3fd9c" x="336.196023" y="133.690571" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m30cea3fd9c" x="445.766932" y="36.997947" style="fill: #d62728; stroke: #d62728"/>
+    </g>
+   </g>
+   <g id="line2d_57">
+    <path d="M 80.530568 254.669269 
+L 117.054205 249.625974 
+L 226.625114 214.242151 
+L 336.196023 134.343752 
+L 445.766932 36.030983 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6; stroke-linecap: square"/>
+    <defs>
+     <path id="m9e1825dcd8" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#pff67067ba7)">
+     <use xlink:href="#m9e1825dcd8" x="80.530568" y="254.669269" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m9e1825dcd8" x="117.054205" y="249.625974" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m9e1825dcd8" x="226.625114" y="214.242151" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m9e1825dcd8" x="336.196023" y="134.343752" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m9e1825dcd8" x="445.766932" y="36.030983" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_58">
+    <path d="M 80.530568 251.277592 
+L 117.054205 249.524766 
+L 226.625114 213.576473 
+L 336.196023 134.886704 
+L 445.766932 38.111638 
+" clip-path="url(#pff67067ba7)" style="fill: none; stroke: #d62728; stroke-width: 1.6; stroke-linecap: square"/>
+    <defs>
+     <path id="mfe2dc4e87e" d="M -3 3 
+L 3 3 
+L 3 -3 
+L -3 -3 
+z
+" style="stroke: #d62728; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#pff67067ba7)">
+     <use xlink:href="#mfe2dc4e87e" x="80.530568" y="251.277592" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2dc4e87e" x="117.054205" y="249.524766" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2dc4e87e" x="226.625114" y="213.576473" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2dc4e87e" x="336.196023" y="134.886704" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2dc4e87e" x="445.766932" y="38.111638" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 62.26875 266.254125 
+L 62.26875 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 464.02875 266.254125 
+L 464.02875 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 62.26875 266.254125 
+L 464.02875 266.254125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 62.26875 22.318125 
+L 464.02875 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_10">
+    <!-- 488 µs -->
+    <g style="fill: #555555" transform="translate(66.995568 268.669269) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- 542 µs -->
+    <g style="fill: #555555" transform="translate(103.519205 263.625974) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <!-- 1.13 ms -->
+    <g style="fill: #555555" transform="translate(210.467614 228.242151) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(254.443359 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- 5.90 ms -->
+    <g style="fill: #555555" transform="translate(320.038523 148.343752) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(254.443359 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(351.855469 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- 45.18 ms -->
+    <g style="fill: #555555" transform="translate(427.064432 50.030983) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(318.066406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(415.478516 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- state_transition processing time vs validators  (4-run median, error bars = min..max) -->
+    <g transform="translate(7.2 16.318125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(811.523438 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(913.863281 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(975.044922 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1030.025391 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1091.548828 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1143.648438 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1195.748047 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1223.53125 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1286.910156 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1350.386719 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1382.173828 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1421.382812 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1449.166016 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1546.578125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1608.101562 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1639.888672 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1699.068359 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1751.167969 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1782.955078 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1842.134766 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1903.414062 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1931.197266 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1958.980469 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2022.457031 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2083.736328 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2122.945312 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2184.126953 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2225.240234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2277.339844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2309.126953 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2340.914062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(2379.927734 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(2443.550781 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2479.634766 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(2520.748047 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2584.126953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2647.505859 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2679.292969 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2776.705078 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2838.228516 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2901.705078 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2929.488281 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2990.767578 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(3054.146484 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3085.933594 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3117.720703 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3179.244141 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3218.607422 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3257.470703 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3318.652344 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3359.765625 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(3391.552734 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3455.029297 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3516.308594 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3557.421875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3609.521484 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(3641.308594 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3725.097656 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3756.884766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3854.296875 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3882.080078 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3945.458984 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3977.246094 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(4009.033203 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(4106.445312 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(4167.724609 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(4226.904297 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 67.86875 52.203125 
+L 179.82125 52.203125 
+Q 181.42125 52.203125 181.42125 50.603125 
+L 181.42125 27.918125 
+Q 181.42125 26.318125 179.82125 26.318125 
+L 67.86875 26.318125 
+Q 66.26875 26.318125 66.26875 27.918125 
+L 66.26875 50.603125 
+Q 66.26875 52.203125 67.86875 52.203125 
+z
+" style="fill: #ffffff; opacity: 0.9; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="LineCollection_3">
+     <path d="M 77.46875 36.796875 
+L 77.46875 28.796875 
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    </g>
+    <g id="line2d_59">
+     <g>
+      <use xlink:href="#m062a2f57bc" x="77.46875" y="36.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="line2d_60">
+     <g>
+      <use xlink:href="#m062a2f57bc" x="77.46875" y="28.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="line2d_61">
+     <path d="M 69.46875 32.796875 
+L 85.46875 32.796875 
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.6; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_62">
+     <g>
+      <use xlink:href="#m9e1825dcd8" x="77.46875" y="32.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- baseline-pattern data -->
+     <g transform="translate(91.86875 35.596875) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-62"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(124.755859 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(176.855469 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.378906 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.162109 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(293.945312 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(357.324219 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(418.847656 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(454.931641 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(518.408203 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(579.6875 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(618.896484 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(658.105469 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(719.628906 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(758.992188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(822.371094 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(854.158203 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(917.634766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(978.914062 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1018.123047 0)"/>
+     </g>
+    </g>
+    <g id="LineCollection_4">
+     <path d="M 77.46875 48.539375 
+L 77.46875 40.539375 
+" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    </g>
+    <g id="line2d_63">
+     <g>
+      <use xlink:href="#m30cea3fd9c" x="77.46875" y="48.539375" style="fill: #d62728; stroke: #d62728"/>
+     </g>
+    </g>
+    <g id="line2d_64">
+     <g>
+      <use xlink:href="#m30cea3fd9c" x="77.46875" y="40.539375" style="fill: #d62728; stroke: #d62728"/>
+     </g>
+    </g>
+    <g id="line2d_65">
+     <path d="M 69.46875 44.539375 
+L 85.46875 44.539375 
+" style="fill: none; stroke: #d62728; stroke-width: 1.6; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_66">
+     <g>
+      <use xlink:href="#mfe2dc4e87e" x="77.46875" y="44.539375" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- realistic-pattern data -->
+     <g transform="translate(91.86875 47.339375) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-72"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(38.863281 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(100.386719 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(161.666016 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(189.449219 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(217.232422 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(269.332031 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(308.541016 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(336.324219 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(391.304688 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(427.388672 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(490.865234 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(552.144531 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(591.353516 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(630.5625 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(692.085938 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(731.449219 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(794.828125 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(826.615234 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(890.091797 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(951.371094 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(990.580078 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pff67067ba7">
+   <rect x="62.26875" y="22.318125" width="401.76" height="243.936"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/bench-realism-clean.svg
+++ b/docs/assets/bench-realism-clean.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-26T10:49:28.855548</dc:date>
+    <dc:date>2026-06-26T11:40:14.137155</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 80.530568 266.254125 
 L 80.530568 22.318125 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m1b1015ca94" d="M 0 0 
+       <path id="m011437414a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1b1015ca94" x="80.530568" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m011437414a" x="80.530568" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -62,11 +62,11 @@ L 0 3.5
      <g id="line2d_3">
       <path d="M 117.054205 266.254125 
 L 117.054205 22.318125 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1b1015ca94" x="117.054205" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m011437414a" x="117.054205" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -77,11 +77,11 @@ L 117.054205 22.318125
      <g id="line2d_5">
       <path d="M 226.625114 266.254125 
 L 226.625114 22.318125 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m1b1015ca94" x="226.625114" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m011437414a" x="226.625114" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -92,11 +92,11 @@ L 226.625114 22.318125
      <g id="line2d_7">
       <path d="M 336.196023 266.254125 
 L 336.196023 22.318125 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1b1015ca94" x="336.196023" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m011437414a" x="336.196023" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -107,11 +107,11 @@ L 336.196023 22.318125
      <g id="line2d_9">
       <path d="M 445.766932 266.254125 
 L 445.766932 22.318125 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1b1015ca94" x="445.766932" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m011437414a" x="445.766932" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -125,23 +125,23 @@ L 445.766932 22.318125
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_11">
-      <path d="M 62.26875 217.907098 
-L 464.02875 217.907098 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 219.464806 
+L 464.02875 219.464806 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <defs>
-       <path id="m37597691d2" d="M 0 0 
+       <path id="m1de25f7bcb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m37597691d2" x="62.26875" y="217.907098" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1de25f7bcb" x="62.26875" y="219.464806" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(37.66875 221.706316)">
+      <g transform="translate(37.66875 223.264025)">
        <text>
         <tspan x="0" y="-0.976562" style="font-size: 10px; font-family: 'DejaVu Sans'">1</tspan>
         <tspan x="6.362305" y="-0.976562" style="font-size: 10px; font-family: 'DejaVu Sans'">0</tspan>
@@ -152,18 +152,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_13">
-      <path d="M 62.26875 105.570084 
-L 464.02875 105.570084 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 106.179351 
+L 464.02875 106.179351 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m37597691d2" x="62.26875" y="105.570084" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1de25f7bcb" x="62.26875" y="106.179351" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(37.66875 109.369303)">
+      <g transform="translate(37.66875 109.97857)">
        <text>
         <tspan x="0" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">1</tspan>
         <tspan x="6.362305" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">0</tspan>
@@ -174,222 +174,222 @@ L 464.02875 105.570084
     </g>
     <g id="ytick_3">
      <g id="line2d_15">
-      <path d="M 62.26875 262.61049 
-L 464.02875 262.61049 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 264.545622 
+L 464.02875 264.545622 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mb6ab6a026e" d="M 0 0 
+       <path id="m5d82798307" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="262.61049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="264.545622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_17">
-      <path d="M 62.26875 251.723908 
-L 464.02875 251.723908 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 253.567127 
+L 464.02875 253.567127 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="251.723908" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="253.567127" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_19">
-      <path d="M 62.26875 242.828924 
-L 464.02875 242.828924 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 244.597043 
+L 464.02875 244.597043 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="242.828924" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="244.597043" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_21">
-      <path d="M 62.26875 235.308321 
-L 464.02875 235.308321 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 237.012946 
+L 464.02875 237.012946 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="235.308321" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="237.012946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_23">
-      <path d="M 62.26875 228.793679 
-L 464.02875 228.793679 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 230.443301 
+L 464.02875 230.443301 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="228.793679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="230.443301" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_25">
-      <path d="M 62.26875 223.047358 
-L 464.02875 223.047358 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 224.648465 
+L 464.02875 224.648465 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="223.047358" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="224.648465" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_27">
-      <path d="M 62.26875 184.090287 
-L 464.02875 184.090287 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 185.362486 
+L 464.02875 185.362486 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="184.090287" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="185.362486" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_29">
-      <path d="M 62.26875 164.308721 
-L 464.02875 164.308721 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 165.413908 
+L 464.02875 165.413908 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="164.308721" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="165.413908" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_31">
-      <path d="M 62.26875 150.273476 
-L 464.02875 150.273476 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 151.260166 
+L 464.02875 151.260166 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="150.273476" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="151.260166" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_33">
-      <path d="M 62.26875 139.386895 
-L 464.02875 139.386895 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 140.281671 
+L 464.02875 140.281671 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="139.386895" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="140.281671" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_35">
-      <path d="M 62.26875 130.49191 
-L 464.02875 130.49191 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 131.311588 
+L 464.02875 131.311588 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="130.49191" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="131.311588" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_37">
-      <path d="M 62.26875 122.971307 
-L 464.02875 122.971307 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 123.72749 
+L 464.02875 123.72749 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="122.971307" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="123.72749" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_39">
-      <path d="M 62.26875 116.456665 
-L 464.02875 116.456665 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 117.157846 
+L 464.02875 117.157846 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="116.456665" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="117.157846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_41">
-      <path d="M 62.26875 110.710344 
-L 464.02875 110.710344 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 111.363009 
+L 464.02875 111.363009 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="110.710344" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="111.363009" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_43">
-      <path d="M 62.26875 71.753273 
-L 464.02875 71.753273 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 72.077031 
+L 464.02875 72.077031 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="71.753273" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="72.077031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_45">
-      <path d="M 62.26875 51.971707 
-L 464.02875 51.971707 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 52.128453 
+L 464.02875 52.128453 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="51.971707" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="52.128453" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_47">
-      <path d="M 62.26875 37.936462 
-L 464.02875 37.936462 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 37.974711 
+L 464.02875 37.974711 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="37.936462" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="37.974711" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_49">
-      <path d="M 62.26875 27.049881 
-L 464.02875 27.049881 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 62.26875 26.996216 
+L 464.02875 26.996216 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mb6ab6a026e" x="62.26875" y="27.049881" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5d82798307" x="62.26875" y="26.996216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -399,93 +399,53 @@ L 464.02875 27.049881
    </g>
    <g id="LineCollection_1">
     <path d="M 80.530568 255.166125 
-L 80.530568 251.674658 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
-    <path d="M 117.054205 252.241152 
-L 117.054205 247.350096 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
-    <path d="M 226.625114 213.35995 
-L 226.625114 211.1774 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
-    <path d="M 336.196023 132.391279 
-L 336.196023 131.608369 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
-    <path d="M 445.766932 36.302104 
-L 445.766932 35.428423 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+L 80.530568 252.862546 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 117.054205 253.248953 
+L 117.054205 250.664985 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 226.625114 211.140958 
+L 226.625114 209.616368 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 336.196023 133.080005 
+L 336.196023 130.503029 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 445.766932 35.690841 
+L 445.766932 33.406125 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
    </g>
    <g id="line2d_51">
     <defs>
-     <path id="m5f794adcc7" d="M 3 0 
+     <path id="m2ac1196d00" d="M 3 0 
 L -3 -0 
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p99227515fb)">
-     <use xlink:href="#m5f794adcc7" x="80.530568" y="255.166125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5f794adcc7" x="117.054205" y="252.241152" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5f794adcc7" x="226.625114" y="213.35995" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5f794adcc7" x="336.196023" y="132.391279" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5f794adcc7" x="445.766932" y="36.302104" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pe7b8a5d8c1)">
+     <use xlink:href="#m2ac1196d00" x="80.530568" y="255.166125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2ac1196d00" x="117.054205" y="253.248953" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2ac1196d00" x="226.625114" y="211.140958" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2ac1196d00" x="336.196023" y="133.080005" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2ac1196d00" x="445.766932" y="35.690841" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_52">
-    <g clip-path="url(#p99227515fb)">
-     <use xlink:href="#m5f794adcc7" x="80.530568" y="251.674658" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5f794adcc7" x="117.054205" y="247.350096" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5f794adcc7" x="226.625114" y="211.1774" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5f794adcc7" x="336.196023" y="131.608369" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m5f794adcc7" x="445.766932" y="35.428423" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pe7b8a5d8c1)">
+     <use xlink:href="#m2ac1196d00" x="80.530568" y="252.862546" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2ac1196d00" x="117.054205" y="250.664985" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2ac1196d00" x="226.625114" y="209.616368" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2ac1196d00" x="336.196023" y="130.503029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m2ac1196d00" x="445.766932" y="33.406125" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
-   </g>
-   <g id="LineCollection_2">
-    <path d="M 80.530568 253.30952 
-L 80.530568 251.025227 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
-    <path d="M 117.054205 251.408399 
-L 117.054205 248.846064 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
-    <path d="M 226.625114 209.652937 
-L 226.625114 208.141112 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
-    <path d="M 336.196023 132.245521 
-L 336.196023 129.69012 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
-    <path d="M 445.766932 35.671713 
-L 445.766932 33.406125 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
    </g>
    <g id="line2d_53">
+    <path d="M 80.530568 254.311006 
+L 117.054205 252.221884 
+L 226.625114 210.635593 
+L 336.196023 130.93715 
+L 445.766932 35.616539 
+" clip-path="url(#pe7b8a5d8c1)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6; stroke-linecap: square"/>
     <defs>
-     <path id="m946e2561e8" d="M 3 0 
-L -3 -0 
-" style="stroke: #d62728"/>
-    </defs>
-    <g clip-path="url(#p99227515fb)">
-     <use xlink:href="#m946e2561e8" x="80.530568" y="253.30952" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m946e2561e8" x="117.054205" y="251.408399" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m946e2561e8" x="226.625114" y="209.652937" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m946e2561e8" x="336.196023" y="132.245521" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m946e2561e8" x="445.766932" y="35.671713" style="fill: #d62728; stroke: #d62728"/>
-    </g>
-   </g>
-   <g id="line2d_54">
-    <g clip-path="url(#p99227515fb)">
-     <use xlink:href="#m946e2561e8" x="80.530568" y="251.025227" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m946e2561e8" x="117.054205" y="248.846064" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m946e2561e8" x="226.625114" y="208.141112" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m946e2561e8" x="336.196023" y="129.69012" style="fill: #d62728; stroke: #d62728"/>
-     <use xlink:href="#m946e2561e8" x="445.766932" y="33.406125" style="fill: #d62728; stroke: #d62728"/>
-    </g>
-   </g>
-   <g id="line2d_55">
-    <path d="M 80.530568 254.797172 
-L 117.054205 249.453624 
-L 226.625114 212.787221 
-L 336.196023 132.262213 
-L 445.766932 35.485484 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6; stroke-linecap: square"/>
-    <defs>
-     <path id="mcc5b205df2" d="M 0 3 
+     <path id="mddb1ceded9" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -497,35 +457,12 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p99227515fb)">
-     <use xlink:href="#mcc5b205df2" x="80.530568" y="254.797172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcc5b205df2" x="117.054205" y="249.453624" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcc5b205df2" x="226.625114" y="212.787221" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcc5b205df2" x="336.196023" y="132.262213" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#mcc5b205df2" x="445.766932" y="35.485484" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
-   </g>
-   <g id="line2d_56">
-    <path d="M 80.530568 252.46156 
-L 117.054205 250.389928 
-L 226.625114 209.151804 
-L 336.196023 130.120607 
-L 445.766932 35.598033 
-" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6; stroke-linecap: square"/>
-    <defs>
-     <path id="m5166d3245b" d="M -3 3 
-L 3 3 
-L 3 -3 
-L -3 -3 
-z
-" style="stroke: #d62728; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#p99227515fb)">
-     <use xlink:href="#m5166d3245b" x="80.530568" y="252.46156" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m5166d3245b" x="117.054205" y="250.389928" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m5166d3245b" x="226.625114" y="209.151804" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m5166d3245b" x="336.196023" y="130.120607" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m5166d3245b" x="445.766932" y="35.598033" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe7b8a5d8c1)">
+     <use xlink:href="#mddb1ceded9" x="80.530568" y="254.311006" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mddb1ceded9" x="117.054205" y="252.221884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mddb1ceded9" x="226.625114" y="210.635593" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mddb1ceded9" x="336.196023" y="130.93715" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mddb1ceded9" x="445.766932" y="35.616539" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="patch_3">
@@ -549,98 +486,27 @@ L 464.02875 22.318125
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_10">
-    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="80.530568" y="268.797172" transform="rotate(-0 80.530568 268.797172)">469 µs</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="80.530568" y="268.311006" transform="rotate(-0 80.530568 268.311006)">492 µs</text>
    </g>
    <g id="text_11">
-    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="117.054205" y="263.453624" transform="rotate(-0 117.054205 263.453624)">524 µs</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="117.054205" y="266.221884" transform="rotate(-0 117.054205 266.221884)">514 µs</text>
    </g>
    <g id="text_12">
-    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="226.625114" y="226.787221" transform="rotate(-0 226.625114 226.787221)">1.11 ms</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="226.625114" y="224.635593" transform="rotate(-0 226.625114 224.635593)">1.20 ms</text>
    </g>
    <g id="text_13">
-    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="336.196023" y="146.262213" transform="rotate(-0 336.196023 146.262213)">5.79 ms</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="336.196023" y="144.93715" transform="rotate(-0 336.196023 144.93715)">6.05 ms</text>
    </g>
    <g id="text_14">
-    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="445.766932" y="49.485484" transform="rotate(-0 445.766932 49.485484)">42.06 ms</text>
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="445.766932" y="49.616539" transform="rotate(-0 445.766932 49.616539)">41.96 ms</text>
    </g>
    <g id="text_15">
     <text style="font-size: 12px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="263.14875" y="16.318125" transform="rotate(-0 263.14875 16.318125)">state_transition processing time vs validators  (3-run median, error bars = min..max)</text>
    </g>
-   <g id="legend_1">
-    <g id="patch_7">
-     <path d="M 67.86875 52.203125 
-L 126.9775 52.203125 
-Q 128.5775 52.203125 128.5775 50.603125 
-L 128.5775 27.918125 
-Q 128.5775 26.318125 126.9775 26.318125 
-L 67.86875 26.318125 
-Q 66.26875 26.318125 66.26875 27.918125 
-L 66.26875 50.603125 
-Q 66.26875 52.203125 67.86875 52.203125 
-z
-" style="fill: #ffffff; opacity: 0.9; stroke: #cccccc; stroke-linejoin: miter"/>
-    </g>
-    <g id="LineCollection_3">
-     <path d="M 77.46875 36.796875 
-L 77.46875 28.796875 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
-    </g>
-    <g id="line2d_57">
-     <g>
-      <use xlink:href="#m5f794adcc7" x="77.46875" y="36.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="line2d_58">
-     <g>
-      <use xlink:href="#m5f794adcc7" x="77.46875" y="28.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="line2d_59">
-     <path d="M 69.46875 32.796875 
-L 85.46875 32.796875 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.6; stroke-linecap: square"/>
-    </g>
-    <g id="line2d_60">
-     <g>
-      <use xlink:href="#mcc5b205df2" x="77.46875" y="32.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     </g>
-    </g>
-    <g id="text_16">
-     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="91.86875" y="35.596875" transform="rotate(-0 91.86875 35.596875)">baseline</text>
-    </g>
-    <g id="LineCollection_4">
-     <path d="M 77.46875 48.539375 
-L 77.46875 40.539375 
-" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
-    </g>
-    <g id="line2d_61">
-     <g>
-      <use xlink:href="#m946e2561e8" x="77.46875" y="48.539375" style="fill: #d62728; stroke: #d62728"/>
-     </g>
-    </g>
-    <g id="line2d_62">
-     <g>
-      <use xlink:href="#m946e2561e8" x="77.46875" y="40.539375" style="fill: #d62728; stroke: #d62728"/>
-     </g>
-    </g>
-    <g id="line2d_63">
-     <path d="M 69.46875 44.539375 
-L 85.46875 44.539375 
-" style="fill: none; stroke: #d62728; stroke-width: 1.6; stroke-linecap: square"/>
-    </g>
-    <g id="line2d_64">
-     <g>
-      <use xlink:href="#m5166d3245b" x="77.46875" y="44.539375" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_17">
-     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="91.86875" y="47.339375" transform="rotate(-0 91.86875 47.339375)">variant</text>
-    </g>
-   </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p99227515fb">
+  <clipPath id="pe7b8a5d8c1">
    <rect x="62.26875" y="22.318125" width="401.76" height="243.936"/>
   </clipPath>
  </defs>

--- a/docs/assets/bench-realism-clean.svg
+++ b/docs/assets/bench-realism-clean.svg
@@ -1,0 +1,647 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="526.2975pt" height="303.810375pt" viewBox="0 0 526.2975 303.810375" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-26T10:49:28.855548</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7+dfsg1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 303.810375 
+L 526.2975 303.810375 
+L 526.2975 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 62.26875 266.254125 
+L 464.02875 266.254125 
+L 464.02875 22.318125 
+L 62.26875 22.318125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 80.530568 266.254125 
+L 80.530568 22.318125 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m1b1015ca94" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1b1015ca94" x="80.530568" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="80.530568" y="280.852562" transform="rotate(-0 80.530568 280.852562)">4</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 117.054205 266.254125 
+L 117.054205 22.318125 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m1b1015ca94" x="117.054205" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="117.054205" y="280.852562" transform="rotate(-0 117.054205 280.852562)">8</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 226.625114 266.254125 
+L 226.625114 22.318125 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m1b1015ca94" x="226.625114" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="226.625114" y="280.852562" transform="rotate(-0 226.625114 280.852562)">64</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 336.196023 266.254125 
+L 336.196023 22.318125 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m1b1015ca94" x="336.196023" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="336.196023" y="280.852562" transform="rotate(-0 336.196023 280.852562)">512</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 445.766932 266.254125 
+L 445.766932 22.318125 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m1b1015ca94" x="445.766932" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="445.766932" y="280.852562" transform="rotate(-0 445.766932 280.852562)">4096</text>
+     </g>
+    </g>
+    <g id="text_6">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="263.14875" y="294.530687" transform="rotate(-0 263.14875 294.530687)">validators  V  (leanSpec range, V ≤ 4096)</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path d="M 62.26875 217.907098 
+L 464.02875 217.907098 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m37597691d2" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m37597691d2" x="62.26875" y="217.907098" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(37.66875 221.706316)">
+       <text>
+        <tspan x="0" y="-0.976562" style="font-size: 10px; font-family: 'DejaVu Sans'">1</tspan>
+        <tspan x="6.362305" y="-0.976562" style="font-size: 10px; font-family: 'DejaVu Sans'">0</tspan>
+        <tspan x="12.820312" y="-4.804688" style="font-size: 7px; font-family: 'DejaVu Sans'">3</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path d="M 62.26875 105.570084 
+L 464.02875 105.570084 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m37597691d2" x="62.26875" y="105.570084" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(37.66875 109.369303)">
+       <text>
+        <tspan x="0" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">1</tspan>
+        <tspan x="6.362305" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'">0</tspan>
+        <tspan x="12.820312" y="-3.892188" style="font-size: 7px; font-family: 'DejaVu Sans'">4</tspan>
+       </text>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 62.26875 262.61049 
+L 464.02875 262.61049 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="mb6ab6a026e" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="262.61049" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 62.26875 251.723908 
+L 464.02875 251.723908 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="251.723908" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 62.26875 242.828924 
+L 464.02875 242.828924 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="242.828924" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path d="M 62.26875 235.308321 
+L 464.02875 235.308321 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="235.308321" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_23">
+      <path d="M 62.26875 228.793679 
+L 464.02875 228.793679 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="228.793679" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_25">
+      <path d="M 62.26875 223.047358 
+L 464.02875 223.047358 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="223.047358" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_27">
+      <path d="M 62.26875 184.090287 
+L 464.02875 184.090287 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="184.090287" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_29">
+      <path d="M 62.26875 164.308721 
+L 464.02875 164.308721 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="164.308721" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_31">
+      <path d="M 62.26875 150.273476 
+L 464.02875 150.273476 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="150.273476" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_33">
+      <path d="M 62.26875 139.386895 
+L 464.02875 139.386895 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="139.386895" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_35">
+      <path d="M 62.26875 130.49191 
+L 464.02875 130.49191 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="130.49191" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_37">
+      <path d="M 62.26875 122.971307 
+L 464.02875 122.971307 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="122.971307" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_39">
+      <path d="M 62.26875 116.456665 
+L 464.02875 116.456665 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="116.456665" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_41">
+      <path d="M 62.26875 110.710344 
+L 464.02875 110.710344 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="110.710344" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_43">
+      <path d="M 62.26875 71.753273 
+L 464.02875 71.753273 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="71.753273" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_45">
+      <path d="M 62.26875 51.971707 
+L 464.02875 51.971707 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="51.971707" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_47">
+      <path d="M 62.26875 37.936462 
+L 464.02875 37.936462 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="37.936462" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_49">
+      <path d="M 62.26875 27.049881 
+L 464.02875 27.049881 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#mb6ab6a026e" x="62.26875" y="27.049881" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_9">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="31.589062" y="144.286125" transform="rotate(-90 31.589062 144.286125)">STF pipeline time  (µs, run − buildonly median)</text>
+    </g>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 80.530568 255.166125 
+L 80.530568 251.674658 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 117.054205 252.241152 
+L 117.054205 247.350096 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 226.625114 213.35995 
+L 226.625114 211.1774 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 336.196023 132.391279 
+L 336.196023 131.608369 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 445.766932 36.302104 
+L 445.766932 35.428423 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+   </g>
+   <g id="line2d_51">
+    <defs>
+     <path id="m5f794adcc7" d="M 3 0 
+L -3 -0 
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p99227515fb)">
+     <use xlink:href="#m5f794adcc7" x="80.530568" y="255.166125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5f794adcc7" x="117.054205" y="252.241152" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5f794adcc7" x="226.625114" y="213.35995" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5f794adcc7" x="336.196023" y="132.391279" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5f794adcc7" x="445.766932" y="36.302104" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_52">
+    <g clip-path="url(#p99227515fb)">
+     <use xlink:href="#m5f794adcc7" x="80.530568" y="251.674658" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5f794adcc7" x="117.054205" y="247.350096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5f794adcc7" x="226.625114" y="211.1774" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5f794adcc7" x="336.196023" y="131.608369" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m5f794adcc7" x="445.766932" y="35.428423" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 80.530568 253.30952 
+L 80.530568 251.025227 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 117.054205 251.408399 
+L 117.054205 248.846064 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 226.625114 209.652937 
+L 226.625114 208.141112 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 336.196023 132.245521 
+L 336.196023 129.69012 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 445.766932 35.671713 
+L 445.766932 33.406125 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+   </g>
+   <g id="line2d_53">
+    <defs>
+     <path id="m946e2561e8" d="M 3 0 
+L -3 -0 
+" style="stroke: #d62728"/>
+    </defs>
+    <g clip-path="url(#p99227515fb)">
+     <use xlink:href="#m946e2561e8" x="80.530568" y="253.30952" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m946e2561e8" x="117.054205" y="251.408399" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m946e2561e8" x="226.625114" y="209.652937" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m946e2561e8" x="336.196023" y="132.245521" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m946e2561e8" x="445.766932" y="35.671713" style="fill: #d62728; stroke: #d62728"/>
+    </g>
+   </g>
+   <g id="line2d_54">
+    <g clip-path="url(#p99227515fb)">
+     <use xlink:href="#m946e2561e8" x="80.530568" y="251.025227" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m946e2561e8" x="117.054205" y="248.846064" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m946e2561e8" x="226.625114" y="208.141112" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m946e2561e8" x="336.196023" y="129.69012" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m946e2561e8" x="445.766932" y="33.406125" style="fill: #d62728; stroke: #d62728"/>
+    </g>
+   </g>
+   <g id="line2d_55">
+    <path d="M 80.530568 254.797172 
+L 117.054205 249.453624 
+L 226.625114 212.787221 
+L 336.196023 132.262213 
+L 445.766932 35.485484 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6; stroke-linecap: square"/>
+    <defs>
+     <path id="mcc5b205df2" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p99227515fb)">
+     <use xlink:href="#mcc5b205df2" x="80.530568" y="254.797172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mcc5b205df2" x="117.054205" y="249.453624" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mcc5b205df2" x="226.625114" y="212.787221" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mcc5b205df2" x="336.196023" y="132.262213" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mcc5b205df2" x="445.766932" y="35.485484" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_56">
+    <path d="M 80.530568 252.46156 
+L 117.054205 250.389928 
+L 226.625114 209.151804 
+L 336.196023 130.120607 
+L 445.766932 35.598033 
+" clip-path="url(#p99227515fb)" style="fill: none; stroke: #d62728; stroke-width: 1.6; stroke-linecap: square"/>
+    <defs>
+     <path id="m5166d3245b" d="M -3 3 
+L 3 3 
+L 3 -3 
+L -3 -3 
+z
+" style="stroke: #d62728; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p99227515fb)">
+     <use xlink:href="#m5166d3245b" x="80.530568" y="252.46156" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m5166d3245b" x="117.054205" y="250.389928" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m5166d3245b" x="226.625114" y="209.151804" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m5166d3245b" x="336.196023" y="130.120607" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m5166d3245b" x="445.766932" y="35.598033" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 62.26875 266.254125 
+L 62.26875 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 464.02875 266.254125 
+L 464.02875 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 62.26875 266.254125 
+L 464.02875 266.254125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 62.26875 22.318125 
+L 464.02875 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_10">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="80.530568" y="268.797172" transform="rotate(-0 80.530568 268.797172)">469 µs</text>
+   </g>
+   <g id="text_11">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="117.054205" y="263.453624" transform="rotate(-0 117.054205 263.453624)">524 µs</text>
+   </g>
+   <g id="text_12">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="226.625114" y="226.787221" transform="rotate(-0 226.625114 226.787221)">1.11 ms</text>
+   </g>
+   <g id="text_13">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="336.196023" y="146.262213" transform="rotate(-0 336.196023 146.262213)">5.79 ms</text>
+   </g>
+   <g id="text_14">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #555555" x="445.766932" y="49.485484" transform="rotate(-0 445.766932 49.485484)">42.06 ms</text>
+   </g>
+   <g id="text_15">
+    <text style="font-size: 12px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="263.14875" y="16.318125" transform="rotate(-0 263.14875 16.318125)">state_transition processing time vs validators  (3-run median, error bars = min..max)</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 67.86875 52.203125 
+L 126.9775 52.203125 
+Q 128.5775 52.203125 128.5775 50.603125 
+L 128.5775 27.918125 
+Q 128.5775 26.318125 126.9775 26.318125 
+L 67.86875 26.318125 
+Q 66.26875 26.318125 66.26875 27.918125 
+L 66.26875 50.603125 
+Q 66.26875 52.203125 67.86875 52.203125 
+z
+" style="fill: #ffffff; opacity: 0.9; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="LineCollection_3">
+     <path d="M 77.46875 36.796875 
+L 77.46875 28.796875 
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    </g>
+    <g id="line2d_57">
+     <g>
+      <use xlink:href="#m5f794adcc7" x="77.46875" y="36.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="line2d_58">
+     <g>
+      <use xlink:href="#m5f794adcc7" x="77.46875" y="28.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="line2d_59">
+     <path d="M 69.46875 32.796875 
+L 85.46875 32.796875 
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.6; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_60">
+     <g>
+      <use xlink:href="#mcc5b205df2" x="77.46875" y="32.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_16">
+     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="91.86875" y="35.596875" transform="rotate(-0 91.86875 35.596875)">baseline</text>
+    </g>
+    <g id="LineCollection_4">
+     <path d="M 77.46875 48.539375 
+L 77.46875 40.539375 
+" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    </g>
+    <g id="line2d_61">
+     <g>
+      <use xlink:href="#m946e2561e8" x="77.46875" y="48.539375" style="fill: #d62728; stroke: #d62728"/>
+     </g>
+    </g>
+    <g id="line2d_62">
+     <g>
+      <use xlink:href="#m946e2561e8" x="77.46875" y="40.539375" style="fill: #d62728; stroke: #d62728"/>
+     </g>
+    </g>
+    <g id="line2d_63">
+     <path d="M 69.46875 44.539375 
+L 85.46875 44.539375 
+" style="fill: none; stroke: #d62728; stroke-width: 1.6; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_64">
+     <g>
+      <use xlink:href="#m5166d3245b" x="77.46875" y="44.539375" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="91.86875" y="47.339375" transform="rotate(-0 91.86875 47.339375)">variant</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p99227515fb">
+   <rect x="62.26875" y="22.318125" width="401.76" height="243.936"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/bench-realism.svg
+++ b/docs/assets/bench-realism.svg
@@ -1,0 +1,1778 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="454.438125pt" height="303.810375pt" viewBox="0 0 454.438125 303.810375" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-26T02:34:35.103014</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7+dfsg1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 303.810375 
+L 454.438125 303.810375 
+L 454.438125 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 45.478125 266.254125 
+L 447.238125 266.254125 
+L 447.238125 22.318125 
+L 45.478125 22.318125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 63.739943 266.254125 
+L 63.739943 22.318125 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mdfb9907290" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdfb9907290" x="63.739943" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 4 -->
+      <g transform="translate(60.558693 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 100.26358 266.254125 
+L 100.26358 22.318125 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mdfb9907290" x="100.26358" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 8 -->
+      <g transform="translate(97.08233 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 209.834489 266.254125 
+L 209.834489 22.318125 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mdfb9907290" x="209.834489" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 64 -->
+      <g transform="translate(203.471989 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 319.405398 266.254125 
+L 319.405398 22.318125 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mdfb9907290" x="319.405398" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 512 -->
+      <g transform="translate(309.861648 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 428.976307 266.254125 
+L 428.976307 22.318125 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mdfb9907290" x="428.976307" y="266.254125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4096 -->
+      <g transform="translate(416.251307 280.852562) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- validators  V  (leanSpec range, V ≤ 4096) -->
+     <g transform="translate(142.268281 294.530687) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2264" d="M 4684 3175 
+L 1684 2309 
+L 4684 1453 
+L 4684 897 
+L 678 2047 
+L 678 2578 
+L 4684 3725 
+L 4684 3175 
+z
+M 678 531 
+L 4684 531 
+L 4684 0 
+L 678 0 
+L 678 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(148.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(176.025391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(239.501953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(300.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(339.990234 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(401.171875 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(442.285156 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(494.384766 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(526.171875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(557.958984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(626.367188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(658.154297 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(689.941406 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(728.955078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(756.738281 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(818.261719 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(879.541016 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(942.919922 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1006.396484 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1069.873047 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1131.396484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1186.376953 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1218.164062 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1259.277344 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1320.556641 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1383.935547 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1447.412109 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1508.935547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1540.722656 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1572.509766 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1640.917969 0)"/>
+      <use xlink:href="#DejaVuSans-2264" transform="translate(1672.705078 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1756.494141 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(1788.28125 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(1851.904297 0)"/>
+      <use xlink:href="#DejaVuSans-39" transform="translate(1915.527344 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(1979.150391 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2042.773438 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path d="M 45.478125 220.018867 
+L 447.238125 220.018867 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m80c25fe207" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m80c25fe207" x="45.478125" y="220.018867" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(20.878125 223.818085) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path d="M 45.478125 108.847082 
+L 447.238125 108.847082 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m80c25fe207" x="45.478125" y="108.847082" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(20.878125 112.646301) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 45.478125 264.258567 
+L 447.238125 264.258567 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="ma1ac142c0f" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="264.258567" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 45.478125 253.484908 
+L 447.238125 253.484908 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="253.484908" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 45.478125 244.682188 
+L 447.238125 244.682188 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="244.682188" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path d="M 45.478125 237.239594 
+L 447.238125 237.239594 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="237.239594" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_23">
+      <path d="M 45.478125 230.792526 
+L 447.238125 230.792526 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="230.792526" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_25">
+      <path d="M 45.478125 225.105808 
+L 447.238125 225.105808 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="225.105808" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_27">
+      <path d="M 45.478125 186.552825 
+L 447.238125 186.552825 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="186.552825" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_29">
+      <path d="M 45.478125 166.976445 
+L 447.238125 166.976445 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="166.976445" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_31">
+      <path d="M 45.478125 153.086783 
+L 447.238125 153.086783 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="153.086783" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_33">
+      <path d="M 45.478125 142.313124 
+L 447.238125 142.313124 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="142.313124" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_35">
+      <path d="M 45.478125 133.510403 
+L 447.238125 133.510403 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="133.510403" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_37">
+      <path d="M 45.478125 126.067809 
+L 447.238125 126.067809 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="126.067809" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_39">
+      <path d="M 45.478125 119.620741 
+L 447.238125 119.620741 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="119.620741" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_41">
+      <path d="M 45.478125 113.934024 
+L 447.238125 113.934024 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="113.934024" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_43">
+      <path d="M 45.478125 75.38104 
+L 447.238125 75.38104 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="75.38104" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_45">
+      <path d="M 45.478125 55.804661 
+L 447.238125 55.804661 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="55.804661" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_47">
+      <path d="M 45.478125 41.914998 
+L 447.238125 41.914998 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="41.914998" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_49">
+      <path d="M 45.478125 31.141339 
+L 447.238125 31.141339 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="31.141339" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_51">
+      <path d="M 45.478125 22.338619 
+L 447.238125 22.338619 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#ma1ac142c0f" x="45.478125" y="22.338619" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_9">
+     <!-- STF pipeline Δ  (µs, run − buildonly median) -->
+     <g transform="translate(14.798437 254.834562) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-394" d="M 2188 4044 
+L 906 525 
+L 3472 525 
+L 2188 4044 
+z
+M 50 0 
+L 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 50 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b5" d="M 544 -1331 
+L 544 3500 
+L 1119 3500 
+L 1119 1325 
+Q 1119 872 1334 640 
+Q 1550 409 1972 409 
+Q 2434 409 2667 671 
+Q 2900 934 2900 1459 
+L 2900 3500 
+L 3475 3500 
+L 3475 806 
+Q 3475 619 3529 530 
+Q 3584 441 3700 441 
+Q 3728 441 3778 458 
+Q 3828 475 3916 513 
+L 3916 50 
+Q 3788 -22 3673 -56 
+Q 3559 -91 3450 -91 
+Q 3234 -91 3106 31 
+Q 2978 153 2931 403 
+Q 2775 156 2548 32 
+Q 2322 -91 2016 -91 
+Q 1697 -91 1473 31 
+Q 1250 153 1119 397 
+L 1119 -1331 
+L 544 -1331 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(124.560547 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(182.080078 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.867188 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(277.34375 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(305.126953 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(368.603516 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(430.126953 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(457.910156 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(485.693359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(549.072266 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(610.595703 0)"/>
+      <use xlink:href="#DejaVuSans-394" transform="translate(642.382812 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(710.791016 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(742.578125 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(774.365234 0)"/>
+      <use xlink:href="#DejaVuSans-b5" transform="translate(813.378906 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(877.001953 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(929.101562 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(960.888672 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(992.675781 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1033.789062 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1097.167969 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1160.546875 0)"/>
+      <use xlink:href="#DejaVuSans-2212" transform="translate(1192.333984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1276.123047 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(1307.910156 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1371.386719 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1434.765625 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1462.548828 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1490.332031 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1553.808594 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1614.990234 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1678.369141 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(1706.152344 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1765.332031 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1797.119141 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1894.53125 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1956.054688 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(2019.53125 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2047.314453 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(2108.59375 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2171.972656 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 63.739943 255.166125 
+L 63.739943 249.28721 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 100.26358 253.551099 
+L 100.26358 247.544363 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 209.834489 216.260548 
+L 209.834489 213.245963 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 319.405398 138.391098 
+L 319.405398 130.553303 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    <path d="M 428.976307 37.912298 
+L 428.976307 33.406125 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+   </g>
+   <g id="line2d_53">
+    <defs>
+     <path id="mc2180bd94f" d="M 3 0 
+L -3 -0 
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p2baefe6458)">
+     <use xlink:href="#mc2180bd94f" x="63.739943" y="255.166125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mc2180bd94f" x="100.26358" y="253.551099" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mc2180bd94f" x="209.834489" y="216.260548" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mc2180bd94f" x="319.405398" y="138.391098" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mc2180bd94f" x="428.976307" y="37.912298" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_54">
+    <g clip-path="url(#p2baefe6458)">
+     <use xlink:href="#mc2180bd94f" x="63.739943" y="249.28721" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mc2180bd94f" x="100.26358" y="247.544363" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mc2180bd94f" x="209.834489" y="213.245963" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mc2180bd94f" x="319.405398" y="130.553303" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#mc2180bd94f" x="428.976307" y="33.406125" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 63.739943 254.085384 
+L 63.739943 248.263237 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 100.26358 251.566683 
+L 100.26358 247.953283 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 209.834489 216.169873 
+L 209.834489 210.832351 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 319.405398 137.525908 
+L 319.405398 133.690571 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    <path d="M 428.976307 40.209893 
+L 428.976307 36.997947 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+   </g>
+   <g id="line2d_55">
+    <defs>
+     <path id="m79e15ab8ab" d="M 3 0 
+L -3 -0 
+" style="stroke: #d62728"/>
+    </defs>
+    <g clip-path="url(#p2baefe6458)">
+     <use xlink:href="#m79e15ab8ab" x="63.739943" y="254.085384" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m79e15ab8ab" x="100.26358" y="251.566683" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m79e15ab8ab" x="209.834489" y="216.169873" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m79e15ab8ab" x="319.405398" y="137.525908" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m79e15ab8ab" x="428.976307" y="40.209893" style="fill: #d62728; stroke: #d62728"/>
+    </g>
+   </g>
+   <g id="line2d_56">
+    <g clip-path="url(#p2baefe6458)">
+     <use xlink:href="#m79e15ab8ab" x="63.739943" y="248.263237" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m79e15ab8ab" x="100.26358" y="247.953283" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m79e15ab8ab" x="209.834489" y="210.832351" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m79e15ab8ab" x="319.405398" y="133.690571" style="fill: #d62728; stroke: #d62728"/>
+     <use xlink:href="#m79e15ab8ab" x="428.976307" y="36.997947" style="fill: #d62728; stroke: #d62728"/>
+    </g>
+   </g>
+   <g id="line2d_57">
+    <path d="M 63.739943 254.669269 
+L 100.26358 249.625974 
+L 209.834489 214.242151 
+L 319.405398 134.343752 
+L 428.976307 36.030983 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #1f77b4; stroke-width: 1.6; stroke-linecap: square"/>
+    <defs>
+     <path id="m938a2a3a4e" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p2baefe6458)">
+     <use xlink:href="#m938a2a3a4e" x="63.739943" y="254.669269" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m938a2a3a4e" x="100.26358" y="249.625974" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m938a2a3a4e" x="209.834489" y="214.242151" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m938a2a3a4e" x="319.405398" y="134.343752" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m938a2a3a4e" x="428.976307" y="36.030983" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_58">
+    <path d="M 63.739943 251.277592 
+L 100.26358 249.524766 
+L 209.834489 213.576473 
+L 319.405398 134.886704 
+L 428.976307 38.111638 
+" clip-path="url(#p2baefe6458)" style="fill: none; stroke: #d62728; stroke-width: 1.6; stroke-linecap: square"/>
+    <defs>
+     <path id="m16dd9ee8bc" d="M -3 3 
+L 3 3 
+L 3 -3 
+L -3 -3 
+z
+" style="stroke: #d62728; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p2baefe6458)">
+     <use xlink:href="#m16dd9ee8bc" x="63.739943" y="251.277592" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m16dd9ee8bc" x="100.26358" y="249.524766" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m16dd9ee8bc" x="209.834489" y="213.576473" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m16dd9ee8bc" x="319.405398" y="134.886704" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m16dd9ee8bc" x="428.976307" y="38.111638" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 45.478125 266.254125 
+L 45.478125 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 447.238125 266.254125 
+L 447.238125 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 45.478125 266.254125 
+L 447.238125 266.254125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 45.478125 22.318125 
+L 447.238125 22.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_10">
+    <!-- 1.07× -->
+    <g style="fill: #555555" transform="translate(51.481818 243.277592) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-d7" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- 1.00× -->
+    <g style="fill: #555555" transform="translate(88.005455 241.524766) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <!-- 1.01× -->
+    <g style="fill: #555555" transform="translate(197.576364 205.576473) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- 0.99× -->
+    <g style="fill: #555555" transform="translate(307.147273 126.343752) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- 0.96× -->
+    <g style="fill: #555555" transform="translate(416.718182 28.030983) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-d7" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- state_transition pipeline Δ  (4-run median, error bars = min..max) -->
+    <g transform="translate(48.541875 16.318125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(91.308594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(152.587891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(191.796875 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(253.320312 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(303.320312 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(342.529297 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(383.642578 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(444.921875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(508.300781 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(560.400391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(588.183594 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(627.392578 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(655.175781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(716.357422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(779.736328 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(811.523438 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(875 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(902.783203 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(966.259766 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1027.783203 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1055.566406 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1083.349609 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1146.728516 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1208.251953 0)"/>
+     <use xlink:href="#DejaVuSans-394" transform="translate(1240.039062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1308.447266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1340.234375 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1372.021484 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1411.035156 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1474.658203 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1510.742188 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1551.855469 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1615.234375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1678.613281 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1710.400391 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1807.8125 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1869.335938 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1932.8125 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1960.595703 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2021.875 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2085.253906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2117.041016 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2148.828125 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2210.351562 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2249.714844 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2288.578125 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2349.759766 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2390.873047 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2422.660156 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2486.136719 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2547.416016 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2588.529297 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2640.628906 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(2672.416016 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2756.205078 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2787.992188 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2885.404297 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2913.1875 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(2976.566406 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(3008.353516 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3040.140625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3137.552734 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(3198.832031 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3258.011719 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 51.078125 52.203125 
+L 110.186875 52.203125 
+Q 111.786875 52.203125 111.786875 50.603125 
+L 111.786875 27.918125 
+Q 111.786875 26.318125 110.186875 26.318125 
+L 51.078125 26.318125 
+Q 49.478125 26.318125 49.478125 27.918125 
+L 49.478125 50.603125 
+Q 49.478125 52.203125 51.078125 52.203125 
+z
+" style="fill: #ffffff; opacity: 0.9; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="LineCollection_3">
+     <path d="M 60.678125 36.796875 
+L 60.678125 28.796875 
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.6"/>
+    </g>
+    <g id="line2d_59">
+     <g>
+      <use xlink:href="#mc2180bd94f" x="60.678125" y="36.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="line2d_60">
+     <g>
+      <use xlink:href="#mc2180bd94f" x="60.678125" y="28.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="line2d_61">
+     <path d="M 52.678125 32.796875 
+L 68.678125 32.796875 
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.6; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_62">
+     <g>
+      <use xlink:href="#m938a2a3a4e" x="60.678125" y="32.796875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- baseline -->
+     <g transform="translate(75.078125 35.596875) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-62"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(124.755859 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(176.855469 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(238.378906 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(266.162109 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(293.945312 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(357.324219 0)"/>
+     </g>
+    </g>
+    <g id="LineCollection_4">
+     <path d="M 60.678125 48.539375 
+L 60.678125 40.539375 
+" style="fill: none; stroke: #d62728; stroke-width: 1.6"/>
+    </g>
+    <g id="line2d_63">
+     <g>
+      <use xlink:href="#m79e15ab8ab" x="60.678125" y="48.539375" style="fill: #d62728; stroke: #d62728"/>
+     </g>
+    </g>
+    <g id="line2d_64">
+     <g>
+      <use xlink:href="#m79e15ab8ab" x="60.678125" y="40.539375" style="fill: #d62728; stroke: #d62728"/>
+     </g>
+    </g>
+    <g id="line2d_65">
+     <path d="M 52.678125 44.539375 
+L 68.678125 44.539375 
+" style="fill: none; stroke: #d62728; stroke-width: 1.6; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_66">
+     <g>
+      <use xlink:href="#m16dd9ee8bc" x="60.678125" y="44.539375" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- variant -->
+     <g transform="translate(75.078125 47.339375) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(161.572266 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(189.355469 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(250.634766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(314.013672 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p2baefe6458">
+   <rect x="45.478125" y="22.318125" width="401.76" height="243.936"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -167,14 +167,15 @@ log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spe
 - **絶対値の注記**: 本節の絶対 Δ は §1b の run(V=4096 で 27.55 ms)より高い(~45 ms)。当初これを「持続負荷の熱ダレ」と見ていたが、下の**クリーン単独プロセス隔離**で測り直すと熱ダレを排しても ~42 ms とほぼ変わらず、絶対水準は**計測時刻のマシン熱状態**に支配されることが分かった(§1b の 27.55 ms は同日でもより冷えた時刻の値)。よって**横断の絶対比較は同一セッション内**で、本節の主眼は同一実行内の相対比とすること。詳細は下のクリーン節を参照。
 - **再現**: `cargo build --release --bin bench-state-transition-realism` 後に `rust-ffi/target/release/bench-state-transition-realism`。SVG は `python3 scripts/plot_realism.py`(realistic/baseline 比)と `python3 scripts/plot_realism_abs.py`(STF 処理時間の絶対値、同じ埋め込みデータから再生成)。
 
-### クリーン単独プロセス隔離 — realistic を §1b と同一方法論で実測
+### クリーン単独プロセス隔離 — realistic fixture を §1b 方法論で実測
 
-上の §1c は `bench-state-transition-realism` で baseline / realistic を **1 プロセスで交互**かつセル毎 calibrate で連続実行する。CPU が走りっぱなしになるため、そこで測る絶対値は持続負荷下の値になる(本節冒頭の注記参照)。本節はこれを **§1b と完全に同一のクリーン方法論**(単独プロセス隔離)で測り直した別物の計測である:
+上の §1c は `bench-state-transition-realism` で CPU を連続負荷下に置く(baseline / realistic を 1 プロセスで交互 + セル毎 calibrate)。本節はこれと別物で、**§1b と同一のクリーン方法論**(単独プロセス隔離)で realistic fixture(散らばったビット＋高エントロピー root = 実 attestation のデータ形状)を測り、**実データ寄りの canonical な clean STF コスト**を出した:
 
-- **同一ハーネス**: §1b の clean harness `bench-state-transition` に `--realistic` フラグを追加し、realistic fixture export(`csf_bench_state_transition_att_real_*`)を選択する。trials / calibrate / paired-delta / self-check(`att_cells(64) == 9`)はすべて baseline と byte-for-byte 同一 ⇒ 同一ハーネス上で baseline と realistic が直接比較可能。
+- **同一ハーネス**: §1b の clean harness `bench-state-transition` に `--realistic` フラグを追加し、realistic fixture export(`csf_bench_state_transition_att_real_*`)を選択する。trials / calibrate / paired-delta / self-check(`att_cells(64) == 9`)は §1b と byte-for-byte 同一。
 - **単独プロセス隔離**: 各 V を `--single-n=N` で**別プロセス**実行(1 プロセス 1 セル)。
 - **cooldown**: 各プロセスの前に 20 s スリープを挟み、ブーストクロックが持続負荷で落ちないようにする。
-- **idle マシン**: 常駐負荷を止め、CPU 95% idle を確認した状態で計測。realistic / baseline 各 V を 3 プロセスずつ回し中央値を取る。
+- **idle マシン**: 常駐負荷を止め、CPU 95% idle を確認した状態で計測。各 V を 3 プロセスずつ回し中央値を取る。
+- データ形状が STF 時間を有意に変えないことは §1c 上段の A/B で確認済み ⇒ 本節は**実データ形状の realistic 値のみ**を canonical として報告する(合成データの値は対照 foil であって canonical ではない)。
 
 #### 計測環境
 
@@ -188,24 +189,23 @@ log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spe
 
 #### 計測結果 (V = 4 … 4096、A=8 valid votes、各 V を 3 プロセスの中央値)
 
-| V | baseline clean Δ | realistic clean Δ | realistic / baseline | 参考 §1b(より冷, 00:40) | 参考 §1c 持続負荷 realistic |
-|---:|---:|---:|---:|---:|---:|
-| 4 | 469.5 µs | 492.5 µs | 1.049× | 315.5 µs | 523.4 µs |
-| 8 | 523.8 µs | 513.9 µs | 0.981× | 369.6 µs | 542.7 µs |
-| 64 | 1.111 ms | 1.197 ms | 1.077× | 761.9 µs | 1.14 ms |
-| 512 | 5.786 ms | 6.046 ms | 1.045× | 3.55 ms | 5.83 ms |
-| 4096 (spec max) | 42.06 ms | 41.96 ms | 0.998× | 27.55 ms | 43.28 ms |
-
-3 プロセスのばらつきは小さい(V=4096 baseline: 41.36–42.11 ms。ラウンド進行で上昇トレンドなし ⇒ 残留熱の人工物ではない安定 steady-state)。
+| V | realistic clean Δ | 3-run min..max | 参考 §1c 持続負荷 realistic |
+|---:|---:|---:|---:|
+| 4 | 492.5 µs | 484.0–507.2 µs | 523.4 µs |
+| 8 | 513.9 µs | 503.2–530.4 µs | 542.7 µs |
+| 64 | 1.197 ms | 1.184–1.222 ms | 1.14 ms |
+| 512 | 6.046 ms | 5.788–6.099 ms | 5.83 ms |
+| 4096 (spec max) | 41.96 ms | 41.90–43.89 ms | 43.28 ms |
 
 ![state_transition processing time vs validators (clean single-process isolation)](./assets/bench-realism-clean.svg)
 
 #### 判定・観察
 
-- **realistic ≈ baseline はクリーン隔離でも成立**: 全 V で 0.98–1.08×、一貫した方向なし。持続負荷の §1c 上段と同じ結論 ——「散らばったビット＋高エントロピー root は STF pipeline の実測時間を有意に変えない」—— が、熱ダレを排した単独プロセス条件でも再確認できた。これが本節の制御された結論(同一セッション・同一条件での比較)。
-- **絶対値はマシン熱状態に支配される(クリーン隔離 ≠ §1b の 27.55 ms)**: クリーン V=4096 = 42.06 ms は、**同日**(2026-06-26)に測った §1c 持続負荷の 43–45 ms とほぼ一致する。§1b の 27.55 ms は同日でも**より早い時刻(00:40、より冷えたマシン)**の値で、その後(02:33 以降〜本計測 10:00)は run / buildonly がともに一律 ~1.48× 遅い(run 112 ms vs 75.68 ms、buildonly 70 ms vs 48 ms)= クロックが下がった状態が続いた。つまり §1c 上段の 45 ms と §1b の 27.55 ms の差は「持続負荷の熱ダレ」ではなく**計測時刻=マシン熱状態の差**であり、単独プロセス隔離だけでは 27.55 ms は再現しない(電力設定は計測時すでに最大: performance gov / EPP=performance / boost / 5.26 GHz 未制限)。
-- **含意**: STF の絶対 µs/ms はセッション間のマシン熱状態に敏感なので、**横断比較は同一セッション内**で取った値どうしで行うこと(本節の realistic-vs-baseline、および §1c 上段の interleave 比がそれに当たる)。絶対の水準は当日のマシン状態に読み替える。V=4096 でも 42 ms で 🟢 green(SLO target 200 ms の ~1/5)は §1b と同じく余裕。
-- **再現**: `cargo build --release --bin bench-state-transition` 後、各 V を別プロセスで `rust-ffi/target/release/bench-state-transition --realistic --single-n=$N`(baseline は `--realistic` を外す)、各実行前に cooldown。SVG は `python3 scripts/plot_realism_clean.py`(実測 ns をスクリプトに直接埋め込み)。
+- **spec 上限 V=4096 で 41.96 ms、🟢 green**(SLO target 200 ms の ~1/5)。実データ形状でも 1 スロット ~4 s に対し余裕。scaling は V に概ね線形〜やや超線形(大 V で SHA-256 HTR が支配)。
+- **絶対値はマシン熱状態に支配される**: クリーン V=4096 = 41.96 ms は、**同日**(2026-06-26)の §1c 持続負荷 realistic(43.28 ms)とほぼ一致する。より早い時刻(00:40、より冷えたマシン)では同 V が大幅に低かった(§1b は 27.55 ms)が、その後(02:33 以降〜本計測 10:00)は run / buildonly がともに一律 ~1.48× 遅い(run 112 ms vs 75.68 ms、buildonly 70 ms vs 48 ms)= クロックが下がった状態が続いた。つまり §1c 上段の 45 ms と §1b の 27.55 ms の差は「持続負荷の熱ダレ」ではなく**計測時刻 = マシン熱状態の差**であり、単独プロセス隔離だけでは低い絶対値は再現しない(電力設定は計測時すでに最大: performance gov / EPP=performance / boost / 5.26 GHz 未制限)。
+- **3 プロセスのばらつきは小さい**(V=4096: 41.90–43.89 ms。ラウンド進行で上昇トレンドなし ⇒ 残留熱の人工物ではない安定 steady-state)。
+- **含意**: STF の絶対 µs/ms はセッション間のマシン熱状態に敏感なので、**横断の絶対比較は同一セッション内**で取った値どうしで行うこと。絶対の水準は当日のマシン状態に読み替える。
+- **再現**: `cargo build --release --bin bench-state-transition` 後、各 V を別プロセスで `rust-ffi/target/release/bench-state-transition --realistic --single-n=$N`、各実行前に cooldown。SVG は `python3 scripts/plot_realism_clean.py`(実測 ns をスクリプトに直接埋め込み)。
 
 ## 2. `compute_lmd_ghost_head` (Aeneas direct, no fast path)
 

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -129,6 +129,40 @@ log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spe
 - **att_cells = 9 を維持**: 実 HTR 化後も 8 票はすべて有効処理(root 整合化は投票の有効性に影響しない)。
 - **依然 STF 外**: 署名検証(XMSS/Poseidon)は未計測(§4e ①)。本節は「実 HTR 込み・署名検証なし」の値。
 
+## 1c. データリアリズム A/B — 合成 fixture の楽観バイアス検証
+
+§1/§1b の fixture は attestation の `aggregation_bits` を**連続 ⌈V/2⌉ ビット接頭辞**(`true` が前半に固まる)で、H256 root を**単一バイト 32 連**(`hashOfNat`)で構築する。どちらも STF を実データより*測りやすく*する経路を持つ:
+
+- **分岐予測**: 連続接頭辞は `processAttestationsFast` の `aggregation_bits` 走査(`FastPath.lean:133`)で分岐予測がほぼ完璧に当たる。実 attestation の散らばったビットなら mispredict が増えうる。
+- **比較短絡**: 単一バイト root は相異なる root が**バイト 0 で分岐**するため `H256` 等価比較・`is_zero` が即短絡する。
+
+本節はこれを定量化するため、同一ワークロード(同 V、同 8 有効票、同 no-bail / `cells = 9` 不変)の **data-realistic twin**(`csf_bench_state_transition_att_real_*`)を作って A/B 計測した:
+
+- **散らばったビット**: `mix64`(splitmix64)を RNG とする固定 Fisher-Yates で、**正確に ⌈V/2⌉ 個**の set ビットを無秩序な位置に配置(`scatteredBitList`)。票数は不変なので 2/3 閾値に当たらず fast path を維持。
+- **高エントロピー root**: `mix64` 由来のバイト列(`hashOfNatHE`、非ゼロ・index について injective)。
+- V / A / SHA ブロック数 / 制御パスはすべて baseline と同一 ⇒ **realistic ≥ baseline ならその差が "データパターン由来の楽観バイアス"**。両 fixture とも `_real_cells = 9` を assert してから計測。
+- **同一プロセスで baseline と realistic を各 V で交互計測**(cache/thermal 状態を共有した公平な A/B)。独立 4 プロセス × 各 7 試行中央値。
+
+### 計測結果 (V = 4 … 4096、A=8 valid votes、4 プロセスの中央値)
+
+| V | baseline Δ | realistic Δ | realistic / baseline |
+|---:|---:|---:|---:|
+| 4 | 487.9 µs | 523.4 µs | 1.073× |
+| 8 | 541.6 µs | 542.7 µs | 1.002× |
+| 64 | 1.13 ms | 1.14 ms | 1.014× |
+| 512 | 5.90 ms | 5.83 ms | 0.989× |
+| 4096 (spec max) | 45.18 ms | 43.28 ms | 0.958× |
+
+![synthetic vs data-realistic state_transition fixture](./assets/bench-realism.svg)
+
+### 判定・観察
+
+- **realistic ≈ baseline(全 V で 0.96–1.07×)、一貫した方向なし**。realistic が速い V も遅い V もある。実行間ノイズ(同一セルで ±10–24%、特に V=512 は 4 プロセスで 0.89–1.10× に振れる)に対し、A/B 差は ±5–7% でその**ノイズ以下**。→ **散らばったビット＋高エントロピー root は STF pipeline の実測時間を有意に変えない**。
+- **なぜ効かないか**: pipeline は (1) 値非依存の SHA-256 `hash_tree_root`(大 V で支配、§1b の HTR 増分 +82%)と (2) ループ上限が `bits.size = V` の**無条件 O(A·V) ビット走査**が支配する。仮説していた分岐予測・比較短絡のコストは、これらに対して小さくノイズに埋もれる。
+- **含意**: §1/§1b の合成 fixture の数字は、fixture の規則性に対して**頑健**。データを現実寄りにしても headline は動かない(少なくとも測定ノイズの範囲で)。
+- **絶対値の注記**: 本節の絶対 Δ は §1b の canonical run(V=4096 で 27.55 ms)より高い(~45 ms)。これは baseline/realistic を interleave しつつ各セルで calibrate を回す持続負荷下の値で、熱・キャッシュ条件が §1b と異なるため。**本節の主眼は同一実行内の相対比**であり、絶対の正準値は §1b を参照。
+- **再現**: `cargo build --release --bin bench-state-transition-realism` 後に `rust-ffi/target/release/bench-state-transition-realism`。SVG は `python3 scripts/plot_realism.py`(埋め込みデータから再生成)。
+
 ## 2. `compute_lmd_ghost_head` (Aeneas direct, no fast path)
 
 軸: (B blocks, A attestations) ∈ `{100} × {32, 128}` × 5 試行 (default)。
@@ -184,6 +218,7 @@ cd rust-ffi && cargo build --release
 # 3. ベンチ実行 (per-cell isolation 推奨: cargo run はせず target/release を直接呼ぶ)
 target/release/bench-state-transition                      # V=4,8,64,512,4096, A=8 valid (~4 s)
 target/release/bench-state-transition --include-1m         # + V=1M (out-of-spec ref、1 trial ~4 s + ~584 MB rss、2 GiB stack)
+target/release/bench-state-transition-realism              # §1c data-realism A/B (synthetic vs scattered-bits + high-entropy roots)
 target/release/bench-ffi-marshal                           # V=1..4096 marshal (~数 s)
 target/release/bench-ffi-marshal --include-1m              # + V=1M (out-of-spec, ~57 MB payload)
 target/release/bench-fork-choice                           # B=100 × A=32,128 (~20 s、V 軸なし)

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -164,8 +164,48 @@ log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spe
 - **realistic ≈ baseline(全 V で 0.96–1.07×)、一貫した方向なし**。realistic が速い V も遅い V もある。実行間ノイズ(同一セルで ±10–24%、特に V=512 は 4 プロセスで 0.89–1.10× に振れる)に対し、A/B 差は ±5–7% でその**ノイズ以下**。→ **散らばったビット＋高エントロピー root は STF pipeline の実測時間を有意に変えない**。
 - **なぜ効かないか**: pipeline は (1) 値非依存の SHA-256 `hash_tree_root`(大 V で支配、§1b の HTR 増分 +82%)と (2) ループ上限が `bits.size = V` の**無条件 O(A·V) ビット走査**が支配する。仮説していた分岐予測・比較短絡のコストは、これらに対して小さくノイズに埋もれる。
 - **含意**: §1/§1b の合成 fixture の数字は、fixture の規則性に対して**頑健**。データを現実寄りにしても headline は動かない(少なくとも測定ノイズの範囲で)。
-- **絶対値の注記**: 本節の絶対 Δ は §1b の canonical run(V=4096 で 27.55 ms)より高い(~45 ms)。これは baseline/realistic を interleave しつつ各セルで calibrate を回す持続負荷下の値で、熱・キャッシュ条件が §1b と異なるため。**本節の主眼は同一実行内の相対比**であり、絶対の正準値は §1b を参照。
+- **絶対値の注記**: 本節の絶対 Δ は §1b の run(V=4096 で 27.55 ms)より高い(~45 ms)。当初これを「持続負荷の熱ダレ」と見ていたが、下の**クリーン単独プロセス隔離**で測り直すと熱ダレを排しても ~42 ms とほぼ変わらず、絶対水準は**計測時刻のマシン熱状態**に支配されることが分かった(§1b の 27.55 ms は同日でもより冷えた時刻の値)。よって**横断の絶対比較は同一セッション内**で、本節の主眼は同一実行内の相対比とすること。詳細は下のクリーン節を参照。
 - **再現**: `cargo build --release --bin bench-state-transition-realism` 後に `rust-ffi/target/release/bench-state-transition-realism`。SVG は `python3 scripts/plot_realism.py`(realistic/baseline 比)と `python3 scripts/plot_realism_abs.py`(STF 処理時間の絶対値、同じ埋め込みデータから再生成)。
+
+### クリーン単独プロセス隔離 — realistic を §1b と同一方法論で実測
+
+上の §1c は `bench-state-transition-realism` で baseline / realistic を **1 プロセスで交互**かつセル毎 calibrate で連続実行する。CPU が走りっぱなしになるため、そこで測る絶対値は持続負荷下の値になる(本節冒頭の注記参照)。本節はこれを **§1b と完全に同一のクリーン方法論**(単独プロセス隔離)で測り直した別物の計測である:
+
+- **同一ハーネス**: §1b の clean harness `bench-state-transition` に `--realistic` フラグを追加し、realistic fixture export(`csf_bench_state_transition_att_real_*`)を選択する。trials / calibrate / paired-delta / self-check(`att_cells(64) == 9`)はすべて baseline と byte-for-byte 同一 ⇒ 同一ハーネス上で baseline と realistic が直接比較可能。
+- **単独プロセス隔離**: 各 V を `--single-n=N` で**別プロセス**実行(1 プロセス 1 セル)。
+- **cooldown**: 各プロセスの前に 20 s スリープを挟み、ブーストクロックが持続負荷で落ちないようにする。
+- **idle マシン**: 常駐負荷を止め、CPU 95% idle を確認した状態で計測。realistic / baseline 各 V を 3 プロセスずつ回し中央値を取る。
+
+#### 計測環境
+
+| 項目 | 値 |
+|---|---|
+| CPU | AMD Ryzen 9 PRO 8945HS (16 threads, Radeon 780M) |
+| governor / EPP / boost | performance / performance / on(最大 5.26 GHz、未制限) |
+| OS / kernel | Kali Linux Rolling 2025.4 / 6.18.12 |
+| 日付 | 2026-06-26 ~10:00 JST |
+| マシン状態 | idle(常駐 clickhouse コンテナ凍結、瞬間 CPU 95% idle を確認) |
+
+#### 計測結果 (V = 4 … 4096、A=8 valid votes、各 V を 3 プロセスの中央値)
+
+| V | baseline clean Δ | realistic clean Δ | realistic / baseline | 参考 §1b(より冷, 00:40) | 参考 §1c 持続負荷 realistic |
+|---:|---:|---:|---:|---:|---:|
+| 4 | 469.5 µs | 492.5 µs | 1.049× | 315.5 µs | 523.4 µs |
+| 8 | 523.8 µs | 513.9 µs | 0.981× | 369.6 µs | 542.7 µs |
+| 64 | 1.111 ms | 1.197 ms | 1.077× | 761.9 µs | 1.14 ms |
+| 512 | 5.786 ms | 6.046 ms | 1.045× | 3.55 ms | 5.83 ms |
+| 4096 (spec max) | 42.06 ms | 41.96 ms | 0.998× | 27.55 ms | 43.28 ms |
+
+3 プロセスのばらつきは小さい(V=4096 baseline: 41.36–42.11 ms。ラウンド進行で上昇トレンドなし ⇒ 残留熱の人工物ではない安定 steady-state)。
+
+![state_transition processing time vs validators (clean single-process isolation)](./assets/bench-realism-clean.svg)
+
+#### 判定・観察
+
+- **realistic ≈ baseline はクリーン隔離でも成立**: 全 V で 0.98–1.08×、一貫した方向なし。持続負荷の §1c 上段と同じ結論 ——「散らばったビット＋高エントロピー root は STF pipeline の実測時間を有意に変えない」—— が、熱ダレを排した単独プロセス条件でも再確認できた。これが本節の制御された結論(同一セッション・同一条件での比較)。
+- **絶対値はマシン熱状態に支配される(クリーン隔離 ≠ §1b の 27.55 ms)**: クリーン V=4096 = 42.06 ms は、**同日**(2026-06-26)に測った §1c 持続負荷の 43–45 ms とほぼ一致する。§1b の 27.55 ms は同日でも**より早い時刻(00:40、より冷えたマシン)**の値で、その後(02:33 以降〜本計測 10:00)は run / buildonly がともに一律 ~1.48× 遅い(run 112 ms vs 75.68 ms、buildonly 70 ms vs 48 ms)= クロックが下がった状態が続いた。つまり §1c 上段の 45 ms と §1b の 27.55 ms の差は「持続負荷の熱ダレ」ではなく**計測時刻=マシン熱状態の差**であり、単独プロセス隔離だけでは 27.55 ms は再現しない(電力設定は計測時すでに最大: performance gov / EPP=performance / boost / 5.26 GHz 未制限)。
+- **含意**: STF の絶対 µs/ms はセッション間のマシン熱状態に敏感なので、**横断比較は同一セッション内**で取った値どうしで行うこと(本節の realistic-vs-baseline、および §1c 上段の interleave 比がそれに当たる)。絶対の水準は当日のマシン状態に読み替える。V=4096 でも 42 ms で 🟢 green(SLO target 200 ms の ~1/5)は §1b と同じく余裕。
+- **再現**: `cargo build --release --bin bench-state-transition` 後、各 V を別プロセスで `rust-ffi/target/release/bench-state-transition --realistic --single-n=$N`(baseline は `--realistic` を外す)、各実行前に cooldown。SVG は `python3 scripts/plot_realism_clean.py`(実測 ns をスクリプトに直接埋め込み)。
 
 ## 2. `compute_lmd_ghost_head` (Aeneas direct, no fast path)
 
@@ -233,6 +273,10 @@ target/release/bench-state-transition --single-n=4096
 target/release/bench-state-transition --single-n=1000000
 target/release/bench-fork-choice --single-cell=100,32
 target/release/bench-fork-choice --single-cell=100,128
+
+# §1c クリーン単独プロセス隔離 (realistic fixture を §1b と同一方法論で):
+target/release/bench-state-transition --realistic --single-n=4096   # realistic data
+target/release/bench-state-transition --single-n=4096               # baseline data (同一ハーネス)
 ```
 
 ## 4b. FFI 境界コスト 追測 (2026-06-04)

--- a/docs/rust-ffi-benchmarks.md
+++ b/docs/rust-ffi-benchmarks.md
@@ -155,13 +155,17 @@ log-log。実線 = spec 範囲 (V ≤ 4096)、破線 + 赤網掛け = out-of-spe
 
 ![synthetic vs data-realistic state_transition fixture](./assets/bench-realism.svg)
 
+同じ 4 ラン分のデータを、比ではなく **STF 処理時間の絶対値 × Validator 数**(他節の scaling 図と同じ log-log)で見たもの。baseline / realistic の 2 本が全 V でノイズ内に重なり、データパターンが pipeline 時間を動かさないことを別表現で示す:
+
+![STF processing time vs validators (realism A/B, absolute)](./assets/bench-realism-abs.svg)
+
 ### 判定・観察
 
 - **realistic ≈ baseline(全 V で 0.96–1.07×)、一貫した方向なし**。realistic が速い V も遅い V もある。実行間ノイズ(同一セルで ±10–24%、特に V=512 は 4 プロセスで 0.89–1.10× に振れる)に対し、A/B 差は ±5–7% でその**ノイズ以下**。→ **散らばったビット＋高エントロピー root は STF pipeline の実測時間を有意に変えない**。
 - **なぜ効かないか**: pipeline は (1) 値非依存の SHA-256 `hash_tree_root`(大 V で支配、§1b の HTR 増分 +82%)と (2) ループ上限が `bits.size = V` の**無条件 O(A·V) ビット走査**が支配する。仮説していた分岐予測・比較短絡のコストは、これらに対して小さくノイズに埋もれる。
 - **含意**: §1/§1b の合成 fixture の数字は、fixture の規則性に対して**頑健**。データを現実寄りにしても headline は動かない(少なくとも測定ノイズの範囲で)。
 - **絶対値の注記**: 本節の絶対 Δ は §1b の canonical run(V=4096 で 27.55 ms)より高い(~45 ms)。これは baseline/realistic を interleave しつつ各セルで calibrate を回す持続負荷下の値で、熱・キャッシュ条件が §1b と異なるため。**本節の主眼は同一実行内の相対比**であり、絶対の正準値は §1b を参照。
-- **再現**: `cargo build --release --bin bench-state-transition-realism` 後に `rust-ffi/target/release/bench-state-transition-realism`。SVG は `python3 scripts/plot_realism.py`(埋め込みデータから再生成)。
+- **再現**: `cargo build --release --bin bench-state-transition-realism` 後に `rust-ffi/target/release/bench-state-transition-realism`。SVG は `python3 scripts/plot_realism.py`(realistic/baseline 比)と `python3 scripts/plot_realism_abs.py`(STF 処理時間の絶対値、同じ埋め込みデータから再生成)。
 
 ## 2. `compute_lmd_ghost_head` (Aeneas direct, no fast path)
 

--- a/rust-ffi/Cargo.toml
+++ b/rust-ffi/Cargo.toml
@@ -20,6 +20,10 @@ name = "bench-state-transition"
 path = "src/bin/bench-state-transition.rs"
 
 [[bin]]
+name = "bench-state-transition-realism"
+path = "src/bin/bench-state-transition-realism.rs"
+
+[[bin]]
 name = "bench-fork-choice"
 path = "src/bin/bench-fork-choice.rs"
 

--- a/rust-ffi/src/bin/bench-state-transition-realism.rs
+++ b/rust-ffi/src/bin/bench-state-transition-realism.rs
@@ -1,0 +1,186 @@
+// Realism probe — quantifies the "optimistic bias" of the M5b synthetic
+// state_transition fixture by measuring it against a data-realistic twin in the
+// SAME process (shared thermal/cache state for a fair A/B).
+//
+// Two configs over the same V axis, same A=8 valid votes, same no-bail /
+// cells=9 invariant (cf. ConsensusLean4/Ffi.lean "Realism probe" section):
+//   * baseline  — contiguous ⌈V/2⌉-bit prefix + single-repeated-byte roots
+//                 (csf_bench_state_transition_att_*)
+//   * realistic — Fisher-Yates-scattered ⌈V/2⌉ bits + high-entropy roots
+//                 (csf_bench_state_transition_att_real_*)
+//
+// The delta isolates the data-pattern component of the timing: branch
+// prediction on the aggregation-bit scan plus H256 comparison short-circuit.
+// Everything algorithmic (V, A, # SHA blocks, control-flow path) is identical,
+// so realistic ≥ baseline is the optimistic-bias factor.
+
+use std::ffi::c_void;
+use std::ptr;
+use std::time::{Duration, Instant};
+
+#[path = "../sha_extern.rs"]
+mod sha_extern;
+
+#[link(name = "Init_shared")]
+extern "C" {
+    fn lean_initialize_runtime_module();
+    fn lean_initialize();
+    fn lean_io_mark_end_initialization();
+}
+
+extern "C" {
+    fn initialize_consensus_x2dffi_x2dpoc_ConsensusLean4_Ffi(
+        builtin: u8,
+        world: *mut c_void,
+    ) -> *mut c_void;
+
+    fn csf_bench_state_transition_att_run(n: u64, a: u64, seed: u64) -> u8;
+    fn csf_bench_state_transition_att_buildonly(n: u64, a: u64, seed: u64) -> u8;
+    fn csf_bench_state_transition_att_cells(n: u64) -> u8;
+
+    fn csf_bench_state_transition_att_real_run(n: u64, a: u64, seed: u64) -> u8;
+    fn csf_bench_state_transition_att_real_buildonly(n: u64, a: u64, seed: u64) -> u8;
+    fn csf_bench_state_transition_att_real_cells(n: u64) -> u8;
+}
+
+unsafe fn boot_lean() {
+    lean_initialize_runtime_module();
+    lean_initialize();
+    let _ = initialize_consensus_x2dffi_x2dpoc_ConsensusLean4_Ffi(1, ptr::null_mut());
+    lean_io_mark_end_initialization();
+}
+
+type BenchFn = unsafe extern "C" fn(u64, u64, u64) -> u8;
+
+struct Config {
+    run: BenchFn,
+    buildonly: BenchFn,
+}
+
+const A_FIXED: u64 = 8;
+const TARGET_TRIAL_DURATION: Duration = Duration::from_millis(100);
+const N_AXIS: &[u64] = &[4, 8, 64, 512, 4096];
+const TRIALS: usize = 7;
+
+fn fmt_duration_ns(ns: u128) -> String {
+    if ns < 1_000 {
+        format!("{} ns", ns)
+    } else if ns < 1_000_000 {
+        format!("{:.1} µs", ns as f64 / 1_000.0)
+    } else if ns < 1_000_000_000 {
+        format!("{:.2} ms", ns as f64 / 1_000_000.0)
+    } else {
+        format!("{:.2} s", ns as f64 / 1_000_000_000.0)
+    }
+}
+
+fn calibrate_iters(run: BenchFn, n: u64, a: u64) -> usize {
+    for _ in 0..5 {
+        let _ = unsafe { run(n, a, 0) };
+    }
+    const SAMPLE: usize = 20;
+    let t0 = Instant::now();
+    for k in 0..SAMPLE {
+        let _ = unsafe { run(n, a, k as u64) };
+    }
+    let per_call_ns = (t0.elapsed().as_nanos() / SAMPLE as u128).max(1);
+    let raw = (TARGET_TRIAL_DURATION.as_nanos() / per_call_ns) as usize;
+    raw.clamp(1, 1_000_000)
+}
+
+/// Pipeline Δ = median(run) − median(buildonly) over `TRIALS` trials.
+fn bench_pipeline(cfg: &Config, n: u64, a: u64) -> u128 {
+    let iters = calibrate_iters(cfg.run, n, a);
+    let mut run_per: Vec<u128> = Vec::with_capacity(TRIALS);
+    let mut bo_per: Vec<u128> = Vec::with_capacity(TRIALS);
+
+    for trial in 0..TRIALS {
+        let seed_base = (trial as u64) * 1_000_000;
+
+        let t0 = Instant::now();
+        for k in 0..iters {
+            let _ = unsafe { (cfg.run)(n, a, seed_base + k as u64) };
+        }
+        run_per.push(t0.elapsed().as_nanos() / iters as u128);
+
+        let t0 = Instant::now();
+        for k in 0..iters {
+            let _ = unsafe { (cfg.buildonly)(n, a, seed_base + k as u64) };
+        }
+        bo_per.push(t0.elapsed().as_nanos() / iters as u128);
+    }
+
+    run_per.sort();
+    bo_per.sort();
+    let mid = TRIALS / 2;
+    run_per[mid].saturating_sub(bo_per[mid])
+}
+
+fn run() {
+    unsafe { boot_lean(); }
+
+    let baseline = Config {
+        run: csf_bench_state_transition_att_run,
+        buildonly: csf_bench_state_transition_att_buildonly,
+    };
+    let realistic = Config {
+        run: csf_bench_state_transition_att_real_run,
+        buildonly: csf_bench_state_transition_att_real_buildonly,
+    };
+
+    // Both fixtures must keep the 8 votes on the fast path (cells = 9), else the
+    // timings compare different control-flow paths and the A/B is meaningless.
+    let bc = unsafe { csf_bench_state_transition_att_cells(64) };
+    let rc = unsafe { csf_bench_state_transition_att_real_cells(64) };
+    assert_eq!(bc, 9, "baseline fixture broken: cells = {bc}, expected 9");
+    assert_eq!(rc, 9, "realistic fixture broken: cells = {rc}, expected 9");
+    println!("[fixture] baseline cells = {bc} ✓  realistic cells = {rc} ✓ (both: 8 valid votes, fast path)");
+    println!();
+
+    let mut rows: Vec<(u64, u128, u128)> = Vec::new();
+    for &n in N_AXIS {
+        // Interleave the two configs at each V so they share cache/thermal state.
+        let b = bench_pipeline(&baseline, n, A_FIXED);
+        let r = bench_pipeline(&realistic, n, A_FIXED);
+        rows.push((n, b, r));
+    }
+
+    println!(
+        "# state_transition realism A/B (A={A_FIXED} valid attestations, {TRIALS} trials, \
+         V ≤ leanSpec VALIDATOR_REGISTRY_LIMIT=4096)"
+    );
+    println!();
+    println!("| V | baseline Δ | realistic Δ | realistic − baseline | realistic / baseline |");
+    println!("|---:|---:|---:|---:|---:|");
+    for &(n, b, r) in &rows {
+        let diff = r as i128 - b as i128;
+        let ratio = if b > 0 { r as f64 / b as f64 } else { f64::NAN };
+        let sign = if diff >= 0 { "+" } else { "−" };
+        println!(
+            "| {} | {} | {} | {}{} | {:.3}× |",
+            n,
+            fmt_duration_ns(b),
+            fmt_duration_ns(r),
+            sign,
+            fmt_duration_ns(diff.unsigned_abs()),
+            ratio,
+        );
+    }
+
+    // Machine-readable block for the SVG generator: V,baseline_ns,realistic_ns
+    println!();
+    println!("<!-- PLOTDATA");
+    for &(n, b, r) in &rows {
+        println!("{},{},{}", n, b, r);
+    }
+    println!("-->");
+}
+
+fn main() {
+    std::thread::Builder::new()
+        .stack_size(2 << 30)
+        .spawn(run)
+        .expect("failed to spawn bench worker thread")
+        .join()
+        .expect("bench worker thread panicked");
+}

--- a/rust-ffi/src/bin/bench-state-transition.rs
+++ b/rust-ffi/src/bin/bench-state-transition.rs
@@ -14,6 +14,11 @@
 // model where state with validator_count > 4096 fails SSZ validation.
 // Pass `--single-n=N` to run only one cell — used for per-process
 // `ru_maxrss` isolation as required by docs/ffi-feasibility.md A10.
+// Pass `--realistic` to drive the data-realistic fixture twin (scattered
+// aggregation bits + high-entropy roots) instead of the baseline synthetic one.
+// The methodology is otherwise byte-for-byte identical, so combining
+// `--realistic --single-n=N` yields clean, thermally-isolated realistic cells
+// directly comparable to the baseline §1b numbers (docs §1c).
 
 use std::env;
 use std::ffi::c_void;
@@ -43,7 +48,42 @@ extern "C" {
     // Verification probe: justifications_roots length after the pipeline.
     // 8 valid votes processed (no skip, no 2/3 bail) ⇒ 9 (incl. zero sentinel).
     fn csf_bench_state_transition_att_cells(n: u64) -> u8;
+
+    // Data-realistic twins (`--realistic`): scattered ⌈V/2⌉ aggregation bits +
+    // high-entropy H256 roots, otherwise the identical A=8 valid-vote workload.
+    // Same control path / SHA block count / cells=9 invariant as the baseline,
+    // so running them through this *same* harness makes the two directly
+    // comparable (only the fixture data differs).
+    fn csf_bench_state_transition_att_real_run(n: u64, a: u64, seed: u64) -> u8;
+    fn csf_bench_state_transition_att_real_buildonly(n: u64, a: u64, seed: u64) -> u8;
+    fn csf_bench_state_transition_att_real_cells(n: u64) -> u8;
 }
+
+/// Selects which fixture family the harness drives. The two variants share an
+/// identical signature surface, so they are interchangeable function pointers —
+/// every measurement knob (trials, calibrate, paired-delta, self-check) stays
+/// byte-for-byte the same across baseline and realistic.
+#[derive(Clone, Copy)]
+struct Fixture {
+    label: &'static str,
+    run: unsafe extern "C" fn(u64, u64, u64) -> u8,
+    buildonly: unsafe extern "C" fn(u64, u64, u64) -> u8,
+    cells: unsafe extern "C" fn(u64) -> u8,
+}
+
+const BASELINE: Fixture = Fixture {
+    label: "baseline (contiguous bits, single-byte roots)",
+    run: csf_bench_state_transition_att_run,
+    buildonly: csf_bench_state_transition_att_buildonly,
+    cells: csf_bench_state_transition_att_cells,
+};
+
+const REALISTIC: Fixture = Fixture {
+    label: "realistic (scattered bits, high-entropy roots)",
+    run: csf_bench_state_transition_att_real_run,
+    buildonly: csf_bench_state_transition_att_real_buildonly,
+    cells: csf_bench_state_transition_att_real_cells,
+};
 
 unsafe fn boot_lean() {
     lean_initialize_runtime_module();
@@ -75,16 +115,16 @@ fn ru_maxrss_kb() -> i64 {
     ru.ru_maxrss
 }
 
-fn calibrate_iters(n: u64, a: u64) -> usize {
+fn calibrate_iters(n: u64, a: u64, fx: &Fixture) -> usize {
     // 5 warmup calls to settle branch predictor / TLB, then time 20 calls
     // and back out an iter count that hits the target trial duration.
     for _ in 0..5 {
-        let _ = unsafe { csf_bench_state_transition_att_run(n, a, 0) };
+        let _ = unsafe { (fx.run)(n, a, 0) };
     }
     const SAMPLE: usize = 20;
     let t0 = Instant::now();
     for k in 0..SAMPLE {
-        let _ = unsafe { csf_bench_state_transition_att_run(n, a, k as u64) };
+        let _ = unsafe { (fx.run)(n, a, k as u64) };
     }
     let elapsed = t0.elapsed();
     let per_call_ns = (elapsed.as_nanos() / SAMPLE as u128).max(1);
@@ -105,11 +145,11 @@ struct CellResult {
     sentinel: u8,
 }
 
-fn bench_cell(n: u64, a: u64, trials: usize) -> CellResult {
+fn bench_cell(n: u64, a: u64, trials: usize, fx: &Fixture) -> CellResult {
     // Sentinel sanity: confirm the pipeline returns Ok before timing.
-    let sentinel = unsafe { csf_bench_state_transition_att_run(n, a, 0) };
+    let sentinel = unsafe { (fx.run)(n, a, 0) };
 
-    let iters = if trials == 1 { 1 } else { calibrate_iters(n, a) };
+    let iters = if trials == 1 { 1 } else { calibrate_iters(n, a, fx) };
     let mut run_per_iter: Vec<u128> = Vec::with_capacity(trials);
     let mut bo_per_iter: Vec<u128> = Vec::with_capacity(trials);
 
@@ -119,7 +159,7 @@ fn bench_cell(n: u64, a: u64, trials: usize) -> CellResult {
         let t0 = Instant::now();
         for k in 0..iters {
             let _ = unsafe {
-                csf_bench_state_transition_att_run(n, a, seed_base + k as u64)
+                (fx.run)(n, a, seed_base + k as u64)
             };
         }
         let elapsed = t0.elapsed();
@@ -128,7 +168,7 @@ fn bench_cell(n: u64, a: u64, trials: usize) -> CellResult {
         let t0 = Instant::now();
         for k in 0..iters {
             let _ = unsafe {
-                csf_bench_state_transition_att_buildonly(n, a, seed_base + k as u64)
+                (fx.buildonly)(n, a, seed_base + k as u64)
             };
         }
         let elapsed = t0.elapsed();
@@ -229,19 +269,25 @@ fn print_budget_table(results: &[CellResult]) {
 fn run() {
     let args: Vec<String> = env::args().skip(1).collect();
     let include_1m = args.iter().any(|s| s == "--include-1m");
+    let realistic = args.iter().any(|s| s == "--realistic");
     let single_n: Option<u64> = args
         .iter()
         .find_map(|s| s.strip_prefix("--single-n="))
         .and_then(|v| v.parse().ok());
 
+    let fx = if realistic { REALISTIC } else { BASELINE };
+
     unsafe { boot_lean(); }
+
+    println!("[fixture] data = {}", fx.label);
 
     // Fixture self-check: the A=8 workload only measures the STF if all 8 votes
     // are *valid*. After the pipeline `justifications_roots` must hold 9 entries
     // (zero sentinel + 8 distinct target roots). Anything else means votes were
     // skipped (invalid) or the 2/3 threshold bailed to the slow path — either way
-    // the timings below would be meaningless, so refuse to measure.
-    let cells = unsafe { csf_bench_state_transition_att_cells(64) };
+    // the timings below would be meaningless, so refuse to measure. The realistic
+    // twin must hold this same invariant (scattering bits keeps the vote count).
+    let cells = unsafe { (fx.cells)(64) };
     assert_eq!(
         cells, 9,
         "valid-vote fixture broken: expected 9 justification roots (zero sentinel + 8 \
@@ -258,13 +304,13 @@ fn run() {
     if let Some(n) = single_n {
         // Per-process cell isolation: trials count depends on cell.
         let trials = if n >= REFERENCE_N { 1 } else { 5 };
-        results.push(bench_cell(n, A_FIXED, trials));
+        results.push(bench_cell(n, A_FIXED, trials, &fx));
     } else {
         for &n in DEFAULT_N_AXIS {
-            results.push(bench_cell(n, A_FIXED, 5));
+            results.push(bench_cell(n, A_FIXED, 5, &fx));
         }
         if include_1m {
-            results.push(bench_cell(REFERENCE_N, A_FIXED, 1));
+            results.push(bench_cell(REFERENCE_N, A_FIXED, 1, &fx));
         }
     }
 
@@ -283,6 +329,19 @@ fn run() {
     println!("| ru_maxrss start | {} MB |", rss_start / 1024);
     println!("| ru_maxrss end | {} MB |", rss_end / 1024);
     println!("| ru_maxrss delta | {} MB |", (rss_end - rss_start) / 1024);
+
+    // Machine-readable block for the SVG generator (raw ns, no formatting loss).
+    // One row per cell: V,pipeline_ns,run_median_ns,buildonly_ns,sentinel.
+    println!();
+    println!("<!-- PLOTDATA fixture={}", if realistic { "realistic" } else { "baseline" });
+    println!("V,pipeline_ns,run_median_ns,buildonly_ns,sentinel");
+    for r in &results {
+        println!(
+            "{},{},{},{},{}",
+            r.n, r.pipeline_ns, r.run_median_ns, r.bo_median_ns, r.sentinel
+        );
+    }
+    println!("-->");
 }
 
 fn main() {

--- a/scripts/plot_realism.py
+++ b/scripts/plot_realism.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Generate docs/assets/bench-realism.svg — the synthetic-vs-realistic A/B chart.
+
+Data are the pipeline Δ (run − buildonly median) of two state_transition
+fixtures measured back-to-back in the same process by
+`bench-state-transition-realism`:
+
+  * baseline  — contiguous ⌈V/2⌉-bit prefix + single-repeated-byte roots
+  * realistic — Fisher-Yates-scattered ⌈V/2⌉ bits + high-entropy roots
+
+Four independent process runs are embedded below (PLOTDATA blocks). The chart
+plots the per-V median of each config with min..max error bars across the four
+runs, so the run-to-run noise is visible and the reader can see the two curves
+overlap within it. Machine: AMD Ryzen 9 PRO 8945HS, 2026-06-26.
+"""
+
+from pathlib import Path
+from statistics import median
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+# (V, baseline_ns, realistic_ns) per run — verbatim from the PLOTDATA blocks.
+RUNS = [
+    [(4, 488742, 493820), (8, 565465, 537549), (64, 1149330, 1135613),
+     (512, 6220110, 5521174), (4096, 43457489, 42634077)],
+    [(4, 487026, 535914), (8, 538965, 547931), (64, 1080952, 1149880),
+     (512, 5423117, 5977652), (4096, 47708752, 41437883)],
+    [(4, 545417, 557108), (8, 499315, 520265), (64, 1104868, 1082984),
+     (512, 6378971, 5764746), (4096, 45539901, 44288330)],
+    [(4, 482889, 510865), (8, 544242, 560696), (64, 1150596, 1209577),
+     (512, 5574544, 5898013), (4096, 44828630, 43922793)],
+]
+
+VS = [4, 8, 64, 512, 4096]
+
+
+def collect(idx):
+    """Return {V: [ns across runs]} for column idx (1=baseline, 2=realistic)."""
+    out = {v: [] for v in VS}
+    for run in RUNS:
+        for row in run:
+            out[row[0]].append(row[idx])
+    return out
+
+
+def stats_us(series):
+    """median, lower-err, upper-err in microseconds for an errorbar plot."""
+    med = [median(series[v]) / 1e3 for v in VS]
+    lo = [(median(series[v]) - min(series[v])) / 1e3 for v in VS]
+    hi = [(max(series[v]) - median(series[v])) / 1e3 for v in VS]
+    return med, lo, hi
+
+
+def main():
+    base = collect(1)
+    real = collect(2)
+    b_med, b_lo, b_hi = stats_us(base)
+    r_med, r_lo, r_hi = stats_us(real)
+
+    fig, ax = plt.subplots(figsize=(7.2, 4.4))
+
+    ax.errorbar(VS, b_med, yerr=[b_lo, b_hi], marker="o", capsize=3,
+                linewidth=1.6, label="baseline", color="#1f77b4")
+    ax.errorbar(VS, r_med, yerr=[r_lo, r_hi], marker="s", capsize=3,
+                linewidth=1.6, label="variant", color="#d62728")
+
+    ax.set_xscale("log", base=2)
+    ax.set_yscale("log")
+    ax.set_xticks(VS)
+    ax.set_xticklabels([str(v) for v in VS])
+    ax.set_xlabel("validators  V  (leanSpec range, V ≤ 4096)")
+    ax.set_ylabel("STF pipeline Δ  (µs, run − buildonly median)")
+    ax.set_title("state_transition pipeline Δ  (4-run median, error bars = min..max)")
+    ax.grid(True, which="both", linewidth=0.4, alpha=0.5)
+
+    # Annotate the median variant/baseline ratio at each V.
+    for i, v in enumerate(VS):
+        ratio = r_med[i] / b_med[i]
+        ax.annotate(f"{ratio:.2f}×",
+                    xy=(v, max(r_med[i], b_med[i])),
+                    xytext=(0, 8), textcoords="offset points",
+                    ha="center", fontsize=8, color="#555555")
+
+    ax.legend(loc="upper left", fontsize=8, framealpha=0.9)
+
+    out = Path(__file__).resolve().parents[1] / "docs" / "assets" / "bench-realism.svg"
+    fig.savefig(out, format="svg", bbox_inches="tight")
+    print(f"wrote {out}")
+    print("median realistic/baseline ratios:",
+          {v: round(r_med[i] / b_med[i], 3) for i, v in enumerate(VS)})
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_realism_abs.py
+++ b/scripts/plot_realism_abs.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Generate docs/assets/bench-realism-abs.svg — STF processing time vs validators.
+
+Same source data as plot_realism.py (the four `bench-state-transition-realism`
+process runs), but plotted as the *absolute* STF pipeline time per validator
+count V instead of the realistic/baseline ratio. This matches the framing of
+the other scaling charts (bench-scaling.svg, htr-cost.svg): processing time on
+the y-axis, validator count V on the x-axis, log-log.
+
+The pipeline time is the paired delta run − buildonly median, i.e. the
+state_transition cost with its fixture-construction overhead cancelled out.
+Both data variants are drawn so the reader can see they coincide within
+run-to-run noise; the curves are the STF scaling, not the A/B residual.
+
+Machine: AMD Ryzen 9 PRO 8945HS, 2026-06-26.
+"""
+
+from pathlib import Path
+from statistics import median
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+# (V, baseline_ns, realistic_ns) per run — verbatim from the PLOTDATA blocks.
+RUNS = [
+    [(4, 488742, 493820), (8, 565465, 537549), (64, 1149330, 1135613),
+     (512, 6220110, 5521174), (4096, 43457489, 42634077)],
+    [(4, 487026, 535914), (8, 538965, 547931), (64, 1080952, 1149880),
+     (512, 5423117, 5977652), (4096, 47708752, 41437883)],
+    [(4, 545417, 557108), (8, 499315, 520265), (64, 1104868, 1082984),
+     (512, 6378971, 5764746), (4096, 45539901, 44288330)],
+    [(4, 482889, 510865), (8, 544242, 560696), (64, 1150596, 1209577),
+     (512, 5574544, 5898013), (4096, 44828630, 43922793)],
+]
+
+VS = [4, 8, 64, 512, 4096]
+
+
+def collect(idx):
+    """Return {V: [ns across runs]} for column idx (1=baseline, 2=realistic)."""
+    out = {v: [] for v in VS}
+    for run in RUNS:
+        for row in run:
+            out[row[0]].append(row[idx])
+    return out
+
+
+def stats_us(series):
+    """median, lower-err, upper-err in microseconds for an errorbar plot."""
+    med = [median(series[v]) / 1e3 for v in VS]
+    lo = [(median(series[v]) - min(series[v])) / 1e3 for v in VS]
+    hi = [(max(series[v]) - median(series[v])) / 1e3 for v in VS]
+    return med, lo, hi
+
+
+def main():
+    b_med, b_lo, b_hi = stats_us(collect(1))
+    r_med, r_lo, r_hi = stats_us(collect(2))
+
+    fig, ax = plt.subplots(figsize=(7.2, 4.4))
+
+    ax.errorbar(VS, b_med, yerr=[b_lo, b_hi], marker="o", capsize=3,
+                linewidth=1.6, label="baseline-pattern data", color="#1f77b4")
+    ax.errorbar(VS, r_med, yerr=[r_lo, r_hi], marker="s", capsize=3,
+                linewidth=1.6, label="realistic-pattern data", color="#d62728")
+
+    ax.set_xscale("log", base=2)
+    ax.set_yscale("log")
+    ax.set_xticks(VS)
+    ax.set_xticklabels([str(v) for v in VS])
+    ax.set_xlabel("validators  V  (leanSpec range, V ≤ 4096)")
+    ax.set_ylabel("STF pipeline time  (µs, run − buildonly median)")
+    ax.set_title("state_transition processing time vs validators  (4-run median, error bars = min..max)")
+    ax.grid(True, which="both", linewidth=0.4, alpha=0.5)
+
+    # Annotate the absolute STF time at each V (use the baseline curve).
+    for i, v in enumerate(VS):
+        t = b_med[i]
+        label = f"{t/1e3:.2f} ms" if t >= 1e3 else f"{t:.0f} µs"
+        ax.annotate(label, xy=(v, t), xytext=(0, -14), textcoords="offset points",
+                    ha="center", fontsize=8, color="#555555")
+
+    ax.legend(loc="upper left", fontsize=8, framealpha=0.9)
+
+    out = Path(__file__).resolve().parents[1] / "docs" / "assets" / "bench-realism-abs.svg"
+    fig.savefig(out, format="svg", bbox_inches="tight")
+    print(f"wrote {out}")
+    print("STF pipeline time (baseline, µs):",
+          {v: round(b_med[i], 1) for i, v in enumerate(VS)})
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_realism_clean.py
+++ b/scripts/plot_realism_clean.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
 """Generate docs/assets/bench-realism-clean.svg — STF processing time vs validators,
-measured under clean single-process isolation.
+measured under clean single-process isolation on the real-data-shaped fixture.
 
-Unlike plot_realism_abs.py (whose data comes from the sustained-load
-`bench-state-transition-realism` binary that interleaves both fixtures with a
-per-cell calibrate, keeping the CPU under continuous load), this chart's data
-comes from the §1b clean harness `bench-state-transition` run once per (V,fixture)
-in its OWN process (`--single-n=N`, `--realistic` to select the fixture), with a
+This is the §1b clean harness `bench-state-transition` run once per V in its OWN
+process (`--single-n=N`, `--realistic` to select the real-data fixture), with a
 cooldown before every process so the boost clock is not depressed by sustained
-load. Both fixture families go through the identical harness, so the two curves
-are directly comparable.
+load. Unlike plot_realism_abs.py (whose data comes from the sustained-load
+`bench-state-transition-realism` binary that keeps the CPU under continuous
+load), each cell here is thermally isolated.
+
+The plotted curve is the realistic fixture (scattered aggregation bits +
+high-entropy roots — the data shape that represents real attestations); it is the
+canonical clean STF cost. The synthetic foil fixture was measured through the
+same harness only to confirm the data shape does not change the cost (see §1c A/B
+in docs/rust-ffi-benchmarks.md); its raw numbers are kept in RUNS for provenance
+but are not plotted.
 
 The pipeline time is the paired delta run − buildonly median, i.e. the
 state_transition cost with its fixture-construction overhead cancelled out.
@@ -31,8 +36,9 @@ matplotlib.use("Agg")
 matplotlib.rcParams["svg.fonttype"] = "none"
 import matplotlib.pyplot as plt
 
-# (V, baseline_ns, variant_ns) per round — verbatim pipeline Δ from the clean
+# (V, foil_ns, realistic_ns) per round — verbatim pipeline Δ from the clean
 # per-process runs (run − buildonly median). 3 rounds, each cell its own process.
+# Only the realistic column is plotted; the foil column is the raw record.
 RUNS = [
     [(4, 500505, 484011), (8, 494727, 513860), (64, 1147906, 1221616),
      (512, 5770899, 6099421), (4096, 41362683, 41963933)],
@@ -46,7 +52,7 @@ VS = [4, 8, 64, 512, 4096]
 
 
 def collect(idx):
-    """Return {V: [ns across rounds]} for column idx (1=baseline, 2=variant)."""
+    """Return {V: [ns across rounds]} for column idx (2=realistic)."""
     out = {v: [] for v in VS}
     for run in RUNS:
         for row in run:
@@ -63,15 +69,12 @@ def stats_us(series):
 
 
 def main():
-    b_med, b_lo, b_hi = stats_us(collect(1))
-    r_med, r_lo, r_hi = stats_us(collect(2))
+    med, lo, hi = stats_us(collect(2))
 
     fig, ax = plt.subplots(figsize=(7.2, 4.4))
 
-    ax.errorbar(VS, b_med, yerr=[b_lo, b_hi], marker="o", capsize=3,
-                linewidth=1.6, label="baseline", color="#1f77b4")
-    ax.errorbar(VS, r_med, yerr=[r_lo, r_hi], marker="s", capsize=3,
-                linewidth=1.6, label="variant", color="#d62728")
+    ax.errorbar(VS, med, yerr=[lo, hi], marker="o", capsize=3,
+                linewidth=1.6, color="#1f77b4")
 
     ax.set_xscale("log", base=2)
     ax.set_yscale("log")
@@ -82,20 +85,17 @@ def main():
     ax.set_title("state_transition processing time vs validators  (3-run median, error bars = min..max)")
     ax.grid(True, which="both", linewidth=0.4, alpha=0.5)
 
-    # Annotate the absolute STF time at each V (use the baseline curve).
+    # Annotate the absolute STF time at each V.
     for i, v in enumerate(VS):
-        t = b_med[i]
+        t = med[i]
         label = f"{t/1e3:.2f} ms" if t >= 1e3 else f"{t:.0f} µs"
         ax.annotate(label, xy=(v, t), xytext=(0, -14), textcoords="offset points",
                     ha="center", fontsize=8, color="#555555")
 
-    ax.legend(loc="upper left", fontsize=8, framealpha=0.9)
-
     out = Path(__file__).resolve().parents[1] / "docs" / "assets" / "bench-realism-clean.svg"
     fig.savefig(out, format="svg", bbox_inches="tight")
     print(f"wrote {out}")
-    print("baseline median (µs):", {v: round(b_med[i], 1) for i, v in enumerate(VS)})
-    print("variant  median (µs):", {v: round(r_med[i], 1) for i, v in enumerate(VS)})
+    print("clean STF pipeline time (µs):", {v: round(med[i], 1) for i, v in enumerate(VS)})
 
 
 if __name__ == "__main__":

--- a/scripts/plot_realism_clean.py
+++ b/scripts/plot_realism_clean.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Generate docs/assets/bench-realism-clean.svg — STF processing time vs validators,
+measured under clean single-process isolation.
+
+Unlike plot_realism_abs.py (whose data comes from the sustained-load
+`bench-state-transition-realism` binary that interleaves both fixtures with a
+per-cell calibrate, keeping the CPU under continuous load), this chart's data
+comes from the §1b clean harness `bench-state-transition` run once per (V,fixture)
+in its OWN process (`--single-n=N`, `--realistic` to select the fixture), with a
+cooldown before every process so the boost clock is not depressed by sustained
+load. Both fixture families go through the identical harness, so the two curves
+are directly comparable.
+
+The pipeline time is the paired delta run − buildonly median, i.e. the
+state_transition cost with its fixture-construction overhead cancelled out.
+
+Machine: AMD Ryzen 9 PRO 8945HS (16 threads), governor=performance,
+EPP=performance, boost on. Kali Linux Rolling, kernel 6.18.12. 2026-06-26 ~10:00,
+idle machine (resident clickhouse container frozen during the run). 3 isolated
+processes per cell; the point is the median, error bars are min..max.
+"""
+
+from pathlib import Path
+from statistics import median
+
+import matplotlib
+
+matplotlib.use("Agg")
+# Keep glyphs as <text> (searchable, diff-friendly, smaller) to match the
+# sibling docs/assets/bench-*.svg rather than path-tracing every character.
+matplotlib.rcParams["svg.fonttype"] = "none"
+import matplotlib.pyplot as plt
+
+# (V, baseline_ns, variant_ns) per round — verbatim pipeline Δ from the clean
+# per-process runs (run − buildonly median). 3 rounds, each cell its own process.
+RUNS = [
+    [(4, 500505, 484011), (8, 494727, 513860), (64, 1147906, 1221616),
+     (512, 5770899, 6099421), (4096, 41362683, 41963933)],
+    [(4, 465938, 492497), (8, 523817, 530381), (64, 1110647, 1196569),
+     (512, 5786186, 5788166), (4096, 42110075, 41900606)],
+    [(4, 469475, 507212), (8, 546896, 503244), (64, 1097685, 1184341),
+     (512, 5864254, 6045838), (4096, 42060853, 43892274)],
+]
+
+VS = [4, 8, 64, 512, 4096]
+
+
+def collect(idx):
+    """Return {V: [ns across rounds]} for column idx (1=baseline, 2=variant)."""
+    out = {v: [] for v in VS}
+    for run in RUNS:
+        for row in run:
+            out[row[0]].append(row[idx])
+    return out
+
+
+def stats_us(series):
+    """median, lower-err, upper-err in microseconds for an errorbar plot."""
+    med = [median(series[v]) / 1e3 for v in VS]
+    lo = [(median(series[v]) - min(series[v])) / 1e3 for v in VS]
+    hi = [(max(series[v]) - median(series[v])) / 1e3 for v in VS]
+    return med, lo, hi
+
+
+def main():
+    b_med, b_lo, b_hi = stats_us(collect(1))
+    r_med, r_lo, r_hi = stats_us(collect(2))
+
+    fig, ax = plt.subplots(figsize=(7.2, 4.4))
+
+    ax.errorbar(VS, b_med, yerr=[b_lo, b_hi], marker="o", capsize=3,
+                linewidth=1.6, label="baseline", color="#1f77b4")
+    ax.errorbar(VS, r_med, yerr=[r_lo, r_hi], marker="s", capsize=3,
+                linewidth=1.6, label="variant", color="#d62728")
+
+    ax.set_xscale("log", base=2)
+    ax.set_yscale("log")
+    ax.set_xticks(VS)
+    ax.set_xticklabels([str(v) for v in VS])
+    ax.set_xlabel("validators  V  (leanSpec range, V ≤ 4096)")
+    ax.set_ylabel("STF pipeline time  (µs, run − buildonly median)")
+    ax.set_title("state_transition processing time vs validators  (3-run median, error bars = min..max)")
+    ax.grid(True, which="both", linewidth=0.4, alpha=0.5)
+
+    # Annotate the absolute STF time at each V (use the baseline curve).
+    for i, v in enumerate(VS):
+        t = b_med[i]
+        label = f"{t/1e3:.2f} ms" if t >= 1e3 else f"{t:.0f} µs"
+        ax.annotate(label, xy=(v, t), xytext=(0, -14), textcoords="offset points",
+                    ha="center", fontsize=8, color="#555555")
+
+    ax.legend(loc="upper left", fontsize=8, framealpha=0.9)
+
+    out = Path(__file__).resolve().parents[1] / "docs" / "assets" / "bench-realism-clean.svg"
+    fig.savefig(out, format="svg", bbox_inches="tight")
+    print(f"wrote {out}")
+    print("baseline median (µs):", {v: round(b_med[i], 1) for i, v in enumerate(VS)})
+    print("variant  median (µs):", {v: round(r_med[i], 1) for i, v in enumerate(VS)})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a data-realism A/B probe for the M5b `state_transition` benchmark fixture.

The existing fixture builds attestation `aggregation_bits` as a contiguous
ceil(V/2)-bit prefix and fills every H256 with a single repeated byte — both
best-case for the CPU (predictable branches, byte-0 comparison short-circuit),
which could bias the measured pipeline time optimistically vs realistic data.

This adds a data-realistic twin (`csf_bench_state_transition_att_real_*`) with
the same workload (same V, 8 valid votes, no-bail / `cells = 9` invariant) but:
- ceil(V/2) set bits scattered by a fixed Fisher-Yates shuffle (mix64 PRNG)
- every root filled with a high-entropy mix64 byte pattern

A new bench binary (`bench-state-transition-realism`) measures baseline vs
variant back-to-back in one process for a fair A/B.

## Result

Over 4 runs, variant/baseline = 0.96–1.07x across V — within the +-10-24%
run-to-run noise. No systematic optimistic bias: the pipeline is dominated by
value-independent SHA-256 `hash_tree_root` and unconditional O(A*V) bit scans,
so fixture regularity does not move the headline. Documented in section 1c with
a chart.

## Files
- `ConsensusLean4/Ffi.lean` — realism-probe fixtures + `*_att_real_*` exports
- `rust-ffi/src/bin/bench-state-transition-realism.rs` — A/B harness
- `scripts/plot_realism.py` + `docs/assets/bench-realism.svg` — chart
- `docs/rust-ffi-benchmarks.md` — section 1c